### PR TITLE
Replacing Blank Values with "NA"

### DIFF
--- a/NFIQ2/NFIQ2Algorithm/include/tool/nfiq2_ui_log.h
+++ b/NFIQ2/NFIQ2Algorithm/include/tool/nfiq2_ui_log.h
@@ -53,16 +53,15 @@ namespace NFIQ2UI
        *
        *  @details
        *    Prints score generated from NFIQ2.
-       *    Error code 255 is printed if image could not be evaluated.
        *
-       *    @param[in] name
+       *  @param[in] name
        *    The name of the image.
-       *    @param[in] fingerCode
+       *  @param[in] fingerCode
        *    Finger position of the image. Valid values: 0-12.
        *  @param[in] score
        *    Calculated NFIQ2 Score.
        *  @param[in] errmsg
-       *    Error message if applicable.
+       *    Error message if applicable. Will be "NA" otherwise.
        *  @param[in] quantized
        *    If the image was quantized 0 = not quantized, 1 = quantized.
        *  @param[in] resampled
@@ -76,8 +75,48 @@ namespace NFIQ2UI
                        unsigned int score, const std::string& errmsg,
                        const bool quantized, const bool resampled,
                        const std::list<NFIQ::QualityFeatureData>& featureVector,
-                       const std::list<NFIQ::QualityFeatureSpeed>& featureTimings,
-                       const std::string& padding = "" ) const;
+                       const std::list<NFIQ::QualityFeatureSpeed>& featureTimings ) const;
+
+      /**
+       *  @brief
+       *  Pads an error score with NA values to provide consistency when CSV output
+       *  is used in an outside data processing application
+       *
+       *  @details
+       *  Checks to see whether Verbose/Quality and/or Speed flags have been
+       *  enabled. If so, the amount of padding will vary.
+       *
+       *  @return
+       *    The padded NA string.
+       */
+      std::string padNA() const;
+
+      /**
+       *  @brief
+       *    Print the score for an Image in CSV format.
+       *
+       *  @details
+       *    Prints Error scores generated from NFIQ2 for images that failed
+       *    processing.
+       *    Error code 255 is printed if image could not be evaluated and padding
+       *    is added to ensure consistency.
+       *
+       *  @param[in] name
+       *    The name of the image.
+       *  @param[in] fingerCode
+       *    Finger position of the image. Valid values: 0-12.
+       *  @param[in] score
+       *    Calculated NFIQ2 Score.
+       *  @param[in] errmsg
+       *    Error message if applicable. Will be "NA" otherwise
+       *  @param[in] quantized
+       *    If the image was quantized 0 = not quantized, 1 = quantized.
+       *  @param[in] resampled
+       *    If the image was resampled 0 = not resampled, 1 = resampled.
+       */
+      void printError(
+        const std::string& name, uint8_t fingerCode, unsigned int score,
+        const std::string& errmsg, const bool quantized, const bool resampled ) const;
 
       /**
        *  @brief

--- a/NFIQ2/NFIQ2Algorithm/include/tool/nfiq2_ui_log.h
+++ b/NFIQ2/NFIQ2Algorithm/include/tool/nfiq2_ui_log.h
@@ -72,12 +72,12 @@ namespace NFIQ2UI
        *  @param[in] featureTimings
        *    Prints featureTimings information if verbose flag is enabled.
        */
