### PR TITLE
Rvup fix

### DIFF
--- a/NFIQ2/NFIQ2Algorithm/src/features/FingerJetFXFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FingerJetFXFeature.cpp
@@ -94,7 +94,6 @@ FingerJetFXFeature::computeFeatureData(
 	    &hFeatureSet);
 	if (fxRes != FRFXLL_OK) {
 		FRFXLLCloseHandle(&hCtx);
-
 		throw NFIQ::NFIQException(
 		    NFIQ::
 			e_Error_FeatureCalculationError_FJFX_CannotCreateFeatureSet,
@@ -104,7 +103,6 @@ FingerJetFXFeature::computeFeatureData(
 	// close handle
 	FRFXLLCloseHandle(&hCtx);
 	if (hFeatureSet == NULL) {
-
 		throw NFIQ::NFIQException(
 		    NFIQ::
 			e_Error_FeatureCalculationError_FJFX_CannotCreateFeatureSet,
@@ -119,8 +117,8 @@ FingerJetFXFeature::computeFeatureData(
 			e_Error_FeatureCalculationError_FJFX_NoFeatureSetCreated,
 		    "Failed to obtain Minutia Info from feature set.");
 	}
-	std::unique_ptr<FRFXLL_Basic_19794_2_Minutia[]> mdata {};
 
+	std::unique_ptr<FRFXLL_Basic_19794_2_Minutia[]> mdata {};
 	try {
 		mdata.reset(new FRFXLL_Basic_19794_2_Minutia[minCnt]);
 	} catch (const std::bad_alloc &) {

--- a/NFIQ2/NFIQ2Algorithm/src/features/FingerJetFXFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FingerJetFXFeature.cpp
@@ -113,6 +113,7 @@ FingerJetFXFeature::computeFeatureData(
 
 	unsigned int minCnt { 0 };
 	if (FRFXLLGetMinutiaInfo(hFeatureSet, &minCnt, nullptr) != FRFXLL_OK) {
+		FRFXLLCloseHandle(&hFeatureSet);
 		throw NFIQ::NFIQException(
 		    NFIQ::
 			e_Error_FeatureCalculationError_FJFX_NoFeatureSetCreated,
@@ -123,12 +124,14 @@ FingerJetFXFeature::computeFeatureData(
 	try {
 		mdata.reset(new FRFXLL_Basic_19794_2_Minutia[minCnt]);
 	} catch (const std::bad_alloc &) {
+		FRFXLLCloseHandle(&hFeatureSet);
 		throw NFIQ::NFIQException(NFIQ::e_Error_NotEnoughMemory,
 		    "Could not allocate space for extracted minutiae records.");
 	}
 
 	if (FRFXLLGetMinutiae(hFeatureSet, BASIC_19794_2_MINUTIA_STRUCT,
 		&minCnt, mdata.get()) != FRFXLL_OK) {
+		FRFXLLCloseHandle(&hFeatureSet);
 		throw NFIQ::NFIQException(
 		    NFIQ::
 			e_Error_FeatureCalculationError_FJFX_NoFeatureSetCreated,

--- a/NFIQ2/NFIQ2Algorithm/src/features/FingerJetFXFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FingerJetFXFeature.cpp
@@ -108,6 +108,18 @@ FingerJetFXFeature::computeFeatureData(
 		res_min_cnt.featureData = fd_min_cnt;
 		featureDataList.push_back(res_min_cnt);
 
+		if (m_bOutputSpeed) {
+			NFIQ::QualityFeatureSpeed speed;
+			speed.featureIDGroup =
+			    FingerJetFXFeature::speedFeatureIDGroup;
+			speed.featureIDs.push_back(
+			    "FJFXPos_Mu_MinutiaeQuality_2");
+			speed.featureIDs.push_back(
+			    "FJFXPos_OCL_MinutiaeQuality_80");
+			speed.featureSpeed = 0;
+			m_lSpeedValues.push_back(speed);
+		}
+
 		return featureDataList;
 	}
 
@@ -127,6 +139,18 @@ FingerJetFXFeature::computeFeatureData(
 		res_min_cnt.featureData = fd_min_cnt;
 		featureDataList.push_back(res_min_cnt);
 
+		if (m_bOutputSpeed) {
+			NFIQ::QualityFeatureSpeed speed;
+			speed.featureIDGroup =
+			    FingerJetFXFeature::speedFeatureIDGroup;
+			speed.featureIDs.push_back(
+			    "FJFXPos_Mu_MinutiaeQuality_2");
+			speed.featureIDs.push_back(
+			    "FJFXPos_OCL_MinutiaeQuality_80");
+			speed.featureSpeed = 0;
+			m_lSpeedValues.push_back(speed);
+		}
+
 		return featureDataList;
 	}
 
@@ -144,6 +168,18 @@ FingerJetFXFeature::computeFeatureData(
 		res_min_cnt.returnCode = 0;
 		res_min_cnt.featureData = fd_min_cnt;
 		featureDataList.push_back(res_min_cnt);
+
+		if (m_bOutputSpeed) {
+			NFIQ::QualityFeatureSpeed speed;
+			speed.featureIDGroup =
+			    FingerJetFXFeature::speedFeatureIDGroup;
+			speed.featureIDs.push_back(
+			    "FJFXPos_Mu_MinutiaeQuality_2");
+			speed.featureIDs.push_back(
+			    "FJFXPos_OCL_MinutiaeQuality_80");
+			speed.featureSpeed = 0;
+			m_lSpeedValues.push_back(speed);
+		}
 
 		return featureDataList;
 	}
@@ -170,6 +206,18 @@ FingerJetFXFeature::computeFeatureData(
 		res_min_cnt.returnCode = 0;
 		res_min_cnt.featureData = fd_min_cnt;
 		featureDataList.push_back(res_min_cnt);
+
+		if (m_bOutputSpeed) {
+			NFIQ::QualityFeatureSpeed speed;
+			speed.featureIDGroup =
+			    FingerJetFXFeature::speedFeatureIDGroup;
+			speed.featureIDs.push_back(
+			    "FJFXPos_Mu_MinutiaeQuality_2");
+			speed.featureIDs.push_back(
+			    "FJFXPos_OCL_MinutiaeQuality_80");
+			speed.featureSpeed = 0;
+			m_lSpeedValues.push_back(speed);
+		}
 
 		return featureDataList;
 	}

--- a/NFIQ2/NFIQ2Algorithm/src/features/FingerJetFXFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FingerJetFXFeature.cpp
@@ -112,11 +112,10 @@ FingerJetFXFeature::computeFeatureData(
 			NFIQ::QualityFeatureSpeed speed;
 			speed.featureIDGroup =
 			    FingerJetFXFeature::speedFeatureIDGroup;
+			speed.featureIDs.push_back("FingerJetFX_MinutiaeCount");
 			speed.featureIDs.push_back(
-			    "FJFXPos_Mu_MinutiaeQuality_2");
-			speed.featureIDs.push_back(
-			    "FJFXPos_OCL_MinutiaeQuality_80");
-			speed.featureSpeed = 0;
+			    "FingerJetFX_MinCount_COMMinRect200x200");
+			speed.featureSpeed = timer.endTimerAndGetElapsedTime();
 			m_lSpeedValues.push_back(speed);
 		}
 
@@ -143,11 +142,10 @@ FingerJetFXFeature::computeFeatureData(
 			NFIQ::QualityFeatureSpeed speed;
 			speed.featureIDGroup =
 			    FingerJetFXFeature::speedFeatureIDGroup;
+			speed.featureIDs.push_back("FingerJetFX_MinutiaeCount");
 			speed.featureIDs.push_back(
-			    "FJFXPos_Mu_MinutiaeQuality_2");
-			speed.featureIDs.push_back(
-			    "FJFXPos_OCL_MinutiaeQuality_80");
-			speed.featureSpeed = 0;
+			    "FingerJetFX_MinCount_COMMinRect200x200");
+			speed.featureSpeed = timer.endTimerAndGetElapsedTime();
 			m_lSpeedValues.push_back(speed);
 		}
 
@@ -173,11 +171,10 @@ FingerJetFXFeature::computeFeatureData(
 			NFIQ::QualityFeatureSpeed speed;
 			speed.featureIDGroup =
 			    FingerJetFXFeature::speedFeatureIDGroup;
+			speed.featureIDs.push_back("FingerJetFX_MinutiaeCount");
 			speed.featureIDs.push_back(
-			    "FJFXPos_Mu_MinutiaeQuality_2");
-			speed.featureIDs.push_back(
-			    "FJFXPos_OCL_MinutiaeQuality_80");
-			speed.featureSpeed = 0;
+			    "FingerJetFX_MinCount_COMMinRect200x200");
+			speed.featureSpeed = timer.endTimerAndGetElapsedTime();
 			m_lSpeedValues.push_back(speed);
 		}
 
@@ -211,11 +208,10 @@ FingerJetFXFeature::computeFeatureData(
 			NFIQ::QualityFeatureSpeed speed;
 			speed.featureIDGroup =
 			    FingerJetFXFeature::speedFeatureIDGroup;
+			speed.featureIDs.push_back("FingerJetFX_MinutiaeCount");
 			speed.featureIDs.push_back(
-			    "FJFXPos_Mu_MinutiaeQuality_2");
-			speed.featureIDs.push_back(
-			    "FJFXPos_OCL_MinutiaeQuality_80");
-			speed.featureSpeed = 0;
+			    "FingerJetFX_MinCount_COMMinRect200x200");
+			speed.featureSpeed = timer.endTimerAndGetElapsedTime();
 			m_lSpeedValues.push_back(speed);
 		}
 

--- a/NFIQ2/NFIQ2Algorithm/src/features/FingerJetFXFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FingerJetFXFeature.cpp
@@ -95,90 +95,28 @@ FingerJetFXFeature::computeFeatureData(
 	if (fxRes != FRFXLL_OK) {
 		FRFXLLCloseHandle(&hCtx);
 
-		// return features
-		fd_min_cnt_comrect200x200.featureDataDouble =
-		    0; // no minutiae found
-		res_min_cnt_comrect200x200.featureData =
-		    fd_min_cnt_comrect200x200;
-		res_min_cnt_comrect200x200.returnCode = fxRes;
-		featureDataList.push_back(res_min_cnt_comrect200x200);
-
-		fd_min_cnt.featureDataDouble = 0; // no minutiae found
-		res_min_cnt.returnCode = fxRes;
-		res_min_cnt.featureData = fd_min_cnt;
-		featureDataList.push_back(res_min_cnt);
-
-		if (m_bOutputSpeed) {
-			NFIQ::QualityFeatureSpeed speed;
-			speed.featureIDGroup =
-			    FingerJetFXFeature::speedFeatureIDGroup;
-			speed.featureIDs.push_back("FingerJetFX_MinutiaeCount");
-			speed.featureIDs.push_back(
-			    "FingerJetFX_MinCount_COMMinRect200x200");
-			speed.featureSpeed = timer.endTimerAndGetElapsedTime();
-			m_lSpeedValues.push_back(speed);
-		}
-
-		return featureDataList;
+		throw NFIQ::NFIQException(
+		    NFIQ::
+			e_Error_FeatureCalculationError_FJFX_CannotCreateFeatureSet,
+		    "Could not create feature set from raw data.");
 	}
 
 	// close handle
 	FRFXLLCloseHandle(&hCtx);
 	if (hFeatureSet == NULL) {
-		// return features
-		fd_min_cnt_comrect200x200.featureDataDouble =
-		    0; // no minutiae found
-		res_min_cnt_comrect200x200.featureData =
-		    fd_min_cnt_comrect200x200;
-		res_min_cnt_comrect200x200.returnCode = 0;
-		featureDataList.push_back(res_min_cnt_comrect200x200);
 
-		fd_min_cnt.featureDataDouble = 0; // no minutiae found
-		res_min_cnt.returnCode = 0;
-		res_min_cnt.featureData = fd_min_cnt;
-		featureDataList.push_back(res_min_cnt);
-
-		if (m_bOutputSpeed) {
-			NFIQ::QualityFeatureSpeed speed;
-			speed.featureIDGroup =
-			    FingerJetFXFeature::speedFeatureIDGroup;
-			speed.featureIDs.push_back("FingerJetFX_MinutiaeCount");
-			speed.featureIDs.push_back(
-			    "FingerJetFX_MinCount_COMMinRect200x200");
-			speed.featureSpeed = timer.endTimerAndGetElapsedTime();
-			m_lSpeedValues.push_back(speed);
-		}
-
-		return featureDataList;
+		throw NFIQ::NFIQException(
+		    NFIQ::
+			e_Error_FeatureCalculationError_FJFX_CannotCreateFeatureSet,
+		    "Feature set creation failed. Feature set is null.");
 	}
 
 	unsigned int minCnt { 0 };
 	if (FRFXLLGetMinutiaInfo(hFeatureSet, &minCnt, nullptr) != FRFXLL_OK) {
-		// return features
-		fd_min_cnt_comrect200x200.featureDataDouble =
-		    0; // no minutiae found
-		res_min_cnt_comrect200x200.featureData =
-		    fd_min_cnt_comrect200x200;
-		res_min_cnt_comrect200x200.returnCode = 0;
-		featureDataList.push_back(res_min_cnt_comrect200x200);
-
-		fd_min_cnt.featureDataDouble = 0; // no minutiae found
-		res_min_cnt.returnCode = 0;
-		res_min_cnt.featureData = fd_min_cnt;
-		featureDataList.push_back(res_min_cnt);
-
-		if (m_bOutputSpeed) {
-			NFIQ::QualityFeatureSpeed speed;
-			speed.featureIDGroup =
-			    FingerJetFXFeature::speedFeatureIDGroup;
-			speed.featureIDs.push_back("FingerJetFX_MinutiaeCount");
-			speed.featureIDs.push_back(
-			    "FingerJetFX_MinCount_COMMinRect200x200");
-			speed.featureSpeed = timer.endTimerAndGetElapsedTime();
-			m_lSpeedValues.push_back(speed);
-		}
-
-		return featureDataList;
+		throw NFIQ::NFIQException(
+		    NFIQ::
+			e_Error_FeatureCalculationError_FJFX_NoFeatureSetCreated,
+		    "Failed to obtain Minutia Info from feature set.");
 	}
 	std::unique_ptr<FRFXLL_Basic_19794_2_Minutia[]> mdata {};
 
@@ -191,31 +129,10 @@ FingerJetFXFeature::computeFeatureData(
 
 	if (FRFXLLGetMinutiae(hFeatureSet, BASIC_19794_2_MINUTIA_STRUCT,
 		&minCnt, mdata.get()) != FRFXLL_OK) {
-		// return features
-		fd_min_cnt_comrect200x200.featureDataDouble =
-		    0; // no minutiae found
-		res_min_cnt_comrect200x200.featureData =
-		    fd_min_cnt_comrect200x200;
-		res_min_cnt_comrect200x200.returnCode = 0;
-		featureDataList.push_back(res_min_cnt_comrect200x200);
-
-		fd_min_cnt.featureDataDouble = 0; // no minutiae found
-		res_min_cnt.returnCode = 0;
-		res_min_cnt.featureData = fd_min_cnt;
-		featureDataList.push_back(res_min_cnt);
-
-		if (m_bOutputSpeed) {
-			NFIQ::QualityFeatureSpeed speed;
-			speed.featureIDGroup =
-			    FingerJetFXFeature::speedFeatureIDGroup;
-			speed.featureIDs.push_back("FingerJetFX_MinutiaeCount");
-			speed.featureIDs.push_back(
-			    "FingerJetFX_MinCount_COMMinRect200x200");
-			speed.featureSpeed = timer.endTimerAndGetElapsedTime();
-			m_lSpeedValues.push_back(speed);
-		}
-
-		return featureDataList;
+		throw NFIQ::NFIQException(
+		    NFIQ::
+			e_Error_FeatureCalculationError_FJFX_NoFeatureSetCreated,
+		    "Failed to parse Minutia Data into 19794 Minutia Struct.");
 	}
 
 	minutiaData.clear();
@@ -236,31 +153,9 @@ FingerJetFXFeature::computeFeatureData(
 	templateCouldBeExtracted = true;
 
 	if (minCnt == 0) {
-		// return features
-		fd_min_cnt_comrect200x200.featureDataDouble =
-		    0; // no minutiae found
-		res_min_cnt_comrect200x200.featureData =
-		    fd_min_cnt_comrect200x200;
-		res_min_cnt_comrect200x200.returnCode = 0;
-		featureDataList.push_back(res_min_cnt_comrect200x200);
-
-		fd_min_cnt.featureDataDouble = 0; // no minutiae found
-		res_min_cnt.returnCode = 0;
-		res_min_cnt.featureData = fd_min_cnt;
-		featureDataList.push_back(res_min_cnt);
-
-		if (m_bOutputSpeed) {
-			NFIQ::QualityFeatureSpeed speed;
-			speed.featureIDGroup =
-			    FingerJetFXFeature::speedFeatureIDGroup;
-			speed.featureIDs.push_back("FingerJetFX_MinutiaeCount");
-			speed.featureIDs.push_back(
-			    "FingerJetFX_MinCount_COMMinRect200x200");
-			speed.featureSpeed = timer.endTimerAndGetElapsedTime();
-			m_lSpeedValues.push_back(speed);
-		}
-
-		return featureDataList;
+		throw NFIQ::NFIQException(
+		    NFIQ::e_Error_FeatureCalculationError_FJFX_NoMinutiaeFound,
+		    "Failed to extract Minutiae. Minutiae count is '0'.");
 	}
 
 	// compute ROI and return features

--- a/NFIQ2/NFIQ2Algorithm/src/features/FingerJetFXFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FingerJetFXFeature.cpp
@@ -153,9 +153,31 @@ FingerJetFXFeature::computeFeatureData(
 	templateCouldBeExtracted = true;
 
 	if (minCnt == 0) {
-		throw NFIQ::NFIQException(
-		    NFIQ::e_Error_FeatureCalculationError_FJFX_NoMinutiaeFound,
-		    "Failed to extract Minutiae. Minutiae count is '0'.");
+		// return features
+		fd_min_cnt_comrect200x200.featureDataDouble =
+		    0; // no minutiae found
+		res_min_cnt_comrect200x200.featureData =
+		    fd_min_cnt_comrect200x200;
+		res_min_cnt_comrect200x200.returnCode = 0;
+		featureDataList.push_back(res_min_cnt_comrect200x200);
+
+		fd_min_cnt.featureDataDouble = 0; // no minutiae found
+		res_min_cnt.returnCode = 0;
+		res_min_cnt.featureData = fd_min_cnt;
+		featureDataList.push_back(res_min_cnt);
+
+		if (m_bOutputSpeed) {
+			NFIQ::QualityFeatureSpeed speed;
+			speed.featureIDGroup =
+			    FingerJetFXFeature::speedFeatureIDGroup;
+			speed.featureIDs.push_back("FingerJetFX_MinutiaeCount");
+			speed.featureIDs.push_back(
+			    "FingerJetFX_MinCount_COMMinRect200x200");
+			speed.featureSpeed = timer.endTimerAndGetElapsedTime();
+			m_lSpeedValues.push_back(speed);
+		}
+
+		return featureDataList;
 	}
 
 	// compute ROI and return features


### PR DESCRIPTION
When FJFX is unable to extract minutia, it does not produce the correct CSV output for speed. This PR ensures the additional "0" gets produced in the CSV output. 