### PR TITLE
Re-adding Biomeval Version information

### DIFF
--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2/tool/nfiq2_ui_utils.h
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2/tool/nfiq2_ui_utils.h
@@ -29,6 +29,18 @@ namespace NFIQ2UI {
 
 /**
  *  @brief
+ *  Returns the version of the Biometric Evaluation Framework Library.
+ *
+ *  @details
+ *  Returns the version of the Biomeval library being used by CLI tool.
+ *
+ *  @return
+ *    A string containing version information.
+ */
+std::string getBiomevalVersion();
+
+/**
+ *  @brief
  *  Identifies a Standard Image from other FileTypes.
  *
  *  @details

--- a/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_utils.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_utils.cpp
@@ -8,6 +8,7 @@
  * about its quality, reliability, or any other characteristic.
  ******************************************************************************/
 
+#include <be_framework.h>
 #include <be_io_utility.h>
 #include <nfiq2/tool/nfiq2_ui_log.h>
 #include <nfiq2/tool/nfiq2_ui_types.h>
@@ -22,6 +23,13 @@
 #include <vector>
 
 namespace BE = BiometricEvaluation;
+
+std::string
+NFIQ2UI::getBiomevalVersion()
+{
+	return (std::to_string(BE::Framework::getMajorVersion()) + "." +
+	    std::to_string(BE::Framework::getMinorVersion()));
+}
 
 // Returns FileType Enum
 NFIQ2UI::FileType
@@ -311,6 +319,8 @@ NFIQ2UI::printUsage()
 	std::cout << "-r: Recursive file scanning if a directory is provided"
 		  << "\n";
 	std::cout << "\nVersion Info\n------------\n"
+		  << "Biometric Evaluation: " << NFIQ2UI::getBiomevalVersion()
+		  << "\n"
 		  << "FingerJet: " << NFIQ::Version::FingerJet()
 		  << "\n"
 		     "OpenCV: "


### PR DESCRIPTION
Biometric Evaluation Framework version information was included in NFIQ2 previously but was removed to prevent biomeval from being a dependency in the NFIQ2 lib. It has been re-added as part of the CLI tool which already has biomeval as a dependency.