-      void
-      printScore( const std::string& name, uint8_t fingerCode, unsigned int score,
-                  const std::string& errmsg, const bool quantized,
-                  const bool resampled,
-                  const std::list<NFIQ::QualityFeatureData>& featureVector,
-                  const std::list<NFIQ::QualityFeatureSpeed>& featureTimings ) const;
+      void printScore( const std::string& name, uint8_t fingerCode,
+                       unsigned int score, const std::string& errmsg,
+                       const bool quantized, const bool resampled,
+                       const std::list<NFIQ::QualityFeatureData>& featureVector,
+                       const std::list<NFIQ::QualityFeatureSpeed>& featureTimings,
+                       const std::string& padding = "" ) const;
 
       /**
        *  @brief

--- a/NFIQ2/NFIQ2Algorithm/include/tool/nfiq2_ui_refresh.h
+++ b/NFIQ2/NFIQ2Algorithm/include/tool/nfiq2_ui_refresh.h
@@ -60,7 +60,7 @@ namespace NFIQ2UI
                       std::shared_ptr<NFIQ::NFIQ2Algorithm> model,
                       std::shared_ptr<NFIQ2UI::Log> logger, const bool singleImage,
                       const bool interactive, const uint8_t fingerPosition = 0,
-                      const std::string& warning = "'NA'" );
+                      const std::string& warning = "NA" );
 
   /**
    *  @brief

--- a/NFIQ2/NFIQ2Algorithm/include/tool/nfiq2_ui_refresh.h
+++ b/NFIQ2/NFIQ2Algorithm/include/tool/nfiq2_ui_refresh.h
@@ -59,8 +59,8 @@ namespace NFIQ2UI
                       const std::string& name, const Flags& flags,
                       std::shared_ptr<NFIQ::NFIQ2Algorithm> model,
                       std::shared_ptr<NFIQ2UI::Log> logger, const bool singleImage,
-                      const bool interactive, const uint8_t fingerPosition,
-                      const std::string& warning );
+                      const bool interactive, const uint8_t fingerPosition = 0,
+                      const std::string& warning = "'NA'" );
 
   /**
    *  @brief

--- a/NFIQ2/NFIQ2Algorithm/include/tool/nfiq2_ui_utils.h
+++ b/NFIQ2/NFIQ2Algorithm/include/tool/nfiq2_ui_utils.h
@@ -159,14 +159,11 @@ namespace NFIQ2UI
    *  Checks to see whether Verbose/Quality and/or Speed flags have been
    *  enabled. If so, the amount of padding will vary.
    *
-   *  @param[in] score
-   *    The score string before any padding is applied.
-   *
    *  @param[in] flags
    *    Flags struct to check if the Verbose or Speed flags were enabled.
    *
    *  @return
-   *    The padded score string.
+   *    The padded 'NA' string.
    */
   std::string padNA( const Flags& flags );
 

--- a/NFIQ2/NFIQ2Algorithm/include/tool/nfiq2_ui_utils.h
+++ b/NFIQ2/NFIQ2Algorithm/include/tool/nfiq2_ui_utils.h
@@ -152,23 +152,6 @@ namespace NFIQ2UI
 
   /**
    *  @brief
-   *  Pads a score with NA values to provide consistency when CSV output
-   *  is used in an outside data processing application
-   *
-   *  @details
-   *  Checks to see whether Verbose/Quality and/or Speed flags have been
-   *  enabled. If so, the amount of padding will vary.
-   *
-   *  @param[in] flags
-   *    Flags struct to check if the Verbose or Speed flags were enabled.
-   *
-   *  @return
-   *    The padded NA string.
-   */
-  std::string padNA( const Flags& flags );
-
-  /**
-   *  @brief
    *  Prints information on how to use this NFIQ2 tool
    */
   void printUsage();

--- a/NFIQ2/NFIQ2Algorithm/include/tool/nfiq2_ui_utils.h
+++ b/NFIQ2/NFIQ2Algorithm/include/tool/nfiq2_ui_utils.h
@@ -152,6 +152,26 @@ namespace NFIQ2UI
 
   /**
    *  @brief
+   *  Pads a score with 'NA' values to provide consistency when CSV output
+   *  is used in an outside data processing application
+   *
+   *  @details
+   *  Checks to see whether Verbose/Quality and/or Speed flags have been
+   *  enabled. If so, the amount of padding will vary.
+   *
+   *  @param[in] score
+   *    The score string before any padding is applied.
+   *
+   *  @param[in] flags
+   *    Flags struct to check if the Verbose or Speed flags were enabled.
+   *
+   *  @return
+   *    The padded score string.
+   */
+  std::string padNA( const Flags& flags );
+
+  /**
+   *  @brief
    *  Prints information on how to use this NFIQ2 tool
    */
   void printUsage();

--- a/NFIQ2/NFIQ2Algorithm/include/tool/nfiq2_ui_utils.h
+++ b/NFIQ2/NFIQ2Algorithm/include/tool/nfiq2_ui_utils.h
@@ -152,7 +152,7 @@ namespace NFIQ2UI
 
   /**
    *  @brief
-   *  Pads a score with 'NA' values to provide consistency when CSV output
+   *  Pads a score with NA values to provide consistency when CSV output
    *  is used in an outside data processing application
    *
    *  @details
@@ -163,7 +163,7 @@ namespace NFIQ2UI
    *    Flags struct to check if the Verbose or Speed flags were enabled.
    *
    *  @return
-   *    The padded 'NA' string.
+   *    The padded NA string.
    */
   std::string padNA( const Flags& flags );
 

