### PR TITLE
computeQualityScore now throws

### DIFF
--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2/features/FingerJetFXFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2/features/FingerJetFXFeature.h
@@ -132,6 +132,8 @@ class FingerJetFXFeature : BaseFeature {
 	static std::pair<unsigned int, unsigned int> centerOfMinutiaeMass(
 	    const std::vector<FingerJetFXFeature::Minutia> &minutiaData);
 
+	std::string parseFRFXLLError(FRFXLL_RESULT fxRes);
+
     private:
 	FRFXLL_RESULT
 	createContext(FRFXLL_HANDLE_PT phContext);

--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2/features/FingerJetFXFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2/features/FingerJetFXFeature.h
@@ -132,7 +132,7 @@ class FingerJetFXFeature : BaseFeature {
 	static std::pair<unsigned int, unsigned int> centerOfMinutiaeMass(
 	    const std::vector<FingerJetFXFeature::Minutia> &minutiaData);
 
-	std::string parseFRFXLLError(FRFXLL_RESULT fxRes);
+	static std::string parseFRFXLLError(FRFXLL_RESULT fxRes);
 
     private:
 	FRFXLL_RESULT

--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2/features/FingerJetFXFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2/features/FingerJetFXFeature.h
@@ -132,7 +132,7 @@ class FingerJetFXFeature : BaseFeature {
 	static std::pair<unsigned int, unsigned int> centerOfMinutiaeMass(
 	    const std::vector<FingerJetFXFeature::Minutia> &minutiaData);
 
-	static std::string parseFRFXLLError(FRFXLL_RESULT fxRes);
+	static std::string parseFRFXLLError(const FRFXLL_RESULT fxRes);
 
     private:
 	FRFXLL_RESULT

--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2/nfiq2.hpp
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2/nfiq2.hpp
@@ -43,6 +43,10 @@ class NFIQ2Algorithm {
 	 * @param qualityFeatureSpeed
 	 * List of feature computation speed
 	 *
+	 *
+	 * @throws NFIQException
+	 * Failure to compute (reason contained within message string).
+	 *
 	 * @return
 	 * Achieved quality score
 	 */

--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2/nfiq2.hpp
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2/nfiq2.hpp
@@ -26,8 +26,6 @@ class NFIQ2Algorithm {
 	 * Computes the quality score from the input fingerprint image
 	 * data.
 	 *
-	 * @throws NFIQ::exception failure to compute, reason in the message
-	 * string
 	 * @param rawImage
 	 * Fingerprint image in raw format
 	 * @param bComputeActionableQuality

--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2/nfiq2.hpp
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2/nfiq2.hpp
@@ -26,6 +26,8 @@ class NFIQ2Algorithm {
 	 * Computes the quality score from the input fingerprint image
 	 * data.
 	 *
+	 * @throws NFIQ::exception failure to compute, reason in the message
+	 * string
 	 * @param rawImage
 	 * Fingerprint image in raw format
 	 * @param bComputeActionableQuality

--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2/tool/nfiq2_ui_types.h
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2/tool/nfiq2_ui_types.h
@@ -138,6 +138,8 @@ struct CoreReturn {
 	std::list<NFIQ::ActionableQualityFeedback> actionableQuality;
 	/** Overall Quality Score for an Image */
 	unsigned int qualityScore;
+
+	std::string exceptionStr;
 };
 
 /**

--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2/tool/nfiq2_ui_types.h
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2/tool/nfiq2_ui_types.h
@@ -138,8 +138,6 @@ struct CoreReturn {
 	std::list<NFIQ::ActionableQualityFeedback> actionableQuality;
 	/** Overall Quality Score for an Image */
 	unsigned int qualityScore;
-
-	std::string exceptionStr;
 };
 
 /**

--- a/NFIQ2/NFIQ2Algorithm/src/features/FingerJetFXFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FingerJetFXFeature.cpp
@@ -31,25 +31,33 @@ FingerJetFXFeature::parseFRFXLLError(const FRFXLL_RESULT fxRes)
 {
 	switch (fxRes) {
 	case FRFXLL_ERR_FB_TOO_SMALL_AREA:
-		return "FRFXLL_ERR_FB_TOO_SMALL_AREA: Fingerprint area is too small. Most likely this is bacause the tip of the finger is presented.";
+		return "FRFXLL_ERR_FB_TOO_SMALL_AREA: Fingerprint area is too "
+		       "small. Most likely this is bacause the tip of the "
+		       "finger is presented.";
 	case FRFXLL_ERR_INVALID_PARAM:
-		return "FRFXLL_ERR_INVALID_PARAM: One or more of the parameters is invalid.";
+		return "FRFXLL_ERR_INVALID_PARAM: One or more of the "
+		       "parameters is invalid.";
 	case FRFXLL_ERR_NO_MEMORY:
-		return "FRFXLL_ERR_NO_MEMORY: There is not enough memory to perform the function.";
+		return "FRFXLL_ERR_NO_MEMORY: There is not enough memory to "
+		       "perform the function.";
 	case FRFXLL_ERR_MORE_DATA:
 		return "FRFXLL_ERR_MORE_DATA: More data is available.";
 	case FRFXLL_ERR_INTERNAL:
-		return "FRFXLL_ERR_INTERNAL: An unknown internal error has occurred.";
+		return "FRFXLL_ERR_INTERNAL: An unknown internal error has "
+		       "occurred.";
 	case FRFXLL_ERR_INVALID_BUFFER:
-		return "FRFXLL_ERR_INVALID_BUFFER: The image buffer is too small for in-place processing.";
+		return "FRFXLL_ERR_INVALID_BUFFER: The image buffer is too "
+		       "small for in-place processing.";
 	case FRFXLL_ERR_INVALID_HANDLE:
-		return "FRFXLL_ERR_INVALID_HANDLE: The specified handle is invalid.";
+		return "FRFXLL_ERR_INVALID_HANDLE: The specified handle is "
+		       "invalid.";
 	case FRFXLL_ERR_INVALID_IMAGE:
 		return "FRFXLL_ERR_INVALID_IMAGE: The image buffer is invalid.";
 	case FRFXLL_ERR_INVALID_DATA:
 		return "FRFXLL_ERR_INVALID_DATA: Supplied data is invalid.";
 	case FRFXLL_ERR_NO_FP:
-		return "FRFXLL_ERR_NO_FP: The specified finger or view is not present.";
+		return "FRFXLL_ERR_NO_FP: The specified finger or view is not "
+		       "present.";
 	default:
 		return "Unknown FRFXLL Error";
 	}

--- a/NFIQ2/NFIQ2Algorithm/src/features/FingerJetFXFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FingerJetFXFeature.cpp
@@ -26,6 +26,35 @@ FingerJetFXFeature::centerOfMinutiaeMass(
 	    lx / minutiaData.size(), ly / minutiaData.size());
 }
 
+std::string
+FingerJetFXFeature::parseFRFXLLError(FRFXLL_RESULT fxRes)
+{
+	switch (fxRes) {
+	case FRFXLL_ERR_FB_TOO_SMALL_AREA:
+		return "FRFXLL_ERR_FB_TOO_SMALL_AREA: Fingerprint area is too small. Most likely this is bacause the tip of the finger is presented.";
+	case FRFXLL_ERR_INVALID_PARAM:
+		return "FRFXLL_ERR_INVALID_PARAM: One or more of the parameters is invalid.";
+	case FRFXLL_ERR_NO_MEMORY:
+		return "FRFXLL_ERR_NO_MEMORY: There is not enough memory to perform the function.";
+	case FRFXLL_ERR_MORE_DATA:
+		return "FRFXLL_ERR_MORE_DATA: More data is available.";
+	case FRFXLL_ERR_INTERNAL:
+		return "FRFXLL_ERR_INTERNAL: An unknown internal error has occurred.";
+	case FRFXLL_ERR_INVALID_BUFFER:
+		return "FRFXLL_ERR_INVALID_BUFFER: The image buffer is too small for in-place processing.";
+	case FRFXLL_ERR_INVALID_HANDLE:
+		return "FRFXLL_ERR_INVALID_HANDLE: The specified handle is invalid.";
+	case FRFXLL_ERR_INVALID_IMAGE:
+		return "FRFXLL_ERR_INVALID_IMAGE: The image buffer is invalid.";
+	case FRFXLL_ERR_INVALID_DATA:
+		return "FRFXLL_ERR_INVALID_DATA: Supplied data is invalid.";
+	case FRFXLL_ERR_NO_FP:
+		return "FRFXLL_ERR_NO_FP: The specified finger or view is not present.";
+	default:
+		return "Unknown FRFXLL Error";
+	}
+}
+
 std::list<NFIQ::QualityFeatureResult>
 FingerJetFXFeature::computeFeatureData(
     const NFIQ::FingerprintImageData fingerprintImage,
@@ -97,7 +126,8 @@ FingerJetFXFeature::computeFeatureData(
 		throw NFIQ::NFIQException(
 		    NFIQ::
 			e_Error_FeatureCalculationError_FJFX_CannotCreateFeatureSet,
-		    "Could not create feature set from raw data.");
+		    "Could not create feature set from raw data: " +
+			FingerJetFXFeature::parseFRFXLLError(fxRes));
 	}
 
 	// close handle
@@ -110,12 +140,15 @@ FingerJetFXFeature::computeFeatureData(
 	}
 
 	unsigned int minCnt { 0 };
-	if (FRFXLLGetMinutiaInfo(hFeatureSet, &minCnt, nullptr) != FRFXLL_OK) {
+	FRFXLL_RESULT fxResMin = FRFXLLGetMinutiaInfo(
+	    hFeatureSet, &minCnt, nullptr);
+	if (fxResMin != FRFXLL_OK) {
 		FRFXLLCloseHandle(&hFeatureSet);
 		throw NFIQ::NFIQException(
 		    NFIQ::
 			e_Error_FeatureCalculationError_FJFX_NoFeatureSetCreated,
-		    "Failed to obtain Minutia Info from feature set.");
+		    "Failed to obtain Minutia Info from feature set: " +
+			FingerJetFXFeature::parseFRFXLLError(fxResMin));
 	}
 
 	std::unique_ptr<FRFXLL_Basic_19794_2_Minutia[]> mdata {};
@@ -127,13 +160,15 @@ FingerJetFXFeature::computeFeatureData(
 		    "Could not allocate space for extracted minutiae records.");
 	}
 
-	if (FRFXLLGetMinutiae(hFeatureSet, BASIC_19794_2_MINUTIA_STRUCT,
-		&minCnt, mdata.get()) != FRFXLL_OK) {
+	FRFXLL_RESULT fxResData = FRFXLLGetMinutiae(
+	    hFeatureSet, BASIC_19794_2_MINUTIA_STRUCT, &minCnt, mdata.get());
+	if (fxResData != FRFXLL_OK) {
 		FRFXLLCloseHandle(&hFeatureSet);
 		throw NFIQ::NFIQException(
 		    NFIQ::
 			e_Error_FeatureCalculationError_FJFX_NoFeatureSetCreated,
-		    "Failed to parse Minutia Data into 19794 Minutia Struct.");
+		    "Failed to parse Minutia Data into 19794 Minutia Struct: " +
+			FingerJetFXFeature::parseFRFXLLError(fxResData));
 	}
 
 	minutiaData.clear();

--- a/NFIQ2/NFIQ2Algorithm/src/features/FingerJetFXFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FingerJetFXFeature.cpp
@@ -27,7 +27,7 @@ FingerJetFXFeature::centerOfMinutiaeMass(
 }
 
 std::string
-FingerJetFXFeature::parseFRFXLLError(FRFXLL_RESULT fxRes)
+FingerJetFXFeature::parseFRFXLLError(const FRFXLL_RESULT fxRes)
 {
 	switch (fxRes) {
 	case FRFXLL_ERR_FB_TOO_SMALL_AREA:
@@ -115,7 +115,7 @@ FingerJetFXFeature::computeFeatureData(
 	}
 
 	// extract feature set
-	FRFXLL_RESULT fxRes = FRFXLLCreateFeatureSetFromRaw(hCtx,
+	const FRFXLL_RESULT fxRes = FRFXLLCreateFeatureSetFromRaw(hCtx,
 	    (unsigned char *)localFingerprintImage.data(),
 	    localFingerprintImage.size(), localFingerprintImage.m_ImageWidth,
 	    localFingerprintImage.m_ImageHeight,
@@ -140,7 +140,7 @@ FingerJetFXFeature::computeFeatureData(
 	}
 
 	unsigned int minCnt { 0 };
-	FRFXLL_RESULT fxResMin = FRFXLLGetMinutiaInfo(
+	const FRFXLL_RESULT fxResMin = FRFXLLGetMinutiaInfo(
 	    hFeatureSet, &minCnt, nullptr);
 	if (fxResMin != FRFXLL_OK) {
 		FRFXLLCloseHandle(&hFeatureSet);
@@ -160,7 +160,7 @@ FingerJetFXFeature::computeFeatureData(
 		    "Could not allocate space for extracted minutiae records.");
 	}
 
-	FRFXLL_RESULT fxResData = FRFXLLGetMinutiae(
+	const FRFXLL_RESULT fxResData = FRFXLLGetMinutiae(
 	    hFeatureSet, BASIC_19794_2_MINUTIA_STRUCT, &minCnt, mdata.get());
 	if (fxResData != FRFXLL_OK) {
 		FRFXLLCloseHandle(&hFeatureSet);

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2impl.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2impl.cpp
@@ -407,8 +407,12 @@ NFIQ2Algorithm::Impl::computeQualityScore(NFIQ::FingerprintImageData rawImage,
 {
 	// crop image (white line removal) and use it for feature
 	// computation
-	NFIQ::FingerprintImageData croppedRawImage =
-	    rawImage.removeWhiteFrameAroundFingerprint();
+	NFIQ::FingerprintImageData croppedRawImage {};
+	try {
+		croppedRawImage = rawImage.removeWhiteFrameAroundFingerprint();
+	} catch (const NFIQ::NFIQException &) {
+		throw;
+	}
 
 	// --------------------------------------------------------
 	// compute quality features (including actionable feedback)

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2impl.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2impl.cpp
@@ -389,8 +389,8 @@ double
 NFIQ2Algorithm::Impl::getQualityPrediction(
     std::list<NFIQ::QualityFeatureData> &featureVector) const
 {
-	const double utility = 0.0;
-	double deviation = 0.0;
+	const double utility {};
+	double deviation {};
 	double quality {};
 	m_RandomForestML.evaluate(featureVector, utility, quality, deviation);
 

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2impl.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2impl.cpp
@@ -408,7 +408,6 @@ NFIQ2Algorithm::Impl::computeQualityScore(NFIQ::FingerprintImageData rawImage,
     std::list<NFIQ::QualityFeatureData> &qualityFeatureData, bool bOutputSpeed,
     std::list<NFIQ::QualityFeatureSpeed> &qualityFeatureSpeed) const
 {
-	try {
 		// crop image (white line removal) and use it for feature
 		// computation
 		NFIQ::FingerprintImageData croppedRawImage =
@@ -441,12 +440,7 @@ NFIQ2Algorithm::Impl::computeQualityScore(NFIQ::FingerprintImageData rawImage,
 		}
 
 		return (unsigned int)qualityScore;
-	} catch (...) {
-		// any algorithmic exception is mapped to a quality score of 255
-		// representing "quality not able to be computed"
-		return QUALITY_SCORE_NOT_AVAILABLE;
-	}
-	return QUALITY_SCORE_NOT_AVAILABLE;
+
 }
 
 std::vector<std::string>

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2impl.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2impl.cpp
@@ -421,6 +421,12 @@ NFIQ2Algorithm::Impl::computeQualityScore(NFIQ::FingerprintImageData rawImage,
 		    qualityFeatureSpeed);
 	} catch (const NFIQ::NFIQException &e) {
 		throw;
+	} catch (const std::exception &e) {
+		/*
+		 * Nothing should get here, but computeQualityFeatures() calls
+		 * a lot of code...
+		 */
+		throw NFIQ::NFIQException(e_Error_UnknownError, e.what());
 	}
 
 	if (featureVector.size() == 0) {

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2impl.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2impl.cpp
@@ -423,7 +423,7 @@ NFIQ2Algorithm::Impl::computeQualityScore(NFIQ::FingerprintImageData rawImage,
 		featureVector = computeQualityFeatures(croppedRawImage,
 		    bComputeActionableQuality, actionableQuality, bOutputSpeed,
 		    qualityFeatureSpeed);
-	} catch (const NFIQ::NFIQException &e) {
+	} catch (const NFIQ::NFIQException &) {
 		throw;
 	} catch (const std::exception &e) {
 		/*
@@ -446,7 +446,7 @@ NFIQ2Algorithm::Impl::computeQualityScore(NFIQ::FingerprintImageData rawImage,
 	double qualityScore {};
 	try {
 		qualityScore = getQualityPrediction(featureVector);
-	} catch (const NFIQ::NFIQException &e) {
+	} catch (const NFIQ::NFIQException &) {
 		throw;
 	}
 

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2impl.h
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2impl.h
@@ -49,8 +49,8 @@ class NFIQ2Algorithm::Impl {
 	 * @fn computeQualityScore
 	 * @brief Computes the quality score from the input fingerprint image
 	 * data
-	 * @throws NFIQ::exception failure to compute, reason in the message
-	 * string
+	 * @throws NFIQException
+	 * Failure to compute (reason contained within message string).
 	 * @param rawImage fingerprint image in raw format
 	 * @param bComputeActionableQuality if to compute actionable quality
 	 * flags or not
@@ -113,6 +113,11 @@ class NFIQ2Algorithm::Impl {
 	    std::list<NFIQ::ActionableQualityFeedback> &actionableQuality,
 	    bool bOutputSpeed,
 	    std::list<NFIQ::QualityFeatureSpeed> &speedValues) const;
+
+	/**
+	 * @throws NFIQException
+	 * Failure to compute (OpenCV reason contained within message string).
+	 */
 	double getQualityPrediction(
 	    std::list<NFIQ::QualityFeatureData> &featureVector) const;
 

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2impl.h
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2impl.h
@@ -49,6 +49,8 @@ class NFIQ2Algorithm::Impl {
 	 * @fn computeQualityScore
 	 * @brief Computes the quality score from the input fingerprint image
 	 * data
+	 * @throws NFIQ::exception failure to compute, reason in the message
+	 * string
 	 * @param rawImage fingerprint image in raw format
 	 * @param bComputeActionableQuality if to compute actionable quality
 	 * flags or not

--- a/NFIQ2/NFIQ2Algorithm/src/prediction/RandomForestML.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/prediction/RandomForestML.cpp
@@ -103,8 +103,7 @@ RandomForestML::initModule()
 		initModule(params);
 		return calculateHashString(params);
 	} catch (const cv::Exception &e) {
-		std::cout << e.msg.c_str() << std::endl;
-		throw e;
+		throw NFIQException(e_Error_UnknownError, e.msg);
 	} catch (...) {
 		throw;
 	}
@@ -195,8 +194,7 @@ RandomForestML::evaluate(
 #endif
 
 	} catch (const cv::Exception &e) {
-		std::cout << e.msg.c_str() << std::endl;
-		throw e;
+		throw NFIQException(e_Error_MachineLearningError, e.msg);
 	}
 }
 

--- a/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_refresh.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_refresh.cpp
@@ -304,7 +304,7 @@ NFIQ2UI::coreCompute(const NFIQ::FingerprintImageData &wrappedImage,
 	std::list<NFIQ::QualityFeatureData> featureVector;
 	std::list<NFIQ::QualityFeatureSpeed> featureTimings;
 
-	unsigned int qualityScore = 255;
+	unsigned int qualityScore{};
 
 	try {
 		qualityScore = model.computeQualityScore(wrappedImage, true,

--- a/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_refresh.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_refresh.cpp
@@ -304,7 +304,7 @@ NFIQ2UI::coreCompute(const NFIQ::FingerprintImageData &wrappedImage,
 	std::list<NFIQ::QualityFeatureData> featureVector;
 	std::list<NFIQ::QualityFeatureSpeed> featureTimings;
 
-	unsigned int qualityScore{};
+	unsigned int qualityScore {};
 
 	try {
 		qualityScore = model.computeQualityScore(wrappedImage, true,

--- a/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_refresh.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_refresh.cpp
@@ -262,7 +262,7 @@ NFIQ2UI::executeSingle(std::shared_ptr<BE::Image::Image> img,
 	if (corereturn.qualityScore > 100) {
 		logger->printError(name, fingerPosition,
 		    corereturn.qualityScore,
-		    "NFIQ2 computeQualityScore returned an error code",
+		    "NFIQ2 computeQualityScore returned an error code" + corereturn.exceptionStr,
 		    quantized, resampled);
 		return;
 	}
@@ -302,12 +302,19 @@ NFIQ2UI::coreCompute(const NFIQ::FingerprintImageData &wrappedImage,
 	std::list<NFIQ::QualityFeatureData> featureVector;
 	std::list<NFIQ::QualityFeatureSpeed> featureTimings;
 
-	const unsigned int qualityScore = model.computeQualityScore(
+	unsigned int qualityScore = 255;
+	std::string exceptionStr = "";
+
+	try {
+		qualityScore = model.computeQualityScore(
 	    wrappedImage, true, actionableQuality, true, featureVector, true,
 	    featureTimings);
+	} catch (const NFIQ::NFIQException &e) {
+		exceptionStr = e.what();
+	}
 
 	const CoreReturn corereturn { featureVector, featureTimings,
-		actionableQuality, qualityScore };
+		actionableQuality, qualityScore, exceptionStr };
 	return corereturn;
 }
 

--- a/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_refresh.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_refresh.cpp
@@ -250,9 +250,9 @@ NFIQ2UI::executeSingle(std::shared_ptr<BE::Image::Image> img,
 	// resolution. Quantization will happen below if necessary.
 
 	const NFIQ::FingerprintImageData wrappedImage = resampled ?
-	    NFIQ::FingerprintImageData(postResample.data, postResample.total(),
+		  NFIQ::FingerprintImageData(postResample.data, postResample.total(),
 		postResample.cols, postResample.rows, fingerPosition, 500) :
-	    NFIQ::FingerprintImageData(grayscaleRawData,
+		  NFIQ::FingerprintImageData(grayscaleRawData,
 		grayscaleRawData.size(), imageWidth, imageHeight,
 		fingerPosition, imageDPI);
 
@@ -311,7 +311,7 @@ NFIQ2UI::coreCompute(const NFIQ::FingerprintImageData &wrappedImage,
 		    actionableQuality, true, featureVector, true,
 		    featureTimings);
 	} catch (const NFIQ::NFIQException &e) {
-		throw e;
+		throw;
 	}
 
 	const CoreReturn corereturn { featureVector, featureTimings,
@@ -888,20 +888,20 @@ main(int argc, char **argv)
 
 	logger->debugMsg("Model Name: " +
 	    (modelInfoObj.getModelName().empty() ?
-		    "<NA>" :
-		    modelInfoObj.getModelName()));
+			  "<NA>" :
+			  modelInfoObj.getModelName()));
 	logger->debugMsg("Model Trainer: " +
 	    (modelInfoObj.getModelTrainer().empty() ?
-		    "<NA>" :
-		    modelInfoObj.getModelTrainer()));
+			  "<NA>" :
+			  modelInfoObj.getModelTrainer()));
 	logger->debugMsg("Model Description: " +
 	    (modelInfoObj.getModelDescription().empty() ?
-		    "<NA>" :
-		    modelInfoObj.getModelDescription()));
+			  "<NA>" :
+			  modelInfoObj.getModelDescription()));
 	logger->debugMsg("Model Version: " +
 	    (modelInfoObj.getModelVersion().empty() ?
-		    "<NA>" :
-		    modelInfoObj.getModelVersion()));
+			  "<NA>" :
+			  modelInfoObj.getModelVersion()));
 	logger->debugMsg("Model Path: " + modelInfoObj.getModelPath());
 	logger->debugMsg("Model Hash: " + modelInfoObj.getModelHash());
 

--- a/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_refresh.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_refresh.cpp
@@ -262,7 +262,7 @@ NFIQ2UI::executeSingle(std::shared_ptr<BE::Image::Image> img,
 	if (corereturn.qualityScore > 100) {
 		logger->printError(name, fingerPosition,
 		    corereturn.qualityScore,
-		    "NFIQ2 computeQualityScore returned an error code" + corereturn.exceptionStr,
+		    "NFIQ2 computeQualityScore returned an error code: " + corereturn.exceptionStr,
 		    quantized, resampled);
 		return;
 	}


### PR DESCRIPTION
computeQualityScore now throws an exception so that more information can be provided to the output in the case that an image fails to receive an nfiq2 quality score. This will tell us which exact metric failed which will help with debugging in the future. 

Also added additional error parsing for FJFX. This will allow us to see which error we are receiving in case it fails. 

Removed references to 255 error score. Since computeQualityScore now throws, there is no need to have 255 be represented as a score. CSV output will be updated in a later PR to reflect this change.