### PR TITLE
Fix for Images Returning Error Codes

### DIFF
--- a/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_refresh.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_refresh.cpp
@@ -216,6 +216,13 @@ void NFIQ2UI::executeSingle( std::shared_ptr<BE::Image::Image> img,
   const NFIQ2UI::CoreReturn corereturn =
     NFIQ2UI::coreCompute( wrappedImage, model );
 
+  if( corereturn.qualityScore > 100 )
+  {
+    logger->printError( name, fingerPosition, corereturn.qualityScore,  "NFIQ2 computeQualityScore returned an error code",
+                        quantized, resampled );
+    return;
+  }
+
   // Print score:
   if( singleImage )
   {


### PR DESCRIPTION
Some fingerprint images are unable to be processed correctly through the NFIQ2 core algorithm but pass the resolution and color depth requirements. In this case, the NFIQ2 algorithm returns an error code as the NFIQ2 final quality score (usually 255). This added check confirms that images that make it past the NFIQ2 algorithm will contain a valid quality score. 