--- a/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_image.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_image.cpp
@@ -56,8 +56,8 @@ NFIQ2UI::getImages( const BE::Memory::uint8Array& dataArray,
     default:
       logger->debugMsg( "Image type could not be determined. " + name +
                         " will not be processed" );
-      logger->printScore( name, 0, 255, "'Error: Could not determine FileType'", 0,
-                          0, {}, {} );
+      logger->printError( name, 0, 255, "'Error: Could not determine FileType'", 0,
+                          0 );
 
       return vecCouple;
   }
@@ -87,8 +87,7 @@ NFIQ2UI::getImages( const std::string& path,
   {
 
     std::string error{"'Error: Could not obtain data from path : "};
-    logger->printScore( path, 0, 255, error.append( e.what() ) + "'", false, false,
-                        {}, {} );
+    logger->printError( path, 0, 255, error.append( e.what() ) + "'", false, false );
   }
 
   return vecCouple;
@@ -117,8 +116,7 @@ NFIQ2UI::getImagesFromImage( const BE::Memory::uint8Array& dataArray,
   {
     // Unable to open the image
     std::string error{"'Error: Could not open image : "};
-    logger->printScore( name, 0, 255, error.append( e.what() ) + "'", 0, 0, {},
-                        {} );
+    logger->printError( name, 0, 255, error.append( e.what() ) + "'", 0, 0 );
   }
   return vecCouple;
 }
@@ -144,8 +142,7 @@ NFIQ2UI::getImagesFromAN2K( const BE::Memory::uint8Array& dataArray,
   {
 
     std::string error{"'Error AN2K Record could not be opened : "};
-    logger->printScore( name, 0, 255, error.append( e.what() ) + "'", 0, 0, {},
-                        {} );
+    logger->printError( name, 0, 255, error.append( e.what() ) + "'", 0, 0 );
     return vecCouple;
   }
 
@@ -220,10 +217,10 @@ NFIQ2UI::getImagesFromAN2K( const BE::Memory::uint8Array& dataArray,
       logger->debugMsg( "Invalid fingerprint position provided: " + name + "_" +
                         std::to_string( fingerPosition ) );
 
-      logger->printScore( name + "_" + std::to_string( fingerPosition ),
+      logger->printError( name + "_" + std::to_string( fingerPosition ),
                           static_cast<uint8_t>( fingerPosition ), 255,
                           "'Error: Invalid FingerPosition for NFIQ2 (not 0-12)'",
-                          0, 0, {}, {} );
+                          0, 0 );
     }
   }
   return vecCouple;
@@ -255,8 +252,7 @@ NFIQ2UI::getImagesFromANSI2004( const BE::Memory::uint8Array& dataArray,
   {
     // Could not make ANSI2004Record
     std::string error{"'ERROR: ANSI2004 RECORD COULD NOT BE OPENED : "};
-    logger->printScore( name, 0, 255, error.append( e.what() ) + "'", 0, 0, {},
-                        {} );
+    logger->printError( name, 0, 255, error.append( e.what() ) + "'", 0, 0 );
     return vecCouple;
   }
 
@@ -330,10 +326,10 @@ NFIQ2UI::getImagesFromANSI2004( const BE::Memory::uint8Array& dataArray,
       logger->debugMsg( "Invalid fingerprint position provided: " + name + "_" +
                         std::to_string( fingerPosition ) );
 
-      logger->printScore( name + "_" + std::to_string( fingerPosition ),
+      logger->printError( name + "_" + std::to_string( fingerPosition ),
                           static_cast<uint8_t>( fingerPosition ), 255,
                           "'Error: Invalid finger print position for NFIQ2'", 0,
-                          0, {}, {} );
+                          0 );
     }
   }
 

--- a/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_image.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_image.cpp
@@ -110,7 +110,7 @@ NFIQ2UI::getImagesFromImage( const BE::Memory::uint8Array& dataArray,
 
     logger->debugMsg( "Successfully parsed image from data-blob: " + name );
 
-    vecCouple.emplace_back( img, 0, name, "" );
+    vecCouple.emplace_back( img, 0, name, "'NA'" );
 
   }
   catch( const BE::Error::Exception& e )
@@ -171,7 +171,7 @@ NFIQ2UI::getImagesFromAN2K( const BE::Memory::uint8Array& dataArray,
 
       logger->debugMsg( "Capture is a valid NFIQ2 fingerPosition" );
 
-      std::string warning = "";
+      std::string warning = "'NA'";
 
       const uint16_t imageDPI = static_cast<uint16_t>(
                                   std::round( img->getResolution()
@@ -281,7 +281,7 @@ NFIQ2UI::getImagesFromANSI2004( const BE::Memory::uint8Array& dataArray,
 
       logger->debugMsg( "Capture is a valid NFIQ2 fingerPosition" );
 
-      std::string warning = "";
+      std::string warning = "'NA'";
 
       const uint16_t imageDPI = static_cast<uint16_t>(
                                   std::round( img->getResolution()

--- a/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_image.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_image.cpp
@@ -110,7 +110,7 @@ NFIQ2UI::getImagesFromImage( const BE::Memory::uint8Array& dataArray,
 
     logger->debugMsg( "Successfully parsed image from data-blob: " + name );
 
-    vecCouple.emplace_back( img, 0, name, "'NA'" );
+    vecCouple.emplace_back( img, 0, name, "NA" );
 
   }
   catch( const BE::Error::Exception& e )
@@ -171,7 +171,7 @@ NFIQ2UI::getImagesFromAN2K( const BE::Memory::uint8Array& dataArray,
 
       logger->debugMsg( "Capture is a valid NFIQ2 fingerPosition" );
 
-      std::string warning = "'NA'";
+      std::string warning = "NA";
 
       const uint16_t imageDPI = static_cast<uint16_t>(
                                   std::round( img->getResolution()
@@ -281,7 +281,7 @@ NFIQ2UI::getImagesFromANSI2004( const BE::Memory::uint8Array& dataArray,
 
       logger->debugMsg( "Capture is a valid NFIQ2 fingerPosition" );
 
-      std::string warning = "'NA'";
+      std::string warning = "NA";
 
       const uint16_t imageDPI = static_cast<uint16_t>(
                                   std::round( img->getResolution()

--- a/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_log.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_log.cpp
@@ -46,13 +46,12 @@ void NFIQ2UI::Log::printScore(
   const std::string& name, uint8_t fingerCode, unsigned int score,
   const std::string& errmsg, const bool quantized, const bool resampled,
   const std::list<NFIQ::QualityFeatureData>& featureVector,
-  const std::list<NFIQ::QualityFeatureSpeed>& featureTimings,
-  const std::string& padding ) const
+  const std::list<NFIQ::QualityFeatureSpeed>& featureTimings ) const
 {
 
   *( this->out ) << name << "," << std::to_string( fingerCode ) << "," << score
                  << "," << errmsg << "," << quantized << "," << resampled;
-  if( ( this->verbose || this->speed ) && padding == "" )
+  if( this->verbose || this->speed )
   {
     *( this->out ) << ",";
   }
@@ -88,7 +87,45 @@ void NFIQ2UI::Log::printScore(
       *( this->out ) << std::setprecision( 5 ) << i->featureSpeed;
     }
   }
-  *( this->out ) << padding << "\n";
+  *( this->out ) << "\n";
+}
+
+// Pad CSV output with NAs for row consistency
+std::string NFIQ2UI::Log::padNA() const
+{
+  const unsigned int MIN_NUM_COLS = 6;
+  unsigned int NUM_COLS = MIN_NUM_COLS;
+
+  if( this->verbose )
+  {
+    NUM_COLS += 69;
+  }
+
+  if( this->speed )
+  {
+    NUM_COLS += 10;
+  }
+
+  const unsigned int padding = NUM_COLS - MIN_NUM_COLS;
+  std::string strNA{};
+
+  for( auto i = 0; i < padding; i++ )
+  {
+    strNA = strNA + ",NA";
+  }
+
+  return strNA;
+}
+
+// Prints out an error score if the image was unable to be processed correctly
+void NFIQ2UI::Log::printError(
+  const std::string& name, uint8_t fingerCode, unsigned int score,
+  const std::string& errmsg, const bool quantized, const bool resampled ) const
+{
+  const std::string padding = NFIQ2UI::Log::padNA();
+
+  *( this->out ) << name << "," << std::to_string( fingerCode ) << "," << score
+                 << "," << errmsg << "," << quantized << "," << resampled << padding << "\n";
 }
 
 // Prints the quality score of a single image

--- a/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_log.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_log.cpp
@@ -93,25 +93,29 @@ void NFIQ2UI::Log::printScore(
 // Pad CSV output with NAs for row consistency
 std::string NFIQ2UI::Log::padNA() const
 {
-  const unsigned int MIN_NUM_COLS = 6;
-  unsigned int NUM_COLS = MIN_NUM_COLS;
+  static std::string strNA{};
+  if( !strNA.empty() )
+  {
+    return strNA;
+  }
+
+  static const unsigned int MIN_NUM_COLS{6};
+  unsigned int numCols{MIN_NUM_COLS};
 
   if( this->verbose )
   {
-    NUM_COLS += 69;
+    numCols += 69;
   }
 
   if( this->speed )
   {
-    NUM_COLS += 10;
+    numCols += 10;
   }
 
-  const unsigned int padding = NUM_COLS - MIN_NUM_COLS;
-  std::string strNA{};
-
+  const unsigned int padding = numCols - MIN_NUM_COLS;
   for( auto i = 0; i < padding; i++ )
   {
-    strNA = strNA + ",NA";
+    strNA += ",NA";
   }
 
   return strNA;
@@ -122,10 +126,8 @@ void NFIQ2UI::Log::printError(
   const std::string& name, uint8_t fingerCode, unsigned int score,
   const std::string& errmsg, const bool quantized, const bool resampled ) const
 {
-  const std::string padding = NFIQ2UI::Log::padNA();
-
   *( this->out ) << name << "," << std::to_string( fingerCode ) << "," << score
-                 << "," << errmsg << "," << quantized << "," << resampled << padding << "\n";
+                 << "," << errmsg << "," << quantized << "," << resampled << padNA() << "\n";
 }
 
 // Prints the quality score of a single image

--- a/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_log.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_log.cpp
@@ -46,13 +46,13 @@ void NFIQ2UI::Log::printScore(
   const std::string& name, uint8_t fingerCode, unsigned int score,
   const std::string& errmsg, const bool quantized, const bool resampled,
   const std::list<NFIQ::QualityFeatureData>& featureVector,
-  const std::list<NFIQ::QualityFeatureSpeed>& featureTimings ) const
+  const std::list<NFIQ::QualityFeatureSpeed>& featureTimings,
+  const std::string& padding ) const
 {
 
-  *( this->out ) << name << "," << std::to_string( fingerCode ) << ","
-                 << score << "," << errmsg << "," << quantized << ","
-                 << resampled;
-  if( this->verbose || this->speed )
+  *( this->out ) << name << "," << std::to_string( fingerCode ) << "," << score
+                 << "," << errmsg << "," << quantized << "," << resampled;
+  if( ( this->verbose || this->speed ) && padding == "" )
   {
     *( this->out ) << ",";
   }
@@ -73,7 +73,6 @@ void NFIQ2UI::Log::printScore(
     {
       *( this->out ) << ",";
     }
-
   }
 
   if( this->speed )
@@ -89,7 +88,7 @@ void NFIQ2UI::Log::printScore(
       *( this->out ) << std::setprecision( 5 ) << i->featureSpeed;
     }
   }
-  *( this->out ) << "\n";
+  *( this->out ) << padding << "\n";
 }
 
 // Prints the quality score of a single image
@@ -127,7 +126,7 @@ void NFIQ2UI::Log::printCSVHeader() const
                  << "Quantized"
                  << ","
                  << "Resampled";
-  if( this->verbose || this-> speed )
+  if( this->verbose || this->speed )
   {
     *( this->out ) << ",";
   }

--- a/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_refresh.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_refresh.cpp
@@ -91,22 +91,18 @@ void NFIQ2UI::executeSingle( std::shared_ptr<BE::Image::Image> img,
         else
         {
           // Denied the quantize
-          std::string padding = NFIQ2UI::padNA( flags );
-
           logger->debugMsg( "User denied the quantize" );
-          logger->printScore( name, fingerPosition, 255,
+          logger->printError( name, fingerPosition, 255,
                               "'Error: User chose not to quantize image'",
-                              quantized, resampled, {}, {}, padding );
+                              quantized, resampled );
           return;
         }
       }
       else
       {
-        std::string padding = NFIQ2UI::padNA( flags );
-
-        logger->printScore( name, fingerPosition, 255,
+        logger->printError( name, fingerPosition, 255,
                             "'Error: image is not 8 bit depth and/or color'",
-                            quantized, resampled, {}, {}, padding );
+                            quantized, resampled );
         return;
       }
     }
@@ -148,35 +144,28 @@ void NFIQ2UI::executeSingle( std::shared_ptr<BE::Image::Image> img,
 
           /* FIXME: Re-sample Image Code here
            */
-          std::string padding = NFIQ2UI::padNA( flags );
 
           logger->debugMsg( "User approved the re-sample" );
-          logger->printScore( name, fingerPosition, 255,
+          logger->printError( name, fingerPosition, 255,
                               "'Error: Resampling not implemented'", quantized,
-                              resampled, {}, {}, padding );
+                              resampled );
           return;
         }
         else
         {
           // User decided not to re-sample
-
-          std::string padding = NFIQ2UI::padNA( flags );
-
           logger->debugMsg( "User denied the re-sample" );
-          logger->printScore( name, fingerPosition, 255,
+          logger->printError( name, fingerPosition, 255,
                               "'Error: User chose not to re-sample image'",
-                              quantized, resampled, {}, {}, padding );
+                              quantized, resampled );
           return;
         }
 
       }
       else
       {
-        std::string padding = NFIQ2UI::padNA( flags );
-
-        logger->printScore( name, fingerPosition, 255,
-                            "'Error: Image is not 500PPI'", quantized, resampled,
-                            {}, {}, padding );
+        logger->printError( name, fingerPosition, 255,
+                            "'Error: Image is not 500PPI'", quantized, resampled );
         return;
       }
     }
@@ -210,11 +199,8 @@ void NFIQ2UI::executeSingle( std::shared_ptr<BE::Image::Image> img,
   {
     logger->debugMsg( "Could not get Grayscale raw data from image" + name );
     std::string error{"'Error: Could not get Grayscale raw data from image'"};
-
-    std::string padding = NFIQ2UI::padNA( flags );
-
-    logger->printScore( name, fingerPosition, 255, error.append( e.what() ),
-                        quantized, resampled, {}, {}, padding );
+    logger->printError( name, fingerPosition, 255, error.append( e.what() ),
+                        quantized, resampled );
     return;
   }
 
@@ -486,11 +472,8 @@ void NFIQ2UI::recordStoreConsume( const std::string& name,
   catch( const BE::Error::Exception& e )
   {
     std::string error{"'Error: Could not open RecordStore'"};
-
-    std::string padding = NFIQ2UI::padNA( flags );
-
-    threadedlogger->printScore( name, 0, 255, error.append( e.what() ), false,
-                                false, {}, {}, padding );
+    threadedlogger->printError( name, 0, 255, error.append( e.what() ), false,
+                                false );
     return;
   }
 
@@ -536,11 +519,7 @@ void NFIQ2UI::executeRecordStore( const std::string& filename,
   {
 
     std::string error{"'Error: Could not open RecordStore'"};
-
-    std::string padding = NFIQ2UI::padNA( flags );
-
-    logger->printScore( filename, 0, 255, error.append( e.what() ), false, false,
-                        {}, {}, padding );
+    logger->printError( filename, 0, 255, error.append( e.what() ), false, false );
     return;
   }
 

--- a/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_refresh.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_refresh.cpp
@@ -52,8 +52,8 @@ void NFIQ2UI::executeSingle( std::shared_ptr<BE::Image::Image> img,
                              std::shared_ptr<NFIQ::NFIQ2Algorithm> model,
                              std::shared_ptr<NFIQ2UI::Log> logger,
                              const bool singleImage, const bool interactive,
-                             const uint8_t fingerPosition = 0,
-                             const std::string& warning = "" )
+                             const uint8_t fingerPosition,
+                             const std::string& warning )
 {
 
   // Indicate whether it was quantized or re-sampled
@@ -91,18 +91,22 @@ void NFIQ2UI::executeSingle( std::shared_ptr<BE::Image::Image> img,
         else
         {
           // Denied the quantize
+          std::string padding = NFIQ2UI::padNA( flags );
+
           logger->debugMsg( "User denied the quantize" );
           logger->printScore( name, fingerPosition, 255,
                               "'Error: User chose not to quantize image'",
-                              quantized, resampled, {}, {} );
+                              quantized, resampled, {}, {}, padding );
           return;
         }
       }
       else
       {
+        std::string padding = NFIQ2UI::padNA( flags );
+
         logger->printScore( name, fingerPosition, 255,
                             "'Error: image is not 8 bit depth and/or color'",
-                            quantized, resampled, {}, {} );
+                            quantized, resampled, {}, {}, padding );
         return;
       }
     }
@@ -144,28 +148,35 @@ void NFIQ2UI::executeSingle( std::shared_ptr<BE::Image::Image> img,
 
           /* FIXME: Re-sample Image Code here
            */
+          std::string padding = NFIQ2UI::padNA( flags );
+
           logger->debugMsg( "User approved the re-sample" );
           logger->printScore( name, fingerPosition, 255,
                               "'Error: Resampling not implemented'", quantized,
-                              false, {}, {} );
+                              resampled, {}, {}, padding );
           return;
         }
         else
         {
           // User decided not to re-sample
+
+          std::string padding = NFIQ2UI::padNA( flags );
+
           logger->debugMsg( "User denied the re-sample" );
           logger->printScore( name, fingerPosition, 255,
                               "'Error: User chose not to re-sample image'",
-                              quantized, resampled, {}, {} );
+                              quantized, resampled, {}, {}, padding );
           return;
         }
 
       }
       else
       {
+        std::string padding = NFIQ2UI::padNA( flags );
+
         logger->printScore( name, fingerPosition, 255,
                             "'Error: Image is not 500PPI'", quantized, resampled,
-                            {}, {} );
+                            {}, {}, padding );
         return;
       }
     }
@@ -199,8 +210,11 @@ void NFIQ2UI::executeSingle( std::shared_ptr<BE::Image::Image> img,
   {
     logger->debugMsg( "Could not get Grayscale raw data from image" + name );
     std::string error{"'Error: Could not get Grayscale raw data from image'"};
+
+    std::string padding = NFIQ2UI::padNA( flags );
+
     logger->printScore( name, fingerPosition, 255, error.append( e.what() ),
-                        quantized, resampled, {}, {} );
+                        quantized, resampled, {}, {}, padding );
     return;
   }
 
@@ -472,8 +486,11 @@ void NFIQ2UI::recordStoreConsume( const std::string& name,
   catch( const BE::Error::Exception& e )
   {
     std::string error{"'Error: Could not open RecordStore'"};
+
+    std::string padding = NFIQ2UI::padNA( flags );
+
     threadedlogger->printScore( name, 0, 255, error.append( e.what() ), false,
-                                false, {}, {} );
+                                false, {}, {}, padding );
     return;
   }
 
@@ -519,8 +536,11 @@ void NFIQ2UI::executeRecordStore( const std::string& filename,
   {
 
     std::string error{"'Error: Could not open RecordStore'"};
+
+    std::string padding = NFIQ2UI::padNA( flags );
+
     logger->printScore( filename, 0, 255, error.append( e.what() ), false, false,
-                        {}, {} );
+                        {}, {}, padding );
     return;
   }
 

--- a/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_utils.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_utils.cpp
@@ -276,7 +276,7 @@ std::string NFIQ2UI::padNA( const Flags& flags )
 
     for( auto i = 0; i < padding; i++ )
     {
-      ret = ret + ",'NA'";
+      ret = ret + ",NA";
     }
 
     // Just Quality Attributes
@@ -289,7 +289,7 @@ std::string NFIQ2UI::padNA( const Flags& flags )
 
     for( auto i = 0; i < padding; i++ )
     {
-      ret = ret + ",'NA'";
+      ret = ret + ",NA";
     }
 
     // Just Speed Attributes

--- a/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_utils.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_utils.cpp
@@ -260,58 +260,6 @@ unsigned int NFIQ2UI::checkThreads( const std::string& optarg )
   }
 }
 
-// Pads the given score with NAs to maintain equal length of each produced score
-std::string NFIQ2UI::padNA( const Flags& flags )
-{
-  int ROW_SIZE = 6;
-
-  std::string ret{};
-
-  // Both Quality and Speed attributes
-  // Size: 85
-  if( flags.verbose && flags.speed )
-  {
-    int TOTAL_SIZE = 85;
-    int padding = TOTAL_SIZE - ROW_SIZE;
-
-    for( auto i = 0; i < padding; i++ )
-    {
-      ret = ret + ",NA";
-    }
-
-    // Just Quality Attributes
-    // Size: 75
-  }
-  else if( flags.verbose )
-  {
-    int TOTAL_SIZE = 75;
-    int padding = TOTAL_SIZE - ROW_SIZE;
-
-    for( auto i = 0; i < padding; i++ )
-    {
-      ret = ret + ",NA";
-    }
-
-    // Just Speed Attributes
-    // Size: 16
-  }
-  else if( flags.speed )
-  {
-    int TOTAL_SIZE = 16;
-    int padding = TOTAL_SIZE - ROW_SIZE;
-
-    for( auto i = 0; i < padding; i++ )
-    {
-      ret = ret + ",NA";
-    }
-
-    // No additional attributes
-    // Size: 6 - padding not required
-  }
-
-  return ret;
-}
-
 // Usage of NFIQ2 tool
 void NFIQ2UI::printUsage()
 {

--- a/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_utils.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_utils.cpp
@@ -132,7 +132,7 @@ NFIQ2UI::getFileContent( const std::string& filename )
   }
   catch( const std::ifstream::failure& e )
   {
-    std::cerr << "ERROR: COULD NOT GET LINE FROM BATCH FILE. MESSAGE: "
+    std::cerr << "'Error: Could not get line from Batch file'"
               << e.what() << "\n";
   }
   batchOpen.close();

--- a/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_utils.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_utils.cpp
@@ -10,6 +10,7 @@
 
 #include <array>
 #include <iostream>
+#include <sstream>
 #include <string>
 #include <tuple>
 #include <vector>
@@ -132,8 +133,8 @@ NFIQ2UI::getFileContent( const std::string& filename )
   }
   catch( const std::ifstream::failure& e )
   {
-    std::cerr << "'Error: Could not get line from Batch file'"
-              << e.what() << "\n";
+    std::cerr << "'Error: Could not get line from Batch file'" << e.what()
+              << "\n";
   }
   batchOpen.close();
   std::tuple<std::vector<std::string>, int> ret( content, count );
