### PR TITLE
Added Actionable Quality

### DIFF
--- a/NFIQ2/NFIQ2Algorithm/include/NFIQ2Algorithm.h
+++ b/NFIQ2/NFIQ2Algorithm/include/NFIQ2Algorithm.h
@@ -55,7 +55,16 @@ namespace NFIQ
         std::list<NFIQ::QualityFeatureData>& qualityFeatureData,
         bool bOutputSpeed,
         std::list<NFIQ::QualityFeatureSpeed>& qualityFeatureSpeed );
-
+      
+      /**
+       * @brief
+       * Obtain all actionable quality feedback identifiers.
+       *
+       * @return
+       * Vector of strings containing all actionable quality feedback identifiers.
+       */
+      static std::vector<std::string> getAllActionableIdentifiers();
+      
       /**
        * @brief
        * Obtain all quality feature IDs from quality modules.

--- a/NFIQ2/NFIQ2Algorithm/include/NFIQ2Algorithm.h
+++ b/NFIQ2/NFIQ2Algorithm/include/NFIQ2Algorithm.h
@@ -55,7 +55,7 @@ namespace NFIQ
         std::list<NFIQ::QualityFeatureData>& qualityFeatureData,
         bool bOutputSpeed,
         std::list<NFIQ::QualityFeatureSpeed>& qualityFeatureSpeed );
-      
+
       /**
        * @brief
        * Obtain all actionable quality feedback identifiers.
@@ -64,7 +64,7 @@ namespace NFIQ
        * Vector of strings containing all actionable quality feedback identifiers.
        */
       static std::vector<std::string> getAllActionableIdentifiers();
-      
+
       /**
        * @brief
        * Obtain all quality feature IDs from quality modules.

--- a/NFIQ2/NFIQ2Algorithm/include/tool/nfiq2_ui_log.h
+++ b/NFIQ2/NFIQ2Algorithm/include/tool/nfiq2_ui_log.h
@@ -75,7 +75,8 @@ namespace NFIQ2UI
                        unsigned int score, const std::string& errmsg,
                        const bool quantized, const bool resampled,
                        const std::list<NFIQ::QualityFeatureData>& featureVector,
-                       const std::list<NFIQ::QualityFeatureSpeed>& featureTimings ) const;
+                       const std::list<NFIQ::QualityFeatureSpeed>& featureTimings,
+                       const std::list<NFIQ::ActionableQualityFeedback>& actionableQuality ) const;
 
       /**
        *  @brief
@@ -172,6 +173,8 @@ namespace NFIQ2UI
       bool debug;
       /** Value of speed flag */
       bool speed;
+      /** Value of the actionable flag */
+      bool actionable;
       /** Used if a specified file will be the output stream */
       std::ofstream logFile{};
   };

--- a/NFIQ2/NFIQ2Algorithm/include/tool/nfiq2_ui_types.h
+++ b/NFIQ2/NFIQ2Algorithm/include/tool/nfiq2_ui_types.h
@@ -63,6 +63,8 @@ namespace NFIQ2UI
     bool recursion{false};
     /** Used if an alternative Machine Learning model is to be used */
     std::string model{""};
+    /** Actionable Flag value */
+    bool actionable{false};
     /** Number of threads used for multi-threading */
     unsigned int numthreads{1};
   };
@@ -131,6 +133,8 @@ namespace NFIQ2UI
     std::list<NFIQ::QualityFeatureData> featureVector;
     /** List of Feature Score Timings */
     std::list<NFIQ::QualityFeatureSpeed> featureTimings;
+    /** List of Actionable Quality Scores */
+    std::list<NFIQ::ActionableQualityFeedback> actionableQuality;
     /** Overall Quality Score for an Image */
     unsigned int qualityScore;
   };

--- a/NFIQ2/NFIQ2Algorithm/src/NFIQ2Algorithm.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/NFIQ2Algorithm.cpp
@@ -35,6 +35,11 @@ NFIQ::NFIQ2Algorithm::computeQualityScore(
              qualityFeatureSpeed ) );
 }
 
