### PR TITLE
fix for using the libNfiq2Api.so on Android

### DIFF
--- a/NFIQ2/NFIQ2Algorithm/src/NFIQ2.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/NFIQ2.cpp
@@ -571,6 +571,8 @@ int main(int argc, const char* argv[])
         }
 #ifdef WIN32
         FreeLibrary( hLib );
+#elif ANDROID
+        std::cout << "Do not unload the library on Android." << std::endl;
 #else
         dlclose( hLib );
 #endif


### PR DESCRIPTION
modified test application to NOT unload (dlclose) the  libNfiq2Api.so. Apparently the dlclose behavior on Android is questionable and will not work as expected. Similar issuses were posted through stackoverflow.
To overcome a segmentation fault on Android (and only on Android), I removed the dlclose call from the test application