### PR TITLE
Adding Model Object 

### DIFF
--- a/NFIQ2/NFIQ2Algorithm/CMakeLists.txt
+++ b/NFIQ2/NFIQ2Algorithm/CMakeLists.txt
@@ -54,6 +54,7 @@ set(PUBLIC_HEADERS
     "${CMAKE_CURRENT_SOURCE_DIR}/include/nfiq2/fingerprintimagedata.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/include/nfiq2/data.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/include/nfiq2/nfiqexception.hpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/include/nfiq2/modelinfo.hpp"
 )
 
 set(NFIQ2_STATIC_LIBRARY_TARGET "nfiq2-static-lib")

--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2/modelinfo.hpp
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2/modelinfo.hpp
@@ -8,63 +8,8 @@ namespace NFIQ {
 /** Model Class containing Model Information */
 class ModelInfo {
     public:
-
-    ModelInfo();
+	ModelInfo();
 	ModelInfo(std::unordered_map<std::string, std::string> modelInfoMap);
-
-	/**
-	 * @brief
-	 * Getter for private member modelName
-	 *
-	 * @return
-	 * Returns model name
-	 */
-	std::string getModelName() const;
-
-	/**
-	 * @brief
-	 * Getter for private member modelTrainer
-	 *
-	 * @return
-	 * Returns model trainer
-	 */
-	std::string getModelTrainer() const;
-
-	/**
-	 * @brief
-	 * Getter for private member modelDescription
-	 *
-	 * @return
-	 * Returns model description
-	 */
-	std::string getModelDescription() const;
-
-	/**
-	 * @brief
-	 * Getter for private member modelVersion
-	 *
-	 * @return
-	 * Returns model version
-	 */
-	std::string getModelVersion() const;
-
-	/**
-	 * @brief
-	 * Getter for private member modelPath
-	 *
-	 * @return
-	 * Returns model path
-	 */
-	std::string getModelPath() const;
-
-	/**
-	 * @brief
-	 * Getter for private member modelHash
-	 *
-	 * @return
-	 * Returns model hash
-	 */
-	std::string getModelHash() const;
 
 	static const std::string ModelInfoKeyName;
 	static const std::string ModelInfoKeyTrainer;
@@ -73,7 +18,6 @@ class ModelInfo {
 	static const std::string ModelInfoKeyPath;
 	static const std::string ModelInfoKeyHash;
 
-    private:
 	const std::string modelName;
 	const std::string modelTrainer;
 	const std::string modelDescription;

--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2/modelinfo.hpp
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2/modelinfo.hpp
@@ -1,5 +1,5 @@
-#ifndef NFIQ2_modelinfo_H_
-#define NFIQ2_modelinfo_H_
+#ifndef NFIQ2_MODELINFO_H_
+#define NFIQ2_MODELINFO_H_
 
 #include <string>
 #include <unordered_map>
@@ -8,16 +8,80 @@ namespace NFIQ {
 /** Model Class containing Model Information */
 class ModelInfo {
     public:
-	ModelInfo(const std::string modelInfoFilePath);
+	ModelInfo(const std::string& modelInfoFilePath);
 	~ModelInfo();
 
-	std::string getModelName();
-	std::string getModelTrainer();
-	std::string getModelDescription();
-	std::string getModelVersion();
-	std::string getModelPath();
-	std::string getModelHash();
+	/**
+	 * @brief
+	 * Computes the quality score from the input fingerprint image
+	 * data.
+	 *
+	 * @return
+	 * Achieved quality score
+	 */
+	std::string getModelName() const;
 
+	/**
+	 * @brief
+	 * Computes the quality score from the input fingerprint image
+	 * data.
+	 *
+	 * @return
+	 * Achieved quality score
+	 */
+	std::string getModelTrainer() const;
+
+	/**
+	 * @brief
+	 * Computes the quality score from the input fingerprint image
+	 * data.
+	 *
+	 * @return
+	 * Achieved quality score
+	 */
+	std::string getModelDescription() const;
+
+	/**
+	 * @brief
+	 * Computes the quality score from the input fingerprint image
+	 * data.
+	 *
+	 * @return
+	 * Achieved quality score
+	 */
+	std::string getModelVersion() const;
+
+	/**
+	 * @brief
+	 * Computes the quality score from the input fingerprint image
+	 * data.
+	 *
+	 * @return
+	 * Achieved quality score
+	 */
+	std::string getModelPath() const;
+
+	/**
+	 * @brief
+	 * Computes the quality score from the input fingerprint image
+	 * data.
+	 *
+	 * @return
+	 * Achieved quality score
+	 */
+	std::string getModelHash() const;
+
+	/**
+	 * @brief
+	 * Computes the quality score from the input fingerprint image
+	 * data.
+	 *
+	 * @return
+	 * Achieved quality score
+	 */
+	void setModelPath(const std::string& newPath);
+
+	/** Static strings for Model Info File Keys */
 	static const std::string ModelInfoKeyName;
 	static const std::string ModelInfoKeyTrainer;
 	static const std::string ModelInfoKeyDescription;
@@ -37,8 +101,16 @@ class ModelInfo {
 	ModelInfo &operator=(const ModelInfo &) = delete;
 };
 
+/**
+ * @brief
+ * Computes the quality score from the input fingerprint image
+ * data.
+ *
+ * @return
+ * Achieved quality score
+ */
 std::unordered_map<std::string, std::string> parseModelInfoFile(
-    const std::string modelInfoFilePath);
+    const std::string& modelInfoFilePath);
 
 } // namespace NFIQ
 

--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2/modelinfo.hpp
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2/modelinfo.hpp
@@ -8,8 +8,9 @@ namespace NFIQ {
 /** Model Class containing Model Information */
 class ModelInfo {
     public:
-	ModelInfo(const std::string &modelInfoFilePath);
-	~ModelInfo();
+
+    ModelInfo();
+	ModelInfo(std::unordered_map<std::string, std::string> modelInfoMap);
 
 	/**
 	 * @brief
@@ -65,17 +66,6 @@ class ModelInfo {
 	 */
 	std::string getModelHash() const;
 
-	/**
-	 * @brief
-	 * Setter for private member modelPath
-	 *
-	 * @param newPath
-	 * Updated path containing the model
-	 *
-	 */
-	void setModelPath(const std::string &newPath);
-
-	/** Static strings for Model Info File Keys */
 	static const std::string ModelInfoKeyName;
 	static const std::string ModelInfoKeyTrainer;
 	static const std::string ModelInfoKeyDescription;
@@ -84,15 +74,12 @@ class ModelInfo {
 	static const std::string ModelInfoKeyHash;
 
     private:
-	std::string modelName;
-	std::string modelTrainer;
-	std::string modelDescription;
-	std::string modelVersion;
-	std::string modelPath;
-	std::string modelHash;
-
-	ModelInfo(const ModelInfo &) = delete;
-	ModelInfo &operator=(const ModelInfo &) = delete;
+	const std::string modelName;
+	const std::string modelTrainer;
+	const std::string modelDescription;
+	const std::string modelVersion;
+	const std::string modelPath;
+	const std::string modelHash;
 };
 
 /**
@@ -104,9 +91,23 @@ class ModelInfo {
  * Path to model info text file
  *
  * @return
- * Map of Key/Value pairs
+ * Map of values parsed from model info text file
  */
 std::unordered_map<std::string, std::string> parseModelInfoFile(
+    const std::string &modelInfoFilePath);
+
+/**
+ * @brief
+ * Checks to see if the path to the model is relative to the model info file
+ * and not the cwd. Updates the path in the map accordingly.
+ *
+ * @param modelInfoMap
+ * A reference to the map containing information parsed from the info file.
+ *
+ * @param modelInfoFilePath
+ * Path to model info text file
+ */
+void checkModelPath(std::unordered_map<std::string, std::string> &modelInfoMap,
     const std::string &modelInfoFilePath);
 
 } // namespace NFIQ

--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2/modelinfo.hpp
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2/modelinfo.hpp
@@ -1,0 +1,45 @@
+#ifndef NFIQ2_modelinfo_H_
+#define NFIQ2_modelinfo_H_
+
+#include <string>
+#include <unordered_map>
+
+namespace NFIQ {
+/** Model Class containing Model Information */
+class ModelInfo {
+    public:
+	ModelInfo(const std::string modelInfoFilePath);
+	~ModelInfo();
+
+	std::string getModelName();
+	std::string getModelTrainer();
+	std::string getModelDescription();
+	std::string getModelVersion();
+	std::string getModelPath();
+	std::string getModelHash();
+
+	static const std::string ModelInfoKeyName;
+	static const std::string ModelInfoKeyTrainer;
+	static const std::string ModelInfoKeyDescription;
+	static const std::string ModelInfoKeyVersion;
+	static const std::string ModelInfoKeyPath;
+	static const std::string ModelInfoKeyHash;
+
+    private:
+	std::string modelName;
+	std::string modelTrainer;
+	std::string modelDescription;
+	std::string modelVersion;
+	std::string modelPath;
+	std::string modelHash;
+
+	ModelInfo(const ModelInfo &) = delete;
+	ModelInfo &operator=(const ModelInfo &) = delete;
+};
+
+std::unordered_map<std::string, std::string> parseModelInfoFile(
+    const std::string modelInfoFilePath);
+
+} // namespace NFIQ
+
+#endif

--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2/modelinfo.hpp
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2/modelinfo.hpp
@@ -2,14 +2,13 @@
 #define NFIQ2_MODELINFO_H_
 
 #include <string>
-#include <unordered_map>
 
 namespace NFIQ {
 /** Model Class containing Model Information */
 class ModelInfo {
     public:
 	ModelInfo();
-	ModelInfo(std::unordered_map<std::string, std::string> modelInfoMap);
+	ModelInfo(const std::string &modelInfoFilePath);
 
 	/**
 	 * @brief
@@ -80,34 +79,6 @@ class ModelInfo {
 	std::string modelPath;
 	std::string modelHash;
 };
-
-/**
- * @brief
- * Generates a Key/Value Pair structure containing information from the model
- * info text file
- *
- * @param modelInfoFilePath
- * Path to model info text file
- *
- * @return
- * Map of values parsed from model info text file
- */
-std::unordered_map<std::string, std::string> parseModelInfoFile(
-    const std::string &modelInfoFilePath);
-
-/**
- * @brief
- * Checks to see if the path to the model is relative to the model info file
- * and not the cwd. Updates the path in the map accordingly.
- *
- * @param modelInfoMap
- * A reference to the map containing information parsed from the info file.
- *
- * @param modelInfoFilePath
- * Path to model info text file
- */
-void checkModelPath(std::unordered_map<std::string, std::string> &modelInfoMap,
-    const std::string &modelInfoFilePath);
 
 } // namespace NFIQ
 

--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2/modelinfo.hpp
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2/modelinfo.hpp
@@ -11,6 +11,60 @@ class ModelInfo {
 	ModelInfo();
 	ModelInfo(std::unordered_map<std::string, std::string> modelInfoMap);
 
+	/**
+	 * @brief
+	 * Getter for private member modelName
+	 *
+	 * @return
+	 * Returns model name
+	 */
+	std::string getModelName() const;
+
+	/**
+	 * @brief
+	 * Getter for private member modelTrainer
+	 *
+	 * @return
+	 * Returns model trainer
+	 */
+	std::string getModelTrainer() const;
+
+	/**
+	 * @brief
+	 * Getter for private member modelDescription
+	 *
+	 * @return
+	 * Returns model description
+	 */
+	std::string getModelDescription() const;
+
+	/**
+	 * @brief
+	 * Getter for private member modelVersion
+	 *
+	 * @return
+	 * Returns model version
+	 */
+	std::string getModelVersion() const;
+
+	/**
+	 * @brief
+	 * Getter for private member modelPath
+	 *
+	 * @return
+	 * Returns model path
+	 */
+	std::string getModelPath() const;
+
+	/**
+	 * @brief
+	 * Getter for private member modelHash
+	 *
+	 * @return
+	 * Returns model hash
+	 */
+	std::string getModelHash() const;
+
 	static const std::string ModelInfoKeyName;
 	static const std::string ModelInfoKeyTrainer;
 	static const std::string ModelInfoKeyDescription;
@@ -18,12 +72,13 @@ class ModelInfo {
 	static const std::string ModelInfoKeyPath;
 	static const std::string ModelInfoKeyHash;
 
-	const std::string modelName;
-	const std::string modelTrainer;
-	const std::string modelDescription;
-	const std::string modelVersion;
-	const std::string modelPath;
-	const std::string modelHash;
+    private:
+	std::string modelName;
+	std::string modelTrainer;
+	std::string modelDescription;
+	std::string modelVersion;
+	std::string modelPath;
+	std::string modelHash;
 };
 
 /**

--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2/modelinfo.hpp
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2/modelinfo.hpp
@@ -8,78 +8,72 @@ namespace NFIQ {
 /** Model Class containing Model Information */
 class ModelInfo {
     public:
-	ModelInfo(const std::string& modelInfoFilePath);
+	ModelInfo(const std::string &modelInfoFilePath);
 	~ModelInfo();
 
 	/**
 	 * @brief
-	 * Computes the quality score from the input fingerprint image
-	 * data.
+	 * Getter for private member modelName
 	 *
 	 * @return
-	 * Achieved quality score
+	 * Returns model name
 	 */
 	std::string getModelName() const;
 
 	/**
 	 * @brief
-	 * Computes the quality score from the input fingerprint image
-	 * data.
+	 * Getter for private member modelTrainer
 	 *
 	 * @return
-	 * Achieved quality score
+	 * Returns model trainer
 	 */
 	std::string getModelTrainer() const;
 
 	/**
 	 * @brief
-	 * Computes the quality score from the input fingerprint image
-	 * data.
+	 * Getter for private member modelDescription
 	 *
 	 * @return
-	 * Achieved quality score
+	 * Returns model description
 	 */
 	std::string getModelDescription() const;
 
 	/**
 	 * @brief
-	 * Computes the quality score from the input fingerprint image
-	 * data.
+	 * Getter for private member modelVersion
 	 *
 	 * @return
-	 * Achieved quality score
+	 * Returns model version
 	 */
 	std::string getModelVersion() const;
 
 	/**
 	 * @brief
-	 * Computes the quality score from the input fingerprint image
-	 * data.
+	 * Getter for private member modelPath
 	 *
 	 * @return
-	 * Achieved quality score
+	 * Returns model path
 	 */
 	std::string getModelPath() const;
 
 	/**
 	 * @brief
-	 * Computes the quality score from the input fingerprint image
-	 * data.
+	 * Getter for private member modelHash
 	 *
 	 * @return
-	 * Achieved quality score
+	 * Returns model hash
 	 */
 	std::string getModelHash() const;
 
 	/**
 	 * @brief
-	 * Computes the quality score from the input fingerprint image
-	 * data.
+	 * Setter for private member modelPath
 	 *
-	 * @return
-	 * Achieved quality score
+	 * @param newPath
+	 * Updated path containing the model
+	 *
 	 */
-	void setModelPath(const std::string& newPath);
+	void setModelPath(const std::string &newPath);
 
 	/** Static strings for Model Info File Keys */
 	static const std::string ModelInfoKeyName;
@@ -103,14 +97,17 @@ class ModelInfo {
 
 /**
  * @brief
- * Computes the quality score from the input fingerprint image
- * data.
+ * Generates a Key/Value Pair structure containing information from the model
+ * info text file
+ *
+ * @param modelInfoFilePath
+ * Path to model info text file
  *
  * @return
- * Achieved quality score
+ * Map of Key/Value pairs
  */
 std::unordered_map<std::string, std::string> parseModelInfoFile(
-    const std::string& modelInfoFilePath);
+    const std::string &modelInfoFilePath);
 
 } // namespace NFIQ
 

--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2/nfiq2.hpp
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2/nfiq2.hpp
@@ -18,7 +18,7 @@ class NFIQ2Algorithm {
 #endif
 	NFIQ2Algorithm(
 	    const std::string &fileName, const std::string &fileHash);
-	NFIQ2Algorithm(std::shared_ptr<NFIQ::ModelInfo> modelInfoObj);
+	NFIQ2Algorithm(const NFIQ::ModelInfo &modelInfoObj);
 	~NFIQ2Algorithm();
 
 	/**

--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2/nfiq2.hpp
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2/nfiq2.hpp
@@ -3,6 +3,7 @@
 
 #include <nfiq2/fingerprintimagedata.hpp>
 #include <nfiq2/interfacedefinitions.hpp>
+#include <nfiq2/modelinfo.hpp>
 
 #include <list>
 #include <memory>
@@ -17,6 +18,7 @@ class NFIQ2Algorithm {
 #endif
 	NFIQ2Algorithm(
 	    const std::string &fileName, const std::string &fileHash);
+	NFIQ2Algorithm(std::shared_ptr<NFIQ::ModelInfo> modelInfoObj);
 	~NFIQ2Algorithm();
 
 	/**

--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2/tool/nfiq2_ui_exception.h
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2/tool/nfiq2_ui_exception.h
@@ -162,6 +162,26 @@ class FileNotFoundError : public Exception {
 	FileNotFoundError(const std::string &info);
 };
 
+/**
+ *  @brief
+ *  The machine learning model object could not be constructed correctly
+ */
+class ModelConstructionError : public Exception {
+    public:
+	/**
+	 *  Construct an ModelConstructionError object with
+	 *  the default information string.
+	 */
+	ModelConstructionError();
+
+	/**
+	 *  Construct an ModelConstructionError object with
+	 *  an information string appended to the
+	 *  default information string.
+	 */
+	ModelConstructionError(const std::string &info);
+};
+
 } // namespace NFIQ2UI
 
 #endif /* NFIQ2_UI_EXCEPTION_H_ */

--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2/tool/nfiq2_ui_refresh.h
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2/tool/nfiq2_ui_refresh.h
@@ -12,8 +12,8 @@
 #define NFIQ2_UI_REFRESH_H_
 
 #include <be_image_image.h>
-#include <nfiq2/nfiq2.hpp>
 #include <nfiq2/modelinfo.hpp>
+#include <nfiq2/nfiq2.hpp>
 
 #include "nfiq2_ui_log.h"
 #include "nfiq2_ui_types.h"
@@ -311,7 +311,7 @@ void printHeader(
  *  @return
  *      Returns a tuple containing the model path and the models hash.
  */
-std::shared_ptr<NFIQ::ModelInfo> parseModel(
+std::shared_ptr<NFIQ::ModelInfo> parseModelInfo(
     const NFIQ2UI::Arguments &arguments);
 
 } // namespace NFIQ2UI

--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2/tool/nfiq2_ui_refresh.h
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2/tool/nfiq2_ui_refresh.h
@@ -311,8 +311,7 @@ void printHeader(
  *  @return
  *      Returns a tuple containing the model path and the models hash.
  */
-std::shared_ptr<NFIQ::ModelInfo> parseModelInfo(
-    const NFIQ2UI::Arguments &arguments);
+NFIQ::ModelInfo parseModelInfo(const NFIQ2UI::Arguments &arguments);
 
 } // namespace NFIQ2UI
 

--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2/tool/nfiq2_ui_refresh.h
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2/tool/nfiq2_ui_refresh.h
@@ -13,6 +13,7 @@
 
 #include <be_image_image.h>
 #include <nfiq2/nfiq2.hpp>
+#include <nfiq2/modelinfo.hpp>
 
 #include "nfiq2_ui_log.h"
 #include "nfiq2_ui_types.h"
@@ -310,7 +311,7 @@ void printHeader(
  *  @return
  *      Returns a tuple containing the model path and the models hash.
  */
-std::tuple<std::string, std::string> parseModel(
+std::shared_ptr<NFIQ::ModelInfo> parseModel(
     const NFIQ2UI::Arguments &arguments);
 
 } // namespace NFIQ2UI

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/modelinfo.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/modelinfo.cpp
@@ -40,9 +40,13 @@ NFIQ::ModelInfo::ModelInfo(const std::string &modelInfoFilePath)
 			if (eqPos != 0 && eqPos < llen - 1) {
 				const std::string start = trimWhitespace(
 				    line.substr(0, eqPos));
+				if (start.empty())
+					continue;
 
 				const std::string end = trimWhitespace(
 				    line.substr(eqPos + 1, llen - 1));
+				if (end.empty())
+					continue;
 
 				if (start == ModelInfo::ModelInfoKeyName) {
 					this->modelName = end;

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/modelinfo.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/modelinfo.cpp
@@ -61,15 +61,17 @@ NFIQ::ModelInfo::ModelInfo(const std::string &modelInfoFilePath)
 					// Checks if the path to the model is
 					// relative to the model info file and
 					// not the cwd.
-					if ((end.front() != '/') &&
+					if (((end.length() > 1) &&
+						(end.front() == '/')) ||
 					    ((end.length() > 2) &&
-						(end.substr(0, 2) != "\\\\")) &&
+						(end.substr(0, 2) == "\\\\")) ||
 					    ((end.length() > 3) &&
-						(end.substr(1, 2) != ":\\")) &&
+						(end.substr(1, 2) == ":\\")) ||
 					    ((end.length() > 3) &&
-						(end.substr(1, 2) != ":/"))) {
-
-						std::size_t found =
+						(end.substr(1, 2) == ":/"))) {
+						this->modelPath = end;
+					} else {
+						const auto found =
 						    modelInfoFilePath
 							.find_last_of("/\\");
 
@@ -77,10 +79,7 @@ NFIQ::ModelInfo::ModelInfo(const std::string &modelInfoFilePath)
 						    modelInfoFilePath.substr(
 							0, found) +
 						    '/' + end;
-					} else {
-						this->modelPath = end;
 					}
-
 				} else if (start ==
 				    ModelInfo::ModelInfoKeyHash) {
 					this->modelHash = end;

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/modelinfo.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/modelinfo.cpp
@@ -27,6 +27,42 @@ NFIQ::ModelInfo::ModelInfo(
 {
 }
 
+std::string
+NFIQ::ModelInfo::getModelName() const
+{
+	return this->modelName;
+}
+
+std::string
+NFIQ::ModelInfo::getModelTrainer() const
+{
+	return this->modelTrainer;
+}
+
+std::string
+NFIQ::ModelInfo::getModelDescription() const
+{
+	return this->modelDescription;
+}
+
+std::string
+NFIQ::ModelInfo::getModelVersion() const
+{
+	return this->modelVersion;
+}
+
+std::string
+NFIQ::ModelInfo::getModelPath() const
+{
+	return this->modelPath;
+}
+
+std::string
+NFIQ::ModelInfo::getModelHash() const
+{
+	return this->modelHash;
+}
+
 std::unordered_map<std::string, std::string>
 NFIQ::parseModelInfoFile(const std::string &modelInfoFilePath)
 {

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/modelinfo.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/modelinfo.cpp
@@ -1,0 +1,114 @@
+#include <nfiq2/modelinfo.hpp>
+#include <nfiq2/nfiqexception.hpp>
+
+#include <fstream>
+#include <iostream>
+#include <string>
+
+const std::string NFIQ::ModelInfo::ModelInfoKeyName = "Name";
+const std::string NFIQ::ModelInfo::ModelInfoKeyTrainer = "Trainer";
+const std::string NFIQ::ModelInfo::ModelInfoKeyDescription = "Description";
+const std::string NFIQ::ModelInfo::ModelInfoKeyVersion = "Version";
+const std::string NFIQ::ModelInfo::ModelInfoKeyPath = "Path";
+const std::string NFIQ::ModelInfo::ModelInfoKeyHash = "Hash";
+
+NFIQ::ModelInfo::ModelInfo(const std::string modelInfoFilePath)
+{
+
+	std::unordered_map<std::string, std::string> modelInfoMap {};
+	try {
+		modelInfoMap = parseModelInfoFile(modelInfoFilePath);
+	} catch (...) {
+		throw NFIQ::NFIQException(1, "Model Class Failed Construction");
+	}
+
+	modelInfoMap[ModelInfoKeyName] = this->modelName;
+	modelInfoMap[ModelInfoKeyTrainer] = this->modelTrainer;
+	modelInfoMap[ModelInfoKeyDescription] = this->modelDescription;
+	modelInfoMap[ModelInfoKeyVersion] = this->modelVersion;
+	modelInfoMap[ModelInfoKeyPath] = this->modelPath;
+	modelInfoMap[ModelInfoKeyHash] = this->modelHash;
+}
+
+std::string
+NFIQ::ModelInfo::getModelName()
+{
+	return this->modelName;
+}
+
+std::string
+NFIQ::ModelInfo::getModelTrainer()
+{
+	return this->modelTrainer;
+}
+
+std::string
+NFIQ::ModelInfo::getModelDescription()
+{
+	return this->modelDescription;
+}
+
+std::string
+NFIQ::ModelInfo::getModelVersion()
+{
+	return this->modelVersion;
+}
+
+std::string
+NFIQ::ModelInfo::getModelPath()
+{
+	return this->modelPath;
+}
+
+std::string
+NFIQ::ModelInfo::getModelHash()
+{
+	return this->modelHash;
+}
+
+std::unordered_map<std::string, std::string>
+NFIQ::parseModelInfoFile(const std::string modelInfoFilePath)
+{
+	std::unordered_map<std::string, std::string> modelInfoMap {};
+
+	std::ifstream fp(modelInfoFilePath);
+	std::string line;
+
+	if (fp.is_open()) {
+
+		while (std::getline(fp, line)) {
+
+			const std::string start = line.substr(
+			    0, line.find('=') - 1);
+			const std::string end = line.substr(
+			    line.find('=') + 2, line.size() - 1);
+
+			modelInfoMap[start] = end;
+		}
+
+		fp.close();
+
+	} else {
+		throw NFIQ::NFIQException(
+		    26, "Failed to Read File: " + modelInfoFilePath);
+	}
+
+	if (modelInfoMap.find(ModelInfo::ModelInfoKeyName) ==
+		modelInfoMap.end() ||
+	    modelInfoMap.find(ModelInfo::ModelInfoKeyTrainer) ==
+		modelInfoMap.end() ||
+	    modelInfoMap.find(ModelInfo::ModelInfoKeyDescription) ==
+		modelInfoMap.end() ||
+	    modelInfoMap.find(ModelInfo::ModelInfoKeyVersion) ==
+		modelInfoMap.end() ||
+	    modelInfoMap.find(ModelInfo::ModelInfoKeyPath) ==
+		modelInfoMap.end() ||
+	    modelInfoMap.find(ModelInfo::ModelInfoKeyHash) ==
+		modelInfoMap.end()) {
+
+		throw NFIQ::NFIQException(
+		    1, "File missing required model info");
+	}
+
+	return modelInfoMap;
+}

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/modelinfo.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/modelinfo.cpp
@@ -6,6 +6,8 @@
 #include <iostream>
 #include <string>
 
+static std::string trimWhitespace(const std::string &s);
+
 const std::string NFIQ::ModelInfo::ModelInfoKeyName = "Name";
 const std::string NFIQ::ModelInfo::ModelInfoKeyTrainer = "Trainer";
 const std::string NFIQ::ModelInfo::ModelInfoKeyDescription = "Description";
@@ -36,15 +38,11 @@ NFIQ::ModelInfo::ModelInfo(const std::string &modelInfoFilePath)
 			const unsigned int llen = line.length();
 
 			if (eqPos != 0 && eqPos < llen - 1) {
-				const std::string start = isspace(
-							      line[eqPos - 1]) ?
-				    line.substr(0, eqPos - 1) :
-				    line.substr(0, eqPos);
+				const std::string start = trimWhitespace(
+				    line.substr(0, eqPos));
 
-				const std::string end = isspace(
-							    line[eqPos + 1]) ?
-				    line.substr(eqPos + 2, llen - 1) :
-				    line.substr(eqPos + 1, llen - 1);
+				const std::string end = trimWhitespace(
+				    line.substr(eqPos + 1, llen - 1));
 
 				if (start == ModelInfo::ModelInfoKeyName) {
 					this->modelName = end;
@@ -138,4 +136,24 @@ std::string
 NFIQ::ModelInfo::getModelHash() const
 {
 	return this->modelHash;
+}
+
+std::string
+trimWhitespace(const std::string &s)
+{
+	std::string output { s };
+
+	/* Erase from beginning until the first non-whitespace */
+	output.erase(output.begin(),
+	    std::find_if(output.begin(), output.end(),
+		[&](const char &c) -> bool { return (!std::isspace(c)); }));
+
+	/* Erase from the last non-whitespace to the end */
+	output.erase(
+	    std::find_if(output.rbegin(), output.rend(),
+		[&](const char &c) -> bool { return (!std::isspace(c)); })
+		.base(),
+	    output.end());
+
+	return output;
 }

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/modelinfo.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/modelinfo.cpp
@@ -12,7 +12,7 @@ const std::string NFIQ::ModelInfo::ModelInfoKeyVersion = "Version";
 const std::string NFIQ::ModelInfo::ModelInfoKeyPath = "Path";
 const std::string NFIQ::ModelInfo::ModelInfoKeyHash = "Hash";
 
-NFIQ::ModelInfo::ModelInfo() 
+NFIQ::ModelInfo::ModelInfo()
 {
 }
 
@@ -27,42 +27,6 @@ NFIQ::ModelInfo::ModelInfo(
 {
 }
 
-std::string
-NFIQ::ModelInfo::getModelName() const
-{
-	return this->modelName;
-}
-
-std::string
-NFIQ::ModelInfo::getModelTrainer() const
-{
-	return this->modelTrainer;
-}
-
-std::string
-NFIQ::ModelInfo::getModelDescription() const
-{
-	return this->modelDescription;
-}
-
-std::string
-NFIQ::ModelInfo::getModelVersion() const
-{
-	return this->modelVersion;
-}
-
-std::string
-NFIQ::ModelInfo::getModelPath() const
-{
-	return this->modelPath;
-}
-
-std::string
-NFIQ::ModelInfo::getModelHash() const
-{
-	return this->modelHash;
-}
-
 std::unordered_map<std::string, std::string>
 NFIQ::parseModelInfoFile(const std::string &modelInfoFilePath)
 {
@@ -72,8 +36,8 @@ NFIQ::parseModelInfoFile(const std::string &modelInfoFilePath)
 	std::string line;
 
 	if (!fp) {
-		throw NFIQ::NFIQException(
-		    e_Error_CannotReadFromFile, "Failed to Read File: " + modelInfoFilePath);
+		throw NFIQ::NFIQException(e_Error_CannotReadFromFile,
+		    "Failed to Read File: " + modelInfoFilePath);
 	}
 
 	while (std::getline(fp, line)) {

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/modelinfo.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/modelinfo.cpp
@@ -1,6 +1,7 @@
 #include <nfiq2/modelinfo.hpp>
 #include <nfiq2/nfiqexception.hpp>
 
+#include <algorithm>
 #include <cctype>
 #include <fstream>
 #include <iostream>
@@ -79,10 +80,17 @@ NFIQ::ModelInfo::ModelInfo(const std::string &modelInfoFilePath)
 						    modelInfoFilePath
 							.find_last_of("/\\");
 
-						this->modelPath =
-						    modelInfoFilePath.substr(
-							0, found) +
-						    '/' + end;
+						if (found ==
+						    std::string::npos) {
+							this->modelPath = "./" +
+							    end;
+						} else {
+							this->modelPath =
+							    modelInfoFilePath
+								.substr(
+								    0, found) +
+							    '/' + end;
+						}
 					}
 				} else if (start ==
 				    ModelInfo::ModelInfoKeyHash) {

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/modelinfo.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/modelinfo.cpp
@@ -12,9 +12,8 @@ const std::string NFIQ::ModelInfo::ModelInfoKeyVersion = "Version";
 const std::string NFIQ::ModelInfo::ModelInfoKeyPath = "Path";
 const std::string NFIQ::ModelInfo::ModelInfoKeyHash = "Hash";
 
-NFIQ::ModelInfo::ModelInfo(const std::string& modelInfoFilePath)
+NFIQ::ModelInfo::ModelInfo(const std::string &modelInfoFilePath)
 {
-
 	std::unordered_map<std::string, std::string> modelInfoMap {};
 	try {
 		modelInfoMap = parseModelInfoFile(modelInfoFilePath);
@@ -71,12 +70,13 @@ NFIQ::ModelInfo::getModelHash() const
 }
 
 void
-NFIQ::ModelInfo::setModelPath(const std::string& newPath) {
+NFIQ::ModelInfo::setModelPath(const std::string &newPath)
+{
 	this->modelPath = newPath;
 }
 
 std::unordered_map<std::string, std::string>
-NFIQ::parseModelInfoFile(const std::string& modelInfoFilePath)
+NFIQ::parseModelInfoFile(const std::string &modelInfoFilePath)
 {
 	std::unordered_map<std::string, std::string> modelInfoMap {};
 
@@ -86,15 +86,16 @@ NFIQ::parseModelInfoFile(const std::string& modelInfoFilePath)
 	if (fp.is_open()) {
 
 		while (std::getline(fp, line)) {
-
-			const std::string start = line.substr(
-			    0, line.find('=') - 1);
-			const std::string end = line.substr(
-			    line.find('=') + 2, line.size() - 1);
-
-			modelInfoMap[start] = end;
+			if (line.find('=') == std::string::npos) {
+				continue;
+			} else {
+				const std::string start = line.substr(
+				    0, line.find('=') - 1);
+				const std::string end = line.substr(
+				    line.find('=') + 2, line.size() - 1);
+				modelInfoMap[start] = end;
+			}
 		}
-
 		fp.close();
 
 	} else {

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/modelinfo.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/modelinfo.cpp
@@ -1,6 +1,7 @@
 #include <nfiq2/modelinfo.hpp>
 #include <nfiq2/nfiqexception.hpp>
 
+#include <cctype>
 #include <fstream>
 #include <iostream>
 #include <string>
@@ -34,11 +35,16 @@ NFIQ::ModelInfo::ModelInfo(const std::string &modelInfoFilePath)
 		} else {
 			const unsigned int llen = line.length();
 
-			if (eqPos != 0 && eqPos < llen - 2) {
-				const std::string start = line.substr(
-				    0, eqPos - 1);
-				const std::string end = line.substr(
-				    eqPos + 2, llen - 1);
+			if (eqPos != 0 && eqPos < llen - 1) {
+				const std::string start = isspace(
+							      line[eqPos - 1]) ?
+				    line.substr(0, eqPos - 1) :
+				    line.substr(0, eqPos);
+
+				const std::string end = isspace(
+							    line[eqPos + 1]) ?
+				    line.substr(eqPos + 2, llen - 1) :
+				    line.substr(eqPos + 1, llen - 1);
 
 				if (start == ModelInfo::ModelInfoKeyName) {
 					this->modelName = end;
@@ -73,9 +79,9 @@ NFIQ::ModelInfo::ModelInfo(const std::string &modelInfoFilePath)
 						    modelInfoFilePath.substr(
 							0, found) +
 						    '/' + end;
+					} else {
+						this->modelPath = end;
 					}
-
-					this->modelPath = end;
 
 				} else if (start ==
 				    ModelInfo::ModelInfoKeyHash) {

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/modelinfo.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/modelinfo.cpp
@@ -12,7 +12,7 @@ const std::string NFIQ::ModelInfo::ModelInfoKeyVersion = "Version";
 const std::string NFIQ::ModelInfo::ModelInfoKeyPath = "Path";
 const std::string NFIQ::ModelInfo::ModelInfoKeyHash = "Hash";
 
-NFIQ::ModelInfo::ModelInfo(const std::string modelInfoFilePath)
+NFIQ::ModelInfo::ModelInfo(const std::string& modelInfoFilePath)
 {
 
 	std::unordered_map<std::string, std::string> modelInfoMap {};
@@ -22,52 +22,61 @@ NFIQ::ModelInfo::ModelInfo(const std::string modelInfoFilePath)
 		throw NFIQ::NFIQException(1, "Model Class Failed Construction");
 	}
 
-	modelInfoMap[ModelInfoKeyName] = this->modelName;
-	modelInfoMap[ModelInfoKeyTrainer] = this->modelTrainer;
-	modelInfoMap[ModelInfoKeyDescription] = this->modelDescription;
-	modelInfoMap[ModelInfoKeyVersion] = this->modelVersion;
-	modelInfoMap[ModelInfoKeyPath] = this->modelPath;
-	modelInfoMap[ModelInfoKeyHash] = this->modelHash;
+	this->modelName = modelInfoMap[ModelInfoKeyName];
+	this->modelTrainer = modelInfoMap[ModelInfoKeyTrainer];
+	this->modelDescription = modelInfoMap[ModelInfoKeyDescription];
+	this->modelVersion = modelInfoMap[ModelInfoKeyVersion];
+	this->modelPath = modelInfoMap[ModelInfoKeyPath];
+	this->modelHash = modelInfoMap[ModelInfoKeyHash];
+}
+
+NFIQ::ModelInfo::~ModelInfo()
+{
 }
 
 std::string
-NFIQ::ModelInfo::getModelName()
+NFIQ::ModelInfo::getModelName() const
 {
 	return this->modelName;
 }
 
 std::string
-NFIQ::ModelInfo::getModelTrainer()
+NFIQ::ModelInfo::getModelTrainer() const
 {
 	return this->modelTrainer;
 }
 
 std::string
-NFIQ::ModelInfo::getModelDescription()
+NFIQ::ModelInfo::getModelDescription() const
 {
 	return this->modelDescription;
 }
 
 std::string
-NFIQ::ModelInfo::getModelVersion()
+NFIQ::ModelInfo::getModelVersion() const
 {
 	return this->modelVersion;
 }
 
 std::string
-NFIQ::ModelInfo::getModelPath()
+NFIQ::ModelInfo::getModelPath() const
 {
 	return this->modelPath;
 }
 
 std::string
-NFIQ::ModelInfo::getModelHash()
+NFIQ::ModelInfo::getModelHash() const
 {
 	return this->modelHash;
 }
 
+void
+NFIQ::ModelInfo::setModelPath(const std::string& newPath) {
+	this->modelPath = newPath;
+}
+
 std::unordered_map<std::string, std::string>
-NFIQ::parseModelInfoFile(const std::string modelInfoFilePath)
+NFIQ::parseModelInfoFile(const std::string& modelInfoFilePath)
 {
 	std::unordered_map<std::string, std::string> modelInfoMap {};
 

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2.cpp
@@ -1,3 +1,4 @@
+#include <nfiq2/modelinfo.hpp>
 #include <nfiq2/nfiq2.hpp>
 
 #include "nfiq2impl.h"
@@ -12,6 +13,13 @@ NFIQ::NFIQ2Algorithm::NFIQ2Algorithm()
 NFIQ::NFIQ2Algorithm::NFIQ2Algorithm(
     const std::string &fileName, const std::string &fileHash)
     : pimpl { new NFIQ::NFIQ2Algorithm::Impl(fileName, fileHash) }
+{
+}
+
+NFIQ::NFIQ2Algorithm::NFIQ2Algorithm(
+    std::shared_ptr<NFIQ::ModelInfo> modelInfoObj)
+    : pimpl { new NFIQ::NFIQ2Algorithm::Impl(
+	  modelInfoObj->modelPath, modelInfoObj->modelHash) }
 {
 }
 

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2.cpp
@@ -16,10 +16,9 @@ NFIQ::NFIQ2Algorithm::NFIQ2Algorithm(
 {
 }
 
-NFIQ::NFIQ2Algorithm::NFIQ2Algorithm(
-    std::shared_ptr<NFIQ::ModelInfo> modelInfoObj)
+NFIQ::NFIQ2Algorithm::NFIQ2Algorithm(const NFIQ::ModelInfo &modelInfoObj)
     : pimpl { new NFIQ::NFIQ2Algorithm::Impl(
-	  modelInfoObj->modelPath, modelInfoObj->modelHash) }
+	  modelInfoObj.getModelPath(), modelInfoObj.getModelHash()) }
 {
 }
 

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2.cpp
@@ -17,8 +17,8 @@ NFIQ::NFIQ2Algorithm::NFIQ2Algorithm(
 }
 
 NFIQ::NFIQ2Algorithm::NFIQ2Algorithm(const NFIQ::ModelInfo &modelInfoObj)
-    : pimpl { new NFIQ::NFIQ2Algorithm::Impl(
-	  modelInfoObj.getModelPath(), modelInfoObj.getModelHash()) }
+    : NFIQ::NFIQ2Algorithm { modelInfoObj.getModelPath(),
+	    modelInfoObj.getModelHash() }
 {
 }
 

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2impl.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2impl.cpp
@@ -92,8 +92,8 @@ NFIQ2Algorithm::Impl::computeQualityFeatures(
 		    NFIQ::ActionableQualityFeedbackIdentifier_UniformImage;
 		isUniformImage = (fbUniform.actionableQualityValue <
 			    ActionableQualityFeedbackThreshold_UniformImage ?
-			      true :
-			      false);
+			true :
+			false);
 		actionableQuality.push_back(fbUniform);
 
 		// only return actionable feedback if so configured
@@ -111,8 +111,8 @@ NFIQ2Algorithm::Impl::computeQualityFeatures(
 				    ActionableQualityFeedbackIdentifier_EmptyImageOrContrastTooLow;
 				isEmptyImage = (fb.actionableQualityValue >
 					    ActionableQualityFeedbackThreshold_EmptyImageOrContrastTooLow ?
-					      true :
-					      false);
+					true :
+					false);
 				actionableQuality.push_back(fb);
 			}
 		}

--- a/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_exception.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_exception.cpp
@@ -52,3 +52,8 @@ NFIQ2UI::FileNotFoundError::FileNotFoundError(const std::string &info)
     : Exception("FileNotFoundError: " + info)
 {
 }
+
+NFIQ2UI::ModelConstructionError::ModelConstructionError(const std::string &info)
+    : Exception("ModelConstructionError: " + info)
+{
+}

--- a/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_refresh.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_refresh.cpp
@@ -769,20 +769,9 @@ NFIQ2UI::parseModelInfo(const NFIQ2UI::Arguments &arguments)
 		modelInfoFilePath = arguments.flags.model;
 	}
 
-	std::unordered_map<std::string, std::string> modelInfoMap {};
-	try {
-		modelInfoMap = NFIQ::parseModelInfoFile(modelInfoFilePath);
-	} catch (const NFIQ::NFIQException &e) {
-		throw NFIQ2UI::ModelConstructionError(
-		    "Failed to parse information from model info file. Path: " +
-		    modelInfoFilePath + ". Error: " + e.what());
-	}
-
-	NFIQ::checkModelPath(modelInfoMap, modelInfoFilePath);
-
 	NFIQ::ModelInfo modelInfoObj {};
 	try {
-		modelInfoObj = NFIQ::ModelInfo(modelInfoMap);
+		modelInfoObj = NFIQ::ModelInfo(modelInfoFilePath);
 	} catch (const NFIQ::NFIQException &e) {
 		throw NFIQ2UI::ModelConstructionError(
 		    "Could not construct ModelInfo Object from: " +

--- a/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_refresh.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_refresh.cpp
@@ -730,7 +730,7 @@ NFIQ2UI::printHeader(
 }
 
 std::shared_ptr<NFIQ::ModelInfo>
-NFIQ2UI::parseModel(const NFIQ2UI::Arguments &arguments)
+NFIQ2UI::parseModelInfo(const NFIQ2UI::Arguments &arguments)
 {
 	static const std::string DefaultModelInfoFilename {
 		"nist_plain_tir-ink.txt"
@@ -789,11 +789,11 @@ NFIQ2UI::parseModel(const NFIQ2UI::Arguments &arguments)
 		    modelInfoFilePath + ". Error: " + e.what());
 	}
 
-	if (!BE::IO::Utility::fileExists(modelInfoObj->getModelPath())) {
+	if (!BE::IO::Utility::fileExists(modelInfoObj->modelPath)) {
 		throw NFIQ2UI::PropertyParseError("Unable to parse '" +
 		    NFIQ::ModelInfo::ModelInfoKeyPath + "' from '" +
 		    modelInfoFilePath + "' (No file exists at '" +
-		    modelInfoObj->getModelPath() + "')");
+		    modelInfoObj->modelPath + "')");
 	}
 
 	return modelInfoObj;
@@ -837,25 +837,32 @@ main(int argc, char **argv)
 	std::shared_ptr<NFIQ::ModelInfo> modelInfoObj {};
 
 	try {
-		modelInfoObj = NFIQ2UI::parseModel(arguments);
+		modelInfoObj = NFIQ2UI::parseModelInfo(arguments);
 	} catch (const NFIQ2UI::Exception &e) {
 		std::cerr << "Unable to extract model information. " << e.what()
 			  << "\n";
 		return EXIT_FAILURE;
 	}
 
-	logger->debugMsg("Model Name: " + modelInfoObj->getModelName());
-	logger->debugMsg("Model Trainer: " + modelInfoObj->getModelTrainer());
-	logger->debugMsg(
-	    "Model Description: " + modelInfoObj->getModelDescription());
-	logger->debugMsg("Model Version: " + modelInfoObj->getModelVersion());
-	logger->debugMsg("Model Path: " + modelInfoObj->getModelPath());
-	logger->debugMsg("Model Hash: " + modelInfoObj->getModelHash());
+	logger->debugMsg("Model Name: " +
+	    (modelInfoObj->modelName.empty() ? "<NA>" :
+					       modelInfoObj->modelName));
+	logger->debugMsg("Model Trainer: " +
+	    (modelInfoObj->modelTrainer.empty() ? "<NA>" :
+						  modelInfoObj->modelTrainer));
+	logger->debugMsg("Model Description: " +
+	    (modelInfoObj->modelDescription.empty() ?
+		    "<NA>" :
+		    modelInfoObj->modelDescription));
+	logger->debugMsg("Model Version: " +
+	    (modelInfoObj->modelVersion.empty() ? "<NA>" :
+						  modelInfoObj->modelVersion));
+	logger->debugMsg("Model Path: " + modelInfoObj->modelPath);
+	logger->debugMsg("Model Hash: " + modelInfoObj->modelHash);
 
 	std::shared_ptr<NFIQ::NFIQ2Algorithm> model {};
 	try {
-		model = std::make_shared<NFIQ::NFIQ2Algorithm>(
-		    modelInfoObj->getModelPath(), modelInfoObj->getModelHash());
+		model = std::make_shared<NFIQ::NFIQ2Algorithm>(modelInfoObj);
 	} catch (NFIQ::NFIQException &e) {
 		std::cerr << "Model could not be constructed. " << e.what()
 			  << "\n";

--- a/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_refresh.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_refresh.cpp
@@ -729,7 +729,7 @@ NFIQ2UI::printHeader(
 	}
 }
 
-std::shared_ptr<NFIQ::ModelInfo>
+NFIQ::ModelInfo
 NFIQ2UI::parseModelInfo(const NFIQ2UI::Arguments &arguments)
 {
 	static const std::string DefaultModelInfoFilename {
@@ -780,20 +780,20 @@ NFIQ2UI::parseModelInfo(const NFIQ2UI::Arguments &arguments)
 
 	NFIQ::checkModelPath(modelInfoMap, modelInfoFilePath);
 
-	std::shared_ptr<NFIQ::ModelInfo> modelInfoObj {};
+	NFIQ::ModelInfo modelInfoObj {};
 	try {
-		modelInfoObj = std::make_shared<NFIQ::ModelInfo>(modelInfoMap);
+		modelInfoObj = NFIQ::ModelInfo(modelInfoMap);
 	} catch (const NFIQ::NFIQException &e) {
 		throw NFIQ2UI::ModelConstructionError(
 		    "Could not construct ModelInfo Object from: " +
 		    modelInfoFilePath + ". Error: " + e.what());
 	}
 
-	if (!BE::IO::Utility::fileExists(modelInfoObj->modelPath)) {
+	if (!BE::IO::Utility::fileExists(modelInfoObj.getModelPath())) {
 		throw NFIQ2UI::PropertyParseError("Unable to parse '" +
 		    NFIQ::ModelInfo::ModelInfoKeyPath + "' from '" +
 		    modelInfoFilePath + "' (No file exists at '" +
-		    modelInfoObj->modelPath + "')");
+		    modelInfoObj.getModelPath() + "')");
 	}
 
 	return modelInfoObj;
@@ -834,10 +834,12 @@ main(int argc, char **argv)
 	double timeInit = 0.0;
 	timerInit.startTimer();
 
-	std::shared_ptr<NFIQ::ModelInfo> modelInfoObj {};
+	NFIQ::ModelInfo modelInfoObj {};
 
 	try {
-		modelInfoObj = NFIQ2UI::parseModelInfo(arguments);
+		modelInfoObj = NFIQ::ModelInfo(
+		    NFIQ2UI::parseModelInfo(arguments));
+
 	} catch (const NFIQ2UI::Exception &e) {
 		std::cerr << "Unable to extract model information. " << e.what()
 			  << "\n";
@@ -845,20 +847,23 @@ main(int argc, char **argv)
 	}
 
 	logger->debugMsg("Model Name: " +
-	    (modelInfoObj->modelName.empty() ? "<NA>" :
-					       modelInfoObj->modelName));
-	logger->debugMsg("Model Trainer: " +
-	    (modelInfoObj->modelTrainer.empty() ? "<NA>" :
-						  modelInfoObj->modelTrainer));
-	logger->debugMsg("Model Description: " +
-	    (modelInfoObj->modelDescription.empty() ?
+	    (modelInfoObj.getModelName().empty() ?
 		    "<NA>" :
-		    modelInfoObj->modelDescription));
+		    modelInfoObj.getModelName()));
+	logger->debugMsg("Model Trainer: " +
+	    (modelInfoObj.getModelTrainer().empty() ?
+		    "<NA>" :
+		    modelInfoObj.getModelTrainer()));
+	logger->debugMsg("Model Description: " +
+	    (modelInfoObj.getModelDescription().empty() ?
+		    "<NA>" :
+		    modelInfoObj.getModelDescription()));
 	logger->debugMsg("Model Version: " +
-	    (modelInfoObj->modelVersion.empty() ? "<NA>" :
-						  modelInfoObj->modelVersion));
-	logger->debugMsg("Model Path: " + modelInfoObj->modelPath);
-	logger->debugMsg("Model Hash: " + modelInfoObj->modelHash);
+	    (modelInfoObj.getModelVersion().empty() ?
+		    "<NA>" :
+		    modelInfoObj.getModelVersion()));
+	logger->debugMsg("Model Path: " + modelInfoObj.getModelPath());
+	logger->debugMsg("Model Hash: " + modelInfoObj.getModelHash());
 
 	std::shared_ptr<NFIQ::NFIQ2Algorithm> model {};
 	try {


### PR DESCRIPTION
In response to #110 and #111 

Added model object class to nfiq2 codebase. This is used to gather information from the model info file and parse it without needed to use libbiomeval's PropertiesFile class. This avoids re-adding libbiomeval as a dependency for the nfiq2 library. 

If the debug option is enabled (-d flag) then information about the model is printed to the output stream.

Discovered an existing unchecked exception when testing this new class. the model constructor (NFIQ::NFIQ2Algorithm) throws an exception if the hash of the file and the provided hash are not the same. Switching the model back to a pointer allows us to wrap construction of the model in a try/catch block. This does however remove the const qualifier that the model held previously. This should be made an issue to address in the future.