### PR TITLE
Truncate to 10 decimal places instead of 11

### DIFF
--- a/NFIQ2/NFIQ2Algorithm/src/features/FeatureFunctions.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FeatureFunctions.cpp
@@ -384,19 +384,19 @@ getRidgeValleyStructure(const Mat &blockCropped, std::vector<uint8_t> &ridval,
 		    NFIQ::e_Error_FeatureCalculationError, ssErr.str());
 	}
 
-	// Round to 11 decimal points to preserve score consistency across
-	// platforms (10^11)
+	// Round to 10 decimal points to preserve score consistency across
+	// platforms (10^10)
 #if CV_MAJOR_VERSION <= 2
 	for (int i = 0; i < dt1.rows; i++) {
 		for (int j = 0; j < dt1.cols; j++) {
 			dt1.at<double>(
-			    i, j) = round(dt1.at<double>(i, j) * 100000000000) /
-			    100000000000;
+			    i, j) = round(dt1.at<double>(i, j) * 10000000000) /
+			    10000000000;
 		}
 	}
 #else
 	dt1.forEach<double>([&](double &val, const int *position) {
-		val = round(val * 100000000000) / 100000000000;
+		val = round(val * 10000000000) / 10000000000;
 	});
 #endif /* CV_MAJOR_VERSION */
 


### PR DESCRIPTION
Resolves inconsistency on a handful of images on macOS 11 with LCS and RVU.