### PR TITLE
Truncate dt1 Matrix Precision

### DIFF
--- a/NFIQ2/NFIQ2Algorithm/src/features/FeatureFunctions.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FeatureFunctions.cpp
@@ -347,7 +347,6 @@ void getRotatedBlock( const Mat& block, const double orientation, bool padFlag, 
   return;
 }
 //////////////////////////////////////////////////////////////////////////////
-
 void getRidgeValleyStructure( const Mat& blockCropped, std::vector<uint8_t>& ridval, std::vector<double>& dt )
 {
 

--- a/NFIQ2/NFIQ2Algorithm/src/features/FeatureFunctions.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FeatureFunctions.cpp
@@ -392,17 +392,17 @@ void getRidgeValleyStructure( const Mat& blockCropped, std::vector<uint8_t>& rid
     throw NFIQ::NFIQException( NFIQ::e_Error_FeatureCalculationError, ssErr.str() );
   }
 
-  // Round to 11 decimal points to preserve score consistency across platforms
-  std::function<double( double )> roundtoPrecision = [&]( double val )
+  // Round to 11 decimal points to preserve score consistency across platforms (10^11)
+  std::function<double( double )> truncateEleven = [&]( double val )
   {
-    return round( val * pow( 10, 11 ) ) / pow( 10, 11 );
+    return round( val * 100000000000 ) / 100000000000;
   };
 
   for( int i = 0; i < dt1.rows; i++ )
   {
     for( int j = 0; j < dt1.cols; j++ )
     {
-      dt1.at<double>( i, j ) = roundtoPrecision( dt1.at<double>( i, j ) );
+      dt1.at<double>( i, j ) = truncateEleven( dt1.at<double>( i, j ) );
     }
   }
 

--- a/NFIQ2/NFIQ2Algorithm/src/features/FeatureFunctions.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FeatureFunctions.cpp
@@ -347,6 +347,7 @@ void getRotatedBlock( const Mat& block, const double orientation, bool padFlag, 
   return;
 }
 //////////////////////////////////////////////////////////////////////////////
+
 void getRidgeValleyStructure( const Mat& blockCropped, std::vector<uint8_t>& ridval, std::vector<double>& dt )
 {
 
@@ -392,18 +393,13 @@ void getRidgeValleyStructure( const Mat& blockCropped, std::vector<uint8_t>& rid
   }
 
   // Round to 11 decimal points to preserve score consistency across platforms (10^11)
-  std::function<double( double )> truncateEleven = [&]( double val )
+  dt1.forEach<double>
+  (
+    [&]( double & val, const int* position )
   {
-    return round( val * 100000000000 ) / 100000000000;
-  };
-
-  for( int i = 0; i < dt1.rows; i++ )
-  {
-    for( int j = 0; j < dt1.cols; j++ )
-    {
-      dt1.at<double>( i, j ) = truncateEleven( dt1.at<double>( i, j ) );
-    }
+    val = round( val * 100000000000 ) / 100000000000;
   }
+  );
 
   //%% Block segmentation into ridge and valley regions
   //  dt = x*dt1(2) + dt1(1);

--- a/NFIQ2/NFIQ2Algorithm/src/features/FeatureFunctions.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FeatureFunctions.cpp
@@ -392,6 +392,16 @@ void getRidgeValleyStructure( const Mat& blockCropped, std::vector<uint8_t>& rid
   }
 
   // Round to 11 decimal points to preserve score consistency across platforms (10^11)
+#if CV_MAJOR_VERSION <= 2
+  for( int i = 0; i < dt1.rows; i++ )
+  {
+    for( int j = 0; j < dt1.cols; j++ )
+    {
+      dt1.at<double>( i, j ) = round( dt1.at<double>( i, j ) * 100000000000 ) /
+                               100000000000;
+    }
+  }
+#else
   dt1.forEach<double>
   (
     [&]( double & val, const int* position )
@@ -399,6 +409,7 @@ void getRidgeValleyStructure( const Mat& blockCropped, std::vector<uint8_t>& rid
     val = round( val * 100000000000 ) / 100000000000;
   }
   );
+#endif /* CV_MAJOR_VERSION */
 
   //%% Block segmentation into ridge and valley regions
   //  dt = x*dt1(2) + dt1(1);

--- a/NFIQ2/NFIQ2Algorithm/src/features/FeatureFunctions.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FeatureFunctions.cpp
@@ -9,6 +9,7 @@
 #include <limits>
 #include <iostream>
 #include <cstring>
+#include <iomanip>
 
 #ifndef M_PI
 #define M_PI 3.14159265358979323846
@@ -347,6 +348,13 @@ void getRotatedBlock( const Mat& block, const double orientation, bool padFlag, 
   return;
 }
 //////////////////////////////////////////////////////////////////////////////
+double roundtoPrecision(double val,int precision)
+{
+     // Do initial checks
+     double output = round(val * pow(10,precision))/pow(10,precision);
+     return output;
+}
+
 void getRidgeValleyStructure( const Mat& blockCropped, std::vector<uint8_t>& ridval, std::vector<double>& dt )
 {
 
@@ -390,6 +398,12 @@ void getRidgeValleyStructure( const Mat& blockCropped, std::vector<uint8_t>& rid
     ssErr << "Exception during ridge/valley processing: solve(DECOMP_QR) " << e.what();
     throw NFIQ::NFIQException( NFIQ::e_Error_FeatureCalculationError, ssErr.str() );
   }
+
+  for (int i = 0; i < dt1.rows; i++) {
+    for (int j = 0; j < dt1.cols; j++) {
+      dt1.at<double>(i, j) = roundtoPrecision(dt1.at<double>(i, j), 10);
+    }
+  } 
 
   //%% Block segmentation into ridge and valley regions
   //  dt = x*dt1(2) + dt1(1);

--- a/NFIQ2/NFIQ2Algorithm/src/features/FeatureFunctions.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FeatureFunctions.cpp
@@ -392,15 +392,19 @@ void getRidgeValleyStructure( const Mat& blockCropped, std::vector<uint8_t>& rid
     throw NFIQ::NFIQException( NFIQ::e_Error_FeatureCalculationError, ssErr.str() );
   }
 
-  std::function<double(double, int)> roundtoPrecision = [&](double val, int precision) {
-    return round(val * pow(10,precision))/pow(10,precision);
+  // Round to 11 decimal points to preserve score consistency across platforms
+  std::function<double( double )> roundtoPrecision = [&]( double val )
+  {
+    return round( val * pow( 10, 11 ) ) / pow( 10, 11 );
   };
 
-  for (int i = 0; i < dt1.rows; i++) {
-    for (int j = 0; j < dt1.cols; j++) {
-      dt1.at<double>(i, j) = roundtoPrecision(dt1.at<double>(i, j), 15);
+  for( int i = 0; i < dt1.rows; i++ )
+  {
+    for( int j = 0; j < dt1.cols; j++ )
+    {
+      dt1.at<double>( i, j ) = roundtoPrecision( dt1.at<double>( i, j ) );
     }
-  } 
+  }
 
   //%% Block segmentation into ridge and valley regions
   //  dt = x*dt1(2) + dt1(1);

--- a/NFIQ2/NFIQ2Algorithm/src/features/FeatureFunctions.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FeatureFunctions.cpp
@@ -347,12 +347,6 @@ void getRotatedBlock( const Mat& block, const double orientation, bool padFlag, 
   return;
 }
 //////////////////////////////////////////////////////////////////////////////
-double roundtoPrecision(double val,int precision)
-{
-     // Do initial checks
-     double output = round(val * pow(10,precision))/pow(10,precision);
-     return output;
-}
 
 void getRidgeValleyStructure( const Mat& blockCropped, std::vector<uint8_t>& ridval, std::vector<double>& dt )
 {
@@ -398,9 +392,13 @@ void getRidgeValleyStructure( const Mat& blockCropped, std::vector<uint8_t>& rid
     throw NFIQ::NFIQException( NFIQ::e_Error_FeatureCalculationError, ssErr.str() );
   }
 
+  std::function<double(double, int)> roundtoPrecision = [&](double val, int precision) {
+    return round(val * pow(10,precision))/pow(10,precision);
+  };
+
   for (int i = 0; i < dt1.rows; i++) {
     for (int j = 0; j < dt1.cols; j++) {
-      dt1.at<double>(i, j) = roundtoPrecision(dt1.at<double>(i, j), 10);
+      dt1.at<double>(i, j) = roundtoPrecision(dt1.at<double>(i, j), 15);
     }
   } 
 

--- a/NFIQ2/NFIQ2Algorithm/src/features/FeatureFunctions.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FeatureFunctions.cpp
@@ -9,7 +9,6 @@
 #include <limits>
 #include <iostream>
 #include <cstring>
-#include <iomanip>
 
 #ifndef M_PI
 #define M_PI 3.14159265358979323846


### PR DESCRIPTION
Inconsistencies in NFIQ2 quality scores across Windows, Mac and Centos versions were linked to the dt1 matrix used in RVUP and LCS calculations. This is a 1 x 2 matrix comprised of double values and is the resulting matrix after performing a QR Decomposition using OpenCV's "solve" method. Tests were performed cross platform and in Matlab to compare the resulting dt1 matrices. The results showed that each platform (including Matlab) produced a unique matrix. To try and mitigate the effect this inconsistency will have, the values inside the matrix were truncated to 11 points of precision. This is the point where LCS and RVUP scores no longer deviate from one another across these platforms. 