### PR TITLE
Fixed compiler warnings in CLI Tool

### DIFF
--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2/tool/nfiq2_ui_utils.h
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2/tool/nfiq2_ui_utils.h
@@ -154,16 +154,16 @@ bool yesOrNo(const std::string &prompt, bool default_answer = true,
  *  asked if they would like to change to using n cores
  *  to maintain system stability.
  *
- *  @param[in] optarg
+ *  @param[in] threadArg
  *    The number of desired threads to create for Multi-Threaded
  *    operations.
  *
  *  @return
  *    The number of threads to be used by Multi-threaded operations.
  */
-unsigned int checkThreads(const std::string &optarg);
+unsigned int checkThreads(const std::string &threadArg);
 
-std::string formatDouble(const double &d, const int precision);
+std::string formatDouble(const double &d, const long precision);
 
 /**
  *  @brief

--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2/tool/nfiq2_ui_utils.h
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2/tool/nfiq2_ui_utils.h
@@ -163,7 +163,7 @@ bool yesOrNo(const std::string &prompt, bool default_answer = true,
  */
 unsigned int checkThreads(const std::string &threadArg);
 
-std::string formatDouble(const double &d, const long precision);
+std::string formatDouble(const double &d, const uint8_t precision);
 
 /**
  *  @brief

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/modelinfo.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/modelinfo.cpp
@@ -31,12 +31,12 @@ NFIQ::ModelInfo::ModelInfo(const std::string &modelInfoFilePath)
 	}
 
 	while (std::getline(fp, line)) {
-		const int eqPos = line.find('=');
+		const std::string::size_type eqPos = line.find('=');
 
 		if (eqPos == std::string::npos) {
 			continue;
 		} else {
-			const unsigned int llen = line.length();
+			const size_t llen = line.length();
 
 			if (eqPos != 0 && eqPos < llen - 1) {
 				const std::string start = trimWhitespace(

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/modelinfo.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/modelinfo.cpp
@@ -31,7 +31,7 @@ NFIQ::ModelInfo::ModelInfo(const std::string &modelInfoFilePath)
 	}
 
 	while (std::getline(fp, line)) {
-		const std::string::size_type eqPos = line.find('=');
+		const size_t eqPos = line.find('=');
 
 		if (eqPos == std::string::npos) {
 			continue;

--- a/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_log.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_log.cpp
@@ -124,7 +124,7 @@ NFIQ2UI::Log::padNA() const
 	}
 
 	const unsigned int padding = numCols - MIN_NUM_COLS;
-	for (auto i = 0; i < padding; i++) {
+	for (unsigned int i = 0; i < padding; i++) {
 		strNA += ",NA";
 	}
 

--- a/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_utils.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_utils.cpp
@@ -184,13 +184,13 @@ NFIQ2UI::yesOrNo(const std::string &prompt, bool default_answer,
 // Checks the threads given and prompts user if the requested amount is higher
 // than CPU cores/threads
 unsigned int
-NFIQ2UI::checkThreads(const std::string &optarg)
+NFIQ2UI::checkThreads(const std::string &threadArg)
 {
 	unsigned int n = std::thread::hardware_concurrency();
 	unsigned int input = 1;
 
 	try {
-		input = static_cast<unsigned int>(std::stoul(optarg));
+		input = static_cast<unsigned int>(std::stoul(threadArg));
 	} catch (const std::invalid_argument &e) {
 		std::cerr << e.what() << "\n";
 		std::cerr << "Number not given to threading flag. Single "
@@ -235,7 +235,7 @@ NFIQ2UI::checkThreads(const std::string &optarg)
 }
 
 std::string
-NFIQ2UI::formatDouble(const double &d, const int precision)
+NFIQ2UI::formatDouble(const double &d, const long precision)
 {
 	switch (std::fpclassify(d)) {
 	case FP_NORMAL:
@@ -258,16 +258,22 @@ NFIQ2UI::formatDouble(const double &d, const int precision)
 
 	const std::string::size_type decimalPosition = s.find('.');
 
-	if (decimalPosition == std::string::npos ||
-	    precision >= (s.length() - decimalPosition - 1)) {
+	// Decimal not found
+	if (decimalPosition == std::string::npos) {
 		return s;
 	}
 
+	// Invalid precision, return default precision of string
 	if (precision <= 0) {
 		return s.substr(0, 7);
-	} else {
-		return s.substr(0, decimalPosition + precision + 1);
 	}
+
+	// If precision exceeds the length of the decimal portion of the string
+	if (static_cast<unsigned long>(precision) >= (s.length() - decimalPosition - 1)) {
+		return s;
+	}
+
+	return s.substr(0, decimalPosition + precision + 1);
 }
 
 // Usage of NFIQ2 tool

--- a/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_utils.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_utils.cpp
@@ -235,7 +235,7 @@ NFIQ2UI::checkThreads(const std::string &threadArg)
 }
 
 std::string
-NFIQ2UI::formatDouble(const double &d, const long precision)
+NFIQ2UI::formatDouble(const double &d, const uint8_t precision)
 {
 	switch (std::fpclassify(d)) {
 	case FP_NORMAL:
@@ -258,18 +258,8 @@ NFIQ2UI::formatDouble(const double &d, const long precision)
 
 	const std::string::size_type decimalPosition = s.find('.');
 
-	// Decimal not found
-	if (decimalPosition == std::string::npos) {
-		return s;
-	}
-
-	// Invalid precision, return default precision of string
-	if (precision <= 0) {
-		return s.substr(0, 7);
-	}
-
-	// If precision exceeds the length of the decimal portion of the string
-	if (static_cast<unsigned long>(precision) >= (s.length() - decimalPosition - 1)) {
+	if (decimalPosition == std::string::npos ||
+	    precision >= (s.length() - decimalPosition - 1)) {
 		return s;
 	}
 


### PR DESCRIPTION
Partially Addresses #134 

Fixed global variable shadowing with getopt in checkThreads function in nfiq2_ui_utils.cpp

Fixed type-related compiler warnings in modeling.cpp