+std::vector<std::string> NFIQ::NFIQ2Algorithm::getAllActionableIdentifiers() 
+{
+  return NFIQ::NFIQ2Algorithm::Impl::getAllActionableIdentifiers();
+}
+
 std::vector<std::string> NFIQ::NFIQ2Algorithm::getAllQualityFeatureIDs()
 {
   return NFIQ::NFIQ2Algorithm::Impl::getAllQualityFeatureIDs();

--- a/NFIQ2/NFIQ2Algorithm/src/NFIQ2Algorithm.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/NFIQ2Algorithm.cpp
@@ -35,7 +35,7 @@ NFIQ::NFIQ2Algorithm::computeQualityScore(
              qualityFeatureSpeed ) );
 }
 
-std::vector<std::string> NFIQ::NFIQ2Algorithm::getAllActionableIdentifiers() 
+std::vector<std::string> NFIQ::NFIQ2Algorithm::getAllActionableIdentifiers()
 {
   return NFIQ::NFIQ2Algorithm::Impl::getAllActionableIdentifiers();
 }

--- a/NFIQ2/NFIQ2Algorithm/src/NFIQ2AlgorithmImpl.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/NFIQ2AlgorithmImpl.cpp
@@ -427,6 +427,17 @@ unsigned int NFIQ2Algorithm::Impl::computeQualityScore(
   return QUALITY_SCORE_NOT_AVAILABLE;
 }
 
