### PR TITLE
Fix for Windows/Unix CSV Output Inconsistencies

### DIFF
--- a/NFIQ2/NFIQ2Algorithm/include/tool/nfiq2_ui_utils.h
+++ b/NFIQ2/NFIQ2Algorithm/include/tool/nfiq2_ui_utils.h
@@ -15,6 +15,7 @@
 #include <string>
 #include <tuple>
 #include <vector>
+#include <cmath>
 
 #include <be_io_utility.h>
 
@@ -149,6 +150,8 @@ namespace NFIQ2UI
    *    The number of threads to be used by Multi-threaded operations.
    */
   unsigned int checkThreads( const std::string& optarg );
+
+  std::string formatDouble(const double &d, const int precision);
 
   /**
    *  @brief

--- a/NFIQ2/NFIQ2Algorithm/include/tool/nfiq2_ui_utils.h
+++ b/NFIQ2/NFIQ2Algorithm/include/tool/nfiq2_ui_utils.h
@@ -151,7 +151,7 @@ namespace NFIQ2UI
    */
   unsigned int checkThreads( const std::string& optarg );
 
-  std::string formatDouble(const double &d, const int precision);
+  std::string formatDouble( const double& d, const int precision );
 
   /**
    *  @brief

--- a/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_log.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_log.cpp
@@ -87,7 +87,7 @@ void NFIQ2UI::Log::printScore(
         *( this->out ) << ",";
       }
 
-      *( this->out ) << NFIQ2UI::formatDouble(i->featureDataDouble, 5);
+      *( this->out ) << NFIQ2UI::formatDouble( i->featureDataDouble, 5 );
     }
     if( this->speed )
     {

--- a/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_log.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_log.cpp
@@ -17,6 +17,7 @@
 #include "nfiq2_ui_exception.h"
 #include "nfiq2_ui_log.h"
 #include "nfiq2_ui_types.h"
+#include "nfiq2_ui_utils.h"
 
 // Responsible for all print outputs
 NFIQ2UI::Log::Log( const Flags& flags, const std::string& path )
@@ -86,7 +87,7 @@ void NFIQ2UI::Log::printScore(
         *( this->out ) << ",";
       }
 
-      *( this->out ) << std::setprecision( 5 ) << i->featureDataDouble;
+      *( this->out ) << NFIQ2UI::formatDouble(i->featureDataDouble, 5);
     }
     if( this->speed )
     {

--- a/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_log.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_log.cpp
@@ -69,7 +69,7 @@ void NFIQ2UI::Log::printScore(
         *( this->out ) << ",";
       }
 
-      *( this->out ) << std::setprecision( 5 ) << i->actionableQualityValue;
+      *( this->out ) << NFIQ2UI::formatDouble( i->actionableQualityValue, 5 );
     }
     if( this->verbose || this->speed )
     {

--- a/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_utils.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_utils.cpp
@@ -269,6 +269,10 @@ std::string NFIQ2UI::formatDouble( const double& d, const int precision )
     return s;
   }
 
+  if (static_cast<long>(d) == d) {
+    return std::to_string(static_cast<long>(d));
+  }
+
   const std::string::size_type decimalPosition = s.find( '.' );
 
   if( decimalPosition == std::string::npos ||

--- a/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_utils.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_utils.cpp
@@ -262,6 +262,11 @@ unsigned int NFIQ2UI::checkThreads( const std::string& optarg )
 
 std::string NFIQ2UI::formatDouble( const double& d, const int precision )
 {
+
+  if (d == 0) {
+    return "0";
+  }
+
   const std::string s = std::to_string( d );
 
   if( !std::isnormal( d ) )

--- a/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_utils.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_utils.cpp
@@ -262,14 +262,9 @@ unsigned int NFIQ2UI::checkThreads( const std::string& optarg )
 
 std::string NFIQ2UI::formatDouble( const double& d, const int precision )
 {
-
-  if (d == 0) {
-    return "0";
-  }
-
   const std::string s = std::to_string( d );
 
-  if( !std::isnormal( d ) )
+  if( !std::isfinite( d ) )
   {
     return s;
   }

--- a/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_utils.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_utils.cpp
@@ -260,24 +260,30 @@ unsigned int NFIQ2UI::checkThreads( const std::string& optarg )
   }
 }
 
-std::string NFIQ2UI::formatDouble(const double &d, const int precision) {
-  const std::string s = std::to_string(d);
+std::string NFIQ2UI::formatDouble( const double& d, const int precision )
+{
+  const std::string s = std::to_string( d );
 
-  if (!std::isnormal(d)) {
+  if( !std::isnormal( d ) )
+  {
     return s;
   }
 
-  const std::string::size_type decimalPosition = s.find('.');
+  const std::string::size_type decimalPosition = s.find( '.' );
 
-  if (decimalPosition == std::string::npos ||
-      precision >= (s.length() - decimalPosition - 1)) {
+  if( decimalPosition == std::string::npos ||
+      precision >= ( s.length() - decimalPosition - 1 ) )
+  {
     return s;
   }
 
-  if (precision <= 0) {
-    return s.substr(0, 7);
-  } else {
-    return s.substr(0, decimalPosition + precision + 1);
+  if( precision <= 0 )
+  {
+    return s.substr( 0, 7 );
+  }
+  else
+  {
+    return s.substr( 0, decimalPosition + precision + 1 );
   }
 }
 

--- a/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_utils.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_utils.cpp
@@ -260,6 +260,27 @@ unsigned int NFIQ2UI::checkThreads( const std::string& optarg )
   }
 }
 
+std::string NFIQ2UI::formatDouble(const double &d, const int precision) {
+  const std::string s = std::to_string(d);
+
+  if (!std::isnormal(d)) {
+    return s;
+  }
+
+  const std::string::size_type decimalPosition = s.find('.');
+
+  if (decimalPosition == std::string::npos ||
+      precision >= (s.length() - decimalPosition - 1)) {
+    return s;
+  }
+
+  if (precision <= 0) {
+    return s.substr(0, 7);
+  } else {
+    return s.substr(0, decimalPosition + precision + 1);
+  }
+}
+
 // Usage of NFIQ2 tool
 void NFIQ2UI::printUsage()
 {

--- a/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_utils.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_utils.cpp
@@ -262,6 +262,16 @@ unsigned int NFIQ2UI::checkThreads( const std::string& optarg )
 
 std::string NFIQ2UI::formatDouble( const double& d, const int precision )
 {
+  switch( std::fpclassify( d ) )
+  {
+    case FP_NORMAL:
+      break;
+    case FP_ZERO:
+      return "0";
+    default:
+      return std::to_string( d );
+  }
+
   const std::string s = std::to_string( d );
 
   if( !std::isfinite( d ) )
@@ -269,8 +279,9 @@ std::string NFIQ2UI::formatDouble( const double& d, const int precision )
     return s;
   }
 
-  if (static_cast<long>(d) == d) {
-    return std::to_string(static_cast<long>(d));
+  if( static_cast<long>( d ) == d )
+  {
+    return std::to_string( static_cast<long>( d ) );
   }
 
   const std::string::size_type decimalPosition = s.find( '.' );


### PR DESCRIPTION
Windows and Unix based OSs (Mac and Linux) were experiencing rounding discrepancies when using std::setprecision(5). When a double contains ".XXXX25" (X's could represent any digit), Unix systems would round down to ".XXXX2" while Windows would round up to ".XXXX3."

Multiple troubleshooting solutions were attempted: 
- Trying different compiler options
- Playing around with different values of set precision and manually rounding scores with roundf()
- Experimenting with fesetround()

This approach of converting the double to a string and truncating was the only solution that worked consistently across platforms. 