### PR TITLE
Removing '0x' from model hash

### DIFF
--- a/NFIQ2/NFIQ2Algorithm/src/prediction/RandomForestML.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/prediction/RandomForestML.cpp
@@ -27,7 +27,7 @@ std::string RandomForestML::calculateHashString( const std::string& s )
   // calculate and compare the hash
   digestpp::md5 hasher;
   std::stringstream ss;
-  ss << "0x" << std::hex << hasher.absorb( ( const char* )s.c_str(), s.length() ).hexdigest();
+  ss << std::hex << hasher.absorb( ( const char* )s.c_str(), s.length() ).hexdigest();
   return ss.str();
 }
 

--- a/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_refresh.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_refresh.cpp
@@ -820,7 +820,7 @@ int main( int argc, char** argv )
 
   std::shared_ptr<NFIQ::NFIQ2Algorithm> model =
     std::make_shared<NFIQ::NFIQ2Algorithm>(
-      "nfiq2rf.yaml", "0xccd75820b48c19f1645ef5e9c481c592" );
+      "nfiq2rf.yaml", "ccd75820b48c19f1645ef5e9c481c592" );
 
   timeInit = timerInit.endTimerAndGetElapsedTime();
 

--- a/NFIQ2/NFIQ2Api/nfiq2api.cpp
+++ b/NFIQ2/NFIQ2Api/nfiq2api.cpp
@@ -91,7 +91,7 @@ extern "C" {
 #       ifdef EMBED_RANDOMFOREST_PARAMETERS
         g_nfiq2 = std::unique_ptr<NFIQ::NFIQ2Algorithm>( new NFIQ::NFIQ2Algorithm() );
 #       else
-        g_nfiq2 = std::unique_ptr<NFIQ::NFIQ2Algorithm>( new NFIQ::NFIQ2Algorithm( GetYamlFilePath(), "0xccd75820b48c19f1645ef5e9c481c592" ) );
+        g_nfiq2 = std::unique_ptr<NFIQ::NFIQ2Algorithm>( new NFIQ::NFIQ2Algorithm( GetYamlFilePath(), "ccd75820b48c19f1645ef5e9c481c592" ) );
 #       endif
         return g_nfiq2->getParameterHash().c_str();
       }

--- a/NFIQ2/nfiq2rf.txt
+++ b/NFIQ2/nfiq2rf.txt
@@ -1,3 +1,3 @@
 Owner:    NIST/ISO
 Training: NFIQ2 Version 1.0
-Hash:     0xccd75820b48c19f1645ef5e9c481c592
+Hash:     ccd75820b48c19f1645ef5e9c481c592


### PR DESCRIPTION
Addresses Issue #49 

Removes the '0x' portion from the model hash. 