### PR TITLE
Add a multi-stage Dockerfile (compilation and run)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,46 @@
+################################################################################
+#
+#   Builder environnement
+#
+################################################################################
+
+FROM centos as builder
+
+RUN yum update -y && \
+    yum upgrade -y
+
+RUN yum group install -y "Development Tools" && \
+    yum install -y cmake git
+
+COPY ./OpenCV /tmp/NFIQ2/OpenCV
+RUN mkdir /tmp/NFIQ2/libOpenCV && \
+	cd /tmp/NFIQ2/libOpenCV && \
+	cmake -D CMAKE_MAKE_PROGRAM=make ../OpenCV && \
+	make opencv_core opencv_ts opencv_imgproc opencv_highgui opencv_flann \
+	     opencv_features2d opencv_calib3d opencv_ml opencv_video opencv_objdetect \
+	     opencv_contrib opencv_nonfree opencv_gpu opencv_photo opencv_stitching \
+	     opencv_videostab
+
+COPY . /tmp/NFIQ2
+WORKDIR /tmp/NFIQ2
+RUN mkdir -p /usr/local/man/man1
+RUN make
+RUN make install
+
+################################################################################
+#
+#   Running environnement
+#
+################################################################################
+
+FROM centos
+
+COPY --from=builder /tmp/NFIQ2/NFIQ2/NFIQ2Algorithm/bin/ /NFIQ2/NFIQ2/bin/
+COPY --from=builder /tmp/NFIQ2/NFIQ2/NFIQ2Algorithm/lib/ /NFIQ2/NFIQ2/lib/
+COPY --from=builder /tmp/NFIQ2/biomdi/common/lib/        /NFIQ2/biomdi/common/lib/
+COPY --from=builder /tmp/NFIQ2/biomdi/fingerminutia/lib/ /NFIQ2/biomdi/fingerminutia/lib/
+COPY --from=builder /tmp/NFIQ2/libOpenCV/lib/            /NFIQ2/libOpenCV/lib/
+
+ENV LD_LIBRARY_PATH=/NFIQ2/libOpenCV/lib:/NFIQ2/biomdi/common/lib:/NFIQ2/biomdi/fingerminutia/lib:/NFIQ2/NFIQ2/lib/
+
+RUN ln -s /NFIQ2/NFIQ2/bin/NFIQ2 /usr/bin/NFIQ2

--- a/Makefile
+++ b/Makefile
@@ -33,3 +33,6 @@ clean:
 	@for subdir in $(SUBDIRS); do \
 		(cd $$subdir && $(MAKE) clean) || exit 1; \
 	done
+
+docker:
+	docker build -t nfiq2 .


### PR DESCRIPTION
# Object 
Add a working Dockerfile for compilation and run of the NFIQ2 binary (linux system).

# Aims
- Simplify the build of NFIQ2
- Allow easy tests of the full compilation process in a reproducible way (with a CICD pipeline for example)
- Easy deploy on remote machine
- Be used as a guideline/example to install NFIQ2 on a "traditionnal" system

# Docker
First, Docker needs to be installed (see the docker documentation ( https://docs.docker.com/install/ ) or the install script ( https://get.docker.com/ ) ).

# Build
To build the docker image, a simple `make docker` has to be done. This command will compile OpenCV and NFIQ2 from this Git repo.
The build process is done via a multi-stage dockerfile, hence produce a minimal docker image (364MB, including the OS (CentOS in this case), instead of the multiple GB if compiling directly from the host).

# Run and use
To use the docker image, simple run the following command:

`docker run -it -v $(pwd):/data nfiq2 bash`

The current directory (`$(pwd)`) will be mounted inside the docker container in the /data directory.

To run directly the NFIQ2 bin, type :

`docker run -it -v $(pwd):/data nfiq2 NFIQ2`

# Notes
This Dockerfile has been optimized to use as much of the cache as possible. If a modification is done, the OpenCV is recompiled only if affected (modification in the OpenCV folder)