@@ -257,6 +258,58 @@ unsigned int NFIQ2UI::checkThreads( const std::string& optarg )
   {
     return input;
   }
+}
+
+// Pads the given score with NAs to maintain equal length of each produced score
+std::string NFIQ2UI::padNA( const Flags& flags )
+{
+  int ROW_SIZE = 6;
+
+  std::string ret{};
+
+  // Both Quality and Speed attributes
+  // Size: 85
+  if( flags.verbose && flags.speed )
+  {
+    int TOTAL_SIZE = 85;
+    int padding = TOTAL_SIZE - ROW_SIZE;
+
+    for( auto i = 0; i < padding; i++ )
+    {
+      ret = ret + ",'NA'";
+    }
+
+    // Just Quality Attributes
+    // Size: 75
+  }
+  else if( flags.verbose )
+  {
+    int TOTAL_SIZE = 75;
+    int padding = TOTAL_SIZE - ROW_SIZE;
+
+    for( auto i = 0; i < padding; i++ )
+    {
+      ret = ret + ",'NA'";
+    }
+
+    // Just Speed Attributes
+    // Size: 16
+  }
+  else if( flags.speed )
+  {
+    int TOTAL_SIZE = 16;
+    int padding = TOTAL_SIZE - ROW_SIZE;
+
+    for( auto i = 0; i < padding; i++ )
+    {
+      ret = ret + ",'NA'";
+    }
+
+    // No additional attributes
+    // Size: 6 - padding not required
+  }
+
+  return ret;
 }
 
 // Usage of NFIQ2 tool

--- a/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_utils.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_utils.cpp
@@ -302,7 +302,7 @@ std::string NFIQ2UI::padNA( const Flags& flags )
 
     for( auto i = 0; i < padding; i++ )
     {
-      ret = ret + ",'NA'";
+      ret = ret + ",NA";
     }
 
     // No additional attributes


### PR DESCRIPTION
In order to maintain a consistent representation of missing values in the CSV output, any blank entries have been replaced with NA. This is in the hopes that any data processing software analyzing NFIQ2 CSV output will have an easier time handling missing values. 