### PR TITLE
Fixing Windows 32-bit/64-bit Install collision

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -281,7 +281,16 @@ elseif (CMAKE_SYSTEM_NAME MATCHES "Windows")
 	# Install WiX from https://wixtoolset.org/releases/
 	list(APPEND CPACK_GENERATOR "WIX")
 	set(CPACK_PACKAGE_INSTALL_DIRECTORY "NFIQ 2")
-	set(CPACK_WIX_UPGRADE_GUID "492101f0-5052-11eb-bb05-1b5668cc0087")
+	
+	if (CMAKE_SIZEOF_VOID_P MATCHES "8")
+		# 64-bit GUID
+		set(CPACK_WIX_UPGRADE_GUID "492101f0-5052-11eb-bb05-1b5668cc0087")
+		set(CPACK_PACKAGE_NAME "${NFIQ2_PRODUCT_NAME} (x64)")
+	else()
+		#32-bit GUID
+		set(CPACK_WIX_UPGRADE_GUID "226c3d8e-a622-fe6a-7c2d-3d3dc93eaacb")
+		set(CPACK_PACKAGE_NAME "${NFIQ2_PRODUCT_NAME} (x86)")
+	endif(CMAKE_SIZEOF_VOID_P MATCHES "8")
 
 	# Required for building on NIST machines
 	set(CPACK_WIX_CANDLE_EXTRA_FLAGS "-fips")


### PR DESCRIPTION
32 bit and 64 bit windows builds now use a different CPack GUID. 

The name of the installed nfiq2 app now appears as either "NFIQ 2 (x64)" or "NFIQ 2 (x86)" in windows add/remove programs depending on whether the 32 bit or 64 bit version is installed. Both will show up if both versions are installed.  