### PR TITLE
Excluding astyle build for MSVC and Android

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "biomdi/biomdi"]
 	path = biomdi/biomdi
 	url = https://github.com/usnistgov/biomdi.git
+[submodule "astyle"]
+	path = astyle
+	url = https://github.com/edenhill/astyle.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,9 @@ include( "${ROOT_PATH}/cmake/compiler.cmake" )
 # create build and distribution path
 include( "${ROOT_PATH}/cmake/folders.cmake" )
 
+# setup astyle
+include( "${ROOT_PATH}/cmake/astyle.cmake" )
+
 # include special settings for fingerjetfxose
 include( "${ROOT_PATH}/cmake/fingerjetfxose.cmake" )
 
@@ -40,24 +43,8 @@ set( CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${DIST_PATH} )
 set( CMAKE_LIBRARY_OUTPUT_DIRECTORY ${DIST_PATH} )
 set( CMAKE_RUNTIME_OUTPUT_DIRECTORY ${DIST_PATH} )
 
-add_subdirectory("${ROOT_PATH}/astyle/" "${BUILD_PATH}/astyle/")
 add_subdirectory("${ROOT_PATH}/biomdi/" "${BUILD_PATH}/biomdi/")
 add_subdirectory("${ROOT_PATH}/fingerjetfxose/FingerJetFXOSE/libFRFXLL/src/" "${BUILD_PATH}/fingerjetfxose/FingerJetFXOSE/libFRFXLL/src/")
-
-#astyle
-set( ASTYLE_EXE "${DIST_PATH}/astyle${CMAKE_EXECUTABLE_SUFFIX}" )
-file(GLOB ASTYLE_FILES "${ROOT_PATH}/NFIQ2/NFIQ2Api/*.cpp" "${ROOT_PATH}/NFIQ2/NFIQ2Api/*.h" ) 
-if( NOT ANDROID )
-  add_custom_target( format
-    COMMAND ${ASTYLE_EXE} --options=${ROOT_PATH}/astyle.cfg ${ASTYLE_FILES} 
-    DEPENDS astyle
-  )
-else()
-  add_custom_target( format
-    COMMAND echo "${ASTYLE_EXE} will not run on ${CMAKE_HOST}"
-    DEPENDS astyle
-  )
-endif()
 
 # forwarding 32/64 compiler flags
 if( 32BITS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,8 +40,17 @@ set( CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${DIST_PATH} )
 set( CMAKE_LIBRARY_OUTPUT_DIRECTORY ${DIST_PATH} )
 set( CMAKE_RUNTIME_OUTPUT_DIRECTORY ${DIST_PATH} )
 
+add_subdirectory("${ROOT_PATH}/astyle/" "${BUILD_PATH}/astyle/")
 add_subdirectory("${ROOT_PATH}/biomdi/" "${BUILD_PATH}/biomdi/")
 add_subdirectory("${ROOT_PATH}/fingerjetfxose/FingerJetFXOSE/libFRFXLL/src/" "${BUILD_PATH}/fingerjetfxose/FingerJetFXOSE/libFRFXLL/src/")
+
+#astyle
+set( ASTYLE_EXE "${DIST_PATH}/bin/astyle${CMAKE_EXECUTABLE_SUFFIX}" )
+file(GLOB ASTYLE_FILES "${ROOT_PATH}/NFIQ2/NFIQ2Api/*.cpp" "${ROOT_PATH}/NFIQ2/NFIQ2Api/*.h" ) 
+add_custom_target( format } 
+  COMMAND ${ASTYLE_EXE} --options=${ROOT_PATH}/astyle.cfg ${ASTYLE_FILES} 
+  DEPENDS astyle
+)
 
 # forwarding 32/64 compiler flags
 if( 32BITS)
@@ -163,7 +172,7 @@ ExternalProject_Add(nfiq2
 	BUILD_ALWAYS	YES
 	INSTALL_DIR ${DIST_PATH}
 )
