### PR TITLE
dist folders for manual MSVC build

### DIFF
--- a/cmake/folders.cmake
+++ b/cmake/folders.cmake
@@ -1,12 +1,8 @@
 # derive dist path from build path
 # 1st
-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-  set( DIST_PATH  ${ROOT_PATH}/dist )
-else()
-  get_filename_component( tmp ${BUILD_PATH}/.. ABSOLUTE   )
-  get_filename_component( tmp ${tmp} NAME  )
-  set( DIST_PATH  ${ROOT_PATH}/dist/${tmp} )
-endif()
+get_filename_component( tmp ${BUILD_PATH}/.. ABSOLUTE   )
+get_filename_component( tmp ${tmp} NAME  )
+set( DIST_PATH  ${ROOT_PATH}/dist/${tmp} )
 # 2nd
 get_filename_component( tmp ${BUILD_PATH} ABSOLUTE   )
 get_filename_component( tmp ${tmp} NAME  )


### PR DESCRIPTION
Adapted the dist folders for the manual MSVC build created with the powershell script runCMake.ps1. The folder will be now similar to GCC builds