### PR TITLE
Enable CI Caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,8 +91,8 @@ script:
 cache:
   timeout: 1000
   directories:
-    - /Users/travis/build/usnistgov/NFIQ2/build/OpenCV-prefix
-    - /Users/travis/build/usnistgov/NFIQ2/build/fingerjetfxose
-    - /Users/travis/build/usnistgov/NFIQ2/build/biomdi
-    - /Users/travis/build/usnistgov/NFIQ2/build/libbiomeval-prefix
+    - $HOME/build/usnistgov/NFIQ2/build/OpenCV-prefix
+    - $HOME/build/usnistgov/NFIQ2/build/fingerjetfxose
+    - $HOME/build/usnistgov/NFIQ2/build/biomdi
+    - $HOME/build/usnistgov/NFIQ2/build/libbiomeval-prefix
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,9 +81,18 @@ before_install:
       fi
 
 before_script:
-    - mkdir build
+    - mkdir -p build
     - cd build
     - cmake -D32BITS=$BITS_32 -D64BITS=$BITS_64 -DCMAKE_BUILD_TYPE="$CONFIGURATION_TYPE" -DBUILD_NFIQ2_CLI=$BUILD_NFIQ2_CLI ..
 
 script:
     - cmake --build .
+
+cache:
+  timeout: 1000
+  directories:
+    - /Users/travis/build/usnistgov/NFIQ2/build/OpenCV-prefix
+    - /Users/travis/build/usnistgov/NFIQ2/build/fingerjetfxose
+    - /Users/travis/build/usnistgov/NFIQ2/build/biomdi
+    - /Users/travis/build/usnistgov/NFIQ2/build/libbiomeval-prefix
+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,4 @@
 version: 1.0.{build}
-branches:
-  only:
-  - iso_wg3
 image:
   - Visual Studio 2019
   - Visual Studio 2017

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,12 @@ platform:
 
 configuration: Release
 
-cache: c:\tools\vcpkg\installed\
+cache:
+  - c:\tools\vcpkg\installed -> NFIQ2/NFIQ2Algorithm/CMakeLists.txt
+  - c:\projects\nfiq2\build\Windows\OpenCV-prefix -> .gitmodules
+  - c:\projects\nfiq2\build\Windows\fingerjetfxose -> .gitmodules
+  - c:\projects\nfiq2\build\Windows\biomdi -> .gitmodules
+  - c:\projects\nfiq2\build\Windows\libbiomeval-prefix -> .gitmodules
 
 install:
 - cmd: git submodule update --init
@@ -45,11 +50,11 @@ install:
 
 before_build:
 - cmd: >-
-    md C:\projects\nfiq2\install
+    if not exist C:\projects\nfiq2\install md C:\projects\nfiq2\install
 
     cd C:\projects\nfiq2
 
-    md build\Windows
+    if not exist build\Windows md build\Windows
 
     cd build\Windows
 


### PR DESCRIPTION
Enable caching of git submodule builds. Seems to be working on Travis CI. Questionable on Appveyor, but doesn't break anything either.