### PR TITLE
Remove compiler warning for API

### DIFF
--- a/NFIQ2/NFIQ2Api/nfiq2api.cpp
+++ b/NFIQ2/NFIQ2Api/nfiq2api.cpp
@@ -80,8 +80,9 @@ GetNfiq2Version(int *major, int *minor, int *patch, const char **ocv)
 	*ocv = buf;
 #endif
 }
+// Require an allocated buffer of size 33 to accomodate md5 hash
 DLLEXPORT const char *STDCALL
-InitNfiq2()
+InitNfiq2(char* paramHash)
 {
 	try {
 		if (g_nfiq2.get() == nullptr) {
@@ -93,7 +94,8 @@ InitNfiq2()
 			    new NFIQ::NFIQ2Algorithm(GetYamlFilePath(),
 				"ccd75820b48c19f1645ef5e9c481c592"));
 #endif
-			return g_nfiq2->getParameterHash().c_str();
+			strncpy(paramHash, g_nfiq2->getParameterHash().c_str(), 33);
+			return paramHash;
 		}
 	} catch (std::exception &exc) {
 		std::cerr << "NFIQ2 ERROR => " << exc.what() << std::endl;

--- a/NFIQ2/NFIQ2Api/nfiq2api.cpp
+++ b/NFIQ2/NFIQ2Api/nfiq2api.cpp
@@ -83,6 +83,9 @@ GetNfiq2Version(int *major, int *minor, int *patch, const char **ocv)
 DLLEXPORT const char *STDCALL
 InitNfiq2(char *hash)
 {
+	if (hash == nullptr) {
+		return nullptr;
+	}
 	try {
 		if (g_nfiq2.get() == nullptr) {
 #ifdef EMBED_RANDOMFOREST_PARAMETERS
@@ -93,7 +96,7 @@ InitNfiq2(char *hash)
 			    new NFIQ::NFIQ2Algorithm(GetYamlFilePath(),
 				"ccd75820b48c19f1645ef5e9c481c592"));
 #endif
-			hash = strndup(g_nfiq2->getParameterHash().c_str(),
+			strncpy(hash, g_nfiq2->getParameterHash().c_str(),
 			    g_nfiq2->getParameterHash().length() + 1);
 			return hash;
 		}

--- a/NFIQ2/NFIQ2Api/nfiq2api.cpp
+++ b/NFIQ2/NFIQ2Api/nfiq2api.cpp
@@ -80,9 +80,8 @@ GetNfiq2Version(int *major, int *minor, int *patch, const char **ocv)
 	*ocv = buf;
 #endif
 }
-// Require an allocated buffer of size 33 to accomodate md5 hash
 DLLEXPORT const char *STDCALL
-InitNfiq2(char* paramHash)
+InitNfiq2(char *hash)
 {
 	try {
 		if (g_nfiq2.get() == nullptr) {
@@ -94,8 +93,9 @@ InitNfiq2(char* paramHash)
 			    new NFIQ::NFIQ2Algorithm(GetYamlFilePath(),
 				"ccd75820b48c19f1645ef5e9c481c592"));
 #endif
-			strncpy(paramHash, g_nfiq2->getParameterHash().c_str(), 33);
-			return paramHash;
+			hash = strndup(g_nfiq2->getParameterHash().c_str(),
+			    g_nfiq2->getParameterHash().length() + 1);
+			return hash;
 		}
 	} catch (std::exception &exc) {
 		std::cerr << "NFIQ2 ERROR => " << exc.what() << std::endl;

--- a/NFIQ2/NFIQ2Api/nfiq2api.cpp
+++ b/NFIQ2/NFIQ2Api/nfiq2api.cpp
@@ -81,11 +81,8 @@ GetNfiq2Version(int *major, int *minor, int *patch, const char **ocv)
 #endif
 }
 DLLEXPORT const char *STDCALL
-InitNfiq2(char *hash)
+InitNfiq2(char **hash)
 {
-	if (hash == nullptr) {
-		return nullptr;
-	}
 	try {
 		if (g_nfiq2.get() == nullptr) {
 #ifdef EMBED_RANDOMFOREST_PARAMETERS
@@ -96,9 +93,11 @@ InitNfiq2(char *hash)
 			    new NFIQ::NFIQ2Algorithm(GetYamlFilePath(),
 				"ccd75820b48c19f1645ef5e9c481c592"));
 #endif
-			strncpy(hash, g_nfiq2->getParameterHash().c_str(),
+			*hash = (char *)malloc(
 			    g_nfiq2->getParameterHash().length() + 1);
-			return hash;
+			strncpy(*hash, g_nfiq2->getParameterHash().c_str(),
+			    g_nfiq2->getParameterHash().length() + 1);
+			return *hash;
 		}
 	} catch (std::exception &exc) {
 		std::cerr << "NFIQ2 ERROR => " << exc.what() << std::endl;

--- a/NFIQ2/NFIQ2Api/nfiq2api.h
+++ b/NFIQ2/NFIQ2Api/nfiq2api.h
@@ -13,7 +13,6 @@
 
 extern "C" DLLEXPORT void STDCALL GetNfiq2Version(
     int *major, int *minor, int *patch, const char **ocv);
-/** User must allocate and pass a buffer of 33 bytes for MD5 Hash */
-extern "C" DLLEXPORT const char *STDCALL InitNfiq2(char *hash);
+extern "C" DLLEXPORT const char *STDCALL InitNfiq2(char **hash);
 extern "C" DLLEXPORT int STDCALL ComputeNfiq2Score(int fpos,
     const unsigned char *pixels, int size, int width, int height, int ppi);

--- a/NFIQ2/NFIQ2Api/nfiq2api.h
+++ b/NFIQ2/NFIQ2Api/nfiq2api.h
@@ -13,6 +13,6 @@
 
 extern "C" DLLEXPORT void STDCALL GetNfiq2Version(
     int *major, int *minor, int *patch, const char **ocv);
-extern "C" DLLEXPORT const char *STDCALL InitNfiq2(char* paramHash);
+extern "C" DLLEXPORT const char *STDCALL InitNfiq2(char *hash);
 extern "C" DLLEXPORT int STDCALL ComputeNfiq2Score(int fpos,
     const unsigned char *pixels, int size, int width, int height, int ppi);

--- a/NFIQ2/NFIQ2Api/nfiq2api.h
+++ b/NFIQ2/NFIQ2Api/nfiq2api.h
@@ -13,6 +13,7 @@
 
 extern "C" DLLEXPORT void STDCALL GetNfiq2Version(
     int *major, int *minor, int *patch, const char **ocv);
+/** User must allocate and pass a buffer of 33 bytes for MD5 Hash */
 extern "C" DLLEXPORT const char *STDCALL InitNfiq2(char *hash);
 extern "C" DLLEXPORT int STDCALL ComputeNfiq2Score(int fpos,
     const unsigned char *pixels, int size, int width, int height, int ppi);

--- a/NFIQ2/NFIQ2Api/nfiq2api.h
+++ b/NFIQ2/NFIQ2Api/nfiq2api.h
@@ -13,6 +13,6 @@
 
 extern "C" DLLEXPORT void STDCALL GetNfiq2Version(
     int *major, int *minor, int *patch, const char **ocv);
-extern "C" DLLEXPORT const char *STDCALL InitNfiq2();
+extern "C" DLLEXPORT const char *STDCALL InitNfiq2(char* paramHash);
 extern "C" DLLEXPORT int STDCALL ComputeNfiq2Score(int fpos,
     const unsigned char *pixels, int size, int width, int height, int ppi);


### PR DESCRIPTION
Partially Addresses issue #134 

Remove compiler warning in API. Using strndup to duplicate hash string.