+std::vector<std::string> NFIQ2Algorithm::Impl::getAllActionableIdentifiers() {
+  static const std::vector<std::string> actionableIdentifiers{
+    NFIQ::ActionableQualityFeedbackIdentifier_EmptyImageOrContrastTooLow,
+    NFIQ::ActionableQualityFeedbackIdentifier_UniformImage,
+    NFIQ::ActionableQualityFeedbackIdentifier_FingerprintImageWithMinutiae,
+    ActionableQualityFeedbackIdentifier_SufficientFingerprintForeground
+  };
+
+  return actionableIdentifiers;
+}
+
 std::vector<std::string> NFIQ2Algorithm::Impl::getAllQualityFeatureIDs()
 {
   std::list<std::list<std::string>> lol

--- a/NFIQ2/NFIQ2Algorithm/src/NFIQ2AlgorithmImpl.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/NFIQ2AlgorithmImpl.cpp
@@ -427,8 +427,10 @@ unsigned int NFIQ2Algorithm::Impl::computeQualityScore(
   return QUALITY_SCORE_NOT_AVAILABLE;
 }
 
-std::vector<std::string> NFIQ2Algorithm::Impl::getAllActionableIdentifiers() {
-  static const std::vector<std::string> actionableIdentifiers{
+std::vector<std::string> NFIQ2Algorithm::Impl::getAllActionableIdentifiers()
+{
+  static const std::vector<std::string> actionableIdentifiers
+  {
     NFIQ::ActionableQualityFeedbackIdentifier_EmptyImageOrContrastTooLow,
     NFIQ::ActionableQualityFeedbackIdentifier_UniformImage,
     NFIQ::ActionableQualityFeedbackIdentifier_FingerprintImageWithMinutiae,

--- a/NFIQ2/NFIQ2Algorithm/src/NFIQ2AlgorithmImpl.h
+++ b/NFIQ2/NFIQ2Algorithm/src/NFIQ2AlgorithmImpl.h
@@ -73,7 +73,7 @@ namespace NFIQ
        * Vector of strings containing all actionable quality feedback identifiers.
        */
       static std::vector<std::string> getAllActionableIdentifiers();
-      
+
       /**
        * @brief
        * Obtain all quality feature IDs from quality modules.

--- a/NFIQ2/NFIQ2Algorithm/src/NFIQ2AlgorithmImpl.h
+++ b/NFIQ2/NFIQ2Algorithm/src/NFIQ2AlgorithmImpl.h
@@ -67,6 +67,15 @@ namespace NFIQ
 
       /**
        * @brief
+       * Obtain all actionable quality feedback identifiers.
+       *
+       * @return
+       * Vector of strings containing all actionable quality feedback identifiers.
+       */
+      static std::vector<std::string> getAllActionableIdentifiers();
+      
+      /**
+       * @brief
        * Obtain all quality feature IDs from quality modules.
        *
        * @return

--- a/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_log.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_log.cpp
@@ -68,7 +68,7 @@ void NFIQ2UI::Log::printScore(
         *( this->out ) << ",";
       }
 
-      *( this->out ) << std::setprecision( 5 ) << i->actionableQualityValue; // need to check this
+      *( this->out ) << std::setprecision( 5 ) << i->actionableQualityValue;
     }
     if( this->verbose || this->speed )
     {

--- a/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_log.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_log.cpp
@@ -59,7 +59,7 @@ void NFIQ2UI::Log::printScore(
   }
 
   // Print out actionable first
-  if ( this->actionable )
+  if( this->actionable )
   {
     for( auto i = actionableQuality.begin(); i != actionableQuality.end(); ++i )
     {
@@ -122,7 +122,8 @@ std::string NFIQ2UI::Log::padNA() const
   static const unsigned int MIN_NUM_COLS{6};
   unsigned int numCols{MIN_NUM_COLS};
 
-  if( this->actionable ) {
+  if( this->actionable )
+  {
     numCols += 4;
   }
 

--- a/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_log.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_log.cpp
@@ -24,6 +24,7 @@ NFIQ2UI::Log::Log( const Flags& flags, const std::string& path )
   this->verbose = flags.verbose;
   this->debug = flags.debug;
   this->speed = flags.speed;
+  this->actionable = flags.actionable;
 
   if( path.empty() )
   {
@@ -46,14 +47,33 @@ void NFIQ2UI::Log::printScore(
   const std::string& name, uint8_t fingerCode, unsigned int score,
   const std::string& errmsg, const bool quantized, const bool resampled,
   const std::list<NFIQ::QualityFeatureData>& featureVector,
-  const std::list<NFIQ::QualityFeatureSpeed>& featureTimings ) const
+  const std::list<NFIQ::QualityFeatureSpeed>& featureTimings,
+  const std::list<NFIQ::ActionableQualityFeedback>& actionableQuality ) const
 {
 
   *( this->out ) << name << "," << std::to_string( fingerCode ) << "," << score
                  << "," << errmsg << "," << quantized << "," << resampled;
-  if( this->verbose || this->speed )
+  if( this->actionable || this->verbose || this->speed )
   {
     *( this->out ) << ",";
+  }
+
+  // Print out actionable first
+  if ( this->actionable )
+  {
+    for( auto i = actionableQuality.begin(); i != actionableQuality.end(); ++i )
+    {
+      if( i != actionableQuality.begin() )
+      {
+        *( this->out ) << ",";
+      }
+
+      *( this->out ) << std::setprecision( 5 ) << i->actionableQualityValue; // need to check this
+    }
+    if( this->verbose || this->speed )
+    {
+      *( this->out ) << ",";
+    }
   }
 
   if( this->verbose )
@@ -101,6 +121,10 @@ std::string NFIQ2UI::Log::padNA() const
 
   static const unsigned int MIN_NUM_COLS{6};
   unsigned int numCols{MIN_NUM_COLS};
+
+  if( this->actionable ) {
+    numCols += 4;
+  }
 
   if( this->verbose )
   {
@@ -165,9 +189,28 @@ void NFIQ2UI::Log::printCSVHeader() const
                  << "Quantized"
                  << ","
                  << "Resampled";
-  if( this->verbose || this->speed )
+  if( this->actionable || this->verbose || this->speed )
   {
     *( this->out ) << ",";
+  }
+
+  if( this->actionable )
+  {
+    std::vector<std::string> vHeaders = NFIQ::NFIQ2Algorithm::getAllActionableIdentifiers();
+
+    for( auto it = vHeaders.begin(); it != vHeaders.end(); ++it )
+    {
+      if( it != vHeaders.begin() )
+      {
+        *( this->out ) << ',';
+      }
+      *( this->out ) << *it;
+    }
+
+    if( this->verbose || this->speed )
+    {
+      *( this->out ) << ',';
+    }
   }
 
   if( this->verbose )

--- a/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_refresh.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_refresh.cpp
@@ -729,7 +729,7 @@ void NFIQ2UI::procSingle( NFIQ2UI::Arguments arguments,
   // If there is only one image being processed
   if( arguments.vecSingle.size() == 1 && arguments.vecDirs.size() == 0 &&
       arguments.vecBatch.size() == 0 && !arguments.flags.verbose &&
-      !arguments.flags.speed && !arguments.flags.actionable)
+      !arguments.flags.speed && !arguments.flags.actionable )
   {
 
     const auto images = NFIQ2UI::getImages( arguments.vecSingle[0], logger );
@@ -762,7 +762,7 @@ void NFIQ2UI::printHeader( NFIQ2UI::Arguments arguments,
                            std::shared_ptr<NFIQ2UI::Log> logger )
 {
   if( ( arguments.vecSingle.size() == 1 &&
-        ( arguments.flags.verbose || arguments.flags.speed || arguments.flags.actionable) ) ||
+        ( arguments.flags.verbose || arguments.flags.speed || arguments.flags.actionable ) ) ||
       ( arguments.vecSingle.size() == 1 &&
         NFIQ2UI::isAN2K( arguments.vecSingle[0] ) ) ||
       arguments.vecSingle.size() > 1 || arguments.vecDirs.size() != 0 ||

--- a/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_refresh.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_refresh.cpp
@@ -228,7 +228,7 @@ void NFIQ2UI::executeSingle( std::shared_ptr<BE::Image::Image> img,
     // Print full score with optional headers
     logger->printScore( name, fingerPosition, corereturn.qualityScore, warning,
                         quantized, resampled, corereturn.featureVector,
-                        corereturn.featureTimings );
+                        corereturn.featureTimings, corereturn.actionableQuality );
   }
 }
 
@@ -261,7 +261,7 @@ NFIQ2UI::coreCompute( const NFIQ::FingerprintImageData& wrappedImage,
     model->computeQualityScore( wrappedImage, true, actionableQuality, true,
                                 featureVector, true, featureTimings );
 
-  const CoreReturn corereturn{featureVector, featureTimings, qualityScore};
+  const CoreReturn corereturn{featureVector, featureTimings, actionableQuality, qualityScore};
   return corereturn;
 }
 
@@ -640,7 +640,7 @@ NFIQ2UI::Arguments NFIQ2UI::processArguments( int argc, char** argv )
 
   std::string output{};
 
-  static const char options[] {"i:f:o:j:vqdFrm:"};
+  static const char options[] {"i:f:o:j:vqdFrm:a"};
   int c{};
 
   auto vecPush = [&]( const std::string & m )
@@ -693,6 +693,9 @@ NFIQ2UI::Arguments NFIQ2UI::processArguments( int argc, char** argv )
       case 'm':
         flags.model = optarg;
         break;
+      case 'a':
+        flags.actionable = true;
+        break;
       case '?':
         NFIQ2UI::printUsage();
         throw NFIQ2UI::UndefinedFlagError( "Undefined Flag Used" );
@@ -726,7 +729,7 @@ void NFIQ2UI::procSingle( NFIQ2UI::Arguments arguments,
   // If there is only one image being processed
   if( arguments.vecSingle.size() == 1 && arguments.vecDirs.size() == 0 &&
       arguments.vecBatch.size() == 0 && !arguments.flags.verbose &&
-      !arguments.flags.speed )
+      !arguments.flags.speed && !arguments.flags.actionable)
   {
 
     const auto images = NFIQ2UI::getImages( arguments.vecSingle[0], logger );
@@ -759,7 +762,7 @@ void NFIQ2UI::printHeader( NFIQ2UI::Arguments arguments,
                            std::shared_ptr<NFIQ2UI::Log> logger )
 {
   if( ( arguments.vecSingle.size() == 1 &&
-        ( arguments.flags.verbose || arguments.flags.speed ) ) ||
+        ( arguments.flags.verbose || arguments.flags.speed || arguments.flags.actionable) ) ||
       ( arguments.vecSingle.size() == 1 &&
         NFIQ2UI::isAN2K( arguments.vecSingle[0] ) ) ||
       arguments.vecSingle.size() > 1 || arguments.vecDirs.size() != 0 ||


### PR DESCRIPTION
This addresses issue #86 
Actionable Quality was missing since the command line replacement for NFIQ 2.0. This PR adds this information back into the CSV output. They get printed before quality features, but after preliminary headers like filename, score, errors, etc.

Enable Actionable quality by passing the -a flag into the CLI

Tested using CTS image set for the three platforms. Scores are consistent. 