-ExternalProject_Add_StepDependencies(nfiq2 build OpenCV biomdi fmr FRFXLL_static)
+ExternalProject_Add_StepDependencies(nfiq2 build astyle format OpenCV biomdi fmr FRFXLL_static)
 
 ExternalProject_Add(nfiq2api
 	SOURCE_DIR	${ROOT_PATH}/NFIQ2/NFIQ2Api

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,9 +45,9 @@ add_subdirectory("${ROOT_PATH}/biomdi/" "${BUILD_PATH}/biomdi/")
 add_subdirectory("${ROOT_PATH}/fingerjetfxose/FingerJetFXOSE/libFRFXLL/src/" "${BUILD_PATH}/fingerjetfxose/FingerJetFXOSE/libFRFXLL/src/")
 
 #astyle
-set( ASTYLE_EXE "${DIST_PATH}/bin/astyle${CMAKE_EXECUTABLE_SUFFIX}" )
+set( ASTYLE_EXE "${DIST_PATH}/astyle${CMAKE_EXECUTABLE_SUFFIX}" )
 file(GLOB ASTYLE_FILES "${ROOT_PATH}/NFIQ2/NFIQ2Api/*.cpp" "${ROOT_PATH}/NFIQ2/NFIQ2Api/*.h" ) 
-add_custom_target( format } 
+add_custom_target( format
   COMMAND ${ASTYLE_EXE} --options=${ROOT_PATH}/astyle.cfg ${ASTYLE_FILES} 
   DEPENDS astyle
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,10 +47,17 @@ add_subdirectory("${ROOT_PATH}/fingerjetfxose/FingerJetFXOSE/libFRFXLL/src/" "${
 #astyle
 set( ASTYLE_EXE "${DIST_PATH}/astyle${CMAKE_EXECUTABLE_SUFFIX}" )
 file(GLOB ASTYLE_FILES "${ROOT_PATH}/NFIQ2/NFIQ2Api/*.cpp" "${ROOT_PATH}/NFIQ2/NFIQ2Api/*.h" ) 
-add_custom_target( format
-  COMMAND ${ASTYLE_EXE} --options=${ROOT_PATH}/astyle.cfg ${ASTYLE_FILES} 
-  DEPENDS astyle
-)
+if( NOT ANDROID )
+  add_custom_target( format
+    COMMAND ${ASTYLE_EXE} --options=${ROOT_PATH}/astyle.cfg ${ASTYLE_FILES} 
+    DEPENDS astyle
+  )
+else()
+  add_custom_target( format
+    COMMAND echo "${ASTYLE_EXE} will not run on ${CMAKE_HOST}"
+    DEPENDS astyle
+  )
+endif()
 
 # forwarding 32/64 compiler flags
 if( 32BITS)

--- a/NFIQ2/NFIQ2Algorithm/src/NFIQ2.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/NFIQ2.cpp
@@ -571,6 +571,8 @@ int main(int argc, const char* argv[])
         }
 #ifdef WIN32
         FreeLibrary( hLib );
+#elif ANDROID
+        std::cout << "Do not unload the library on Android." << std::endl;
 #else
         dlclose( hLib );
 #endif

--- a/astyle.cfg
+++ b/astyle.cfg
@@ -1,0 +1,35 @@
+#brace style option
+--style=allman
+
+# indent options
+--indent=spaces=2 
+--indent-classes 
+--indent-namespaces
+--indent-switches
+--indent-preprocessor
+--indent-col1-comments
+--min-conditional-indent=0
+
+#padding options
+--unpad-paren
+--pad-oper 
+--pad-paren-in 
+
+#brackets
+--add-braces
+--break-closing-brackets
+
+#pointers and references
+--align-pointer=type 
+--align-reference=type
+
+#misc
+#--delete-empty-lines 
+--convert-tabs 
+ 
+#no backup, output changes only
+--suffix=none
+--formatted
+
+#line endings
+--lineend=linux

--- a/cmake/astyle.cmake
+++ b/cmake/astyle.cmake
@@ -1,0 +1,23 @@
+set( ASTYLE_EXE "${DIST_PATH}/astyle${CMAKE_EXECUTABLE_SUFFIX}" )
+
+if( NOT ANDROID AND NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+  # Error	C1061	compiler limit: blocks nested too deeply	astyle	D:\Devel\ISO\NFIQ2-official\NFIQ2-rlessmann\astyle\src\astyle_main.cpp	3702	
+  add_subdirectory("${ROOT_PATH}/astyle/" "${BUILD_PATH}/astyle/")
+  # add project folders to be "astyled"
+  file(GLOB ASTYLE_FILES "${ROOT_PATH}/NFIQ2/NFIQ2Api/*.cpp" "${ROOT_PATH}/NFIQ2/NFIQ2Api/*.h" ) 
+  add_custom_target( format
+    COMMAND ${ASTYLE_EXE} --options=${ROOT_PATH}/astyle.cfg ${ASTYLE_FILES} 
+    DEPENDS astyle
+  )
+else()
+  add_custom_target( astyle
+    COMMAND echo "Skip build target 'astyle'"
+  )
+  add_custom_target( format
+    COMMAND echo "Skip build target 'format'"
+    DEPENDS astyle
+  )
+endif()
+
+
+

--- a/runCMake.ps1
+++ b/runCMake.ps1
@@ -30,7 +30,7 @@ function runCMake( $platform, $generator)
   new-item "./build/$msvc/$platform" -ItemType directory -Force
   cd "./build/$msvc/$platform"
   # run cmake
-  & "$global:cmake" -DCMAKE_SYSTEM_VERSION=8.1 -G "${generator}" ../../../
+  & "$global:cmake" -DCMAKE_SYSTEM_VERSION=8.1 -G "${generator}" -DCMAKE_CONFIGURATION_TYPES:STRING=Release -DCMAKE_TRY_COMPILE_CONFIGURATION:STRING=Release ../../../
   # cleanup
   cd ../../../
 }

--- a/runCMake.ps1
+++ b/runCMake.ps1
@@ -1,3 +1,4 @@
+param([Int32]$msvc=2017)
 
 function findCmake()
 {
@@ -16,10 +17,30 @@ function findCmake()
   }
 }
 
+
+function findCMakeGenerator()
+{
+    [string[]] $generators = 
+        "Visual Studio 10 2010",
+        "Visual Studio 11 2012",
+        "Visual Studio 12 2013",
+        "Visual Studio 14 2015",
+        "Visual Studio 15 2017", 
+        "Visual Studio 16 2019"
+    ForEach ( $generator In $generators) {
+        if( $generator -match "$msvc" ) {
+            $global:genX86 = $generator
+            $global:genX64 = $generator + " Win64"
+            return;
+        }
+    }
+    Write-Host "Using default MSVC settings"
+}
+
 function runCMake( $platform, $generator)
 {
   # find visual studio string
-  if( $generator -match "Visual Studio [1-9]* [0-9]*" ) {
+  if( $generator -match "Visual Studio [0-9]* [0-9]*" ) {
     # remove whitespaces to not destroy include pathes
     $msvc = $Matches.Values[0] -replace "\s","_"
   }
@@ -35,10 +56,15 @@ function runCMake( $platform, $generator)
   cd ../../../
 }
 
+$global:genX86 = $null
+$global:genX64 = $null
 findCMake
-runCMake "x86" "Visual Studio 15 2017" 
+findCMakeGenerator
+Write-Host "Using Generator $genX86"
+runCMake "x86" $genX86 
 if ([System.IntPtr]::Size -gt 4) { 
-  runCMake "x64" "Visual Studio 15 2017 Win64" 
+  Write-Host "Using Generator $genX64"
+  runCMake "x64" $genX64 
 }
 
 pause


### PR DESCRIPTION
Astyle cannot be used on cross compilation (Android, IOS,...) due the executable will not run on the build host.
Astyle does not build with MSVC, due a MVC compiler error C1061 (compiler limit: blocks nested too deeply). 
In these cases replace the build targets with simple echo commands.

Also included: a minor fix for the runCMake.ps1, to be able to specify the MSVC version to be used (CMAKE Generator)