### PR TITLE
Removing 255 Error Score

### DIFF
--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2/tool/nfiq2_ui_log.h
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2/tool/nfiq2_ui_log.h
@@ -98,7 +98,7 @@ class Log {
 	 *  @details
 	 *    Prints Error scores generated from NFIQ2 for images that failed
 	 *    processing.
-	 *    Error code 255 is printed if image could not be evaluated and
+	 *    Error 'NA' is printed if image could not be evaluated and
 	 * padding is added to ensure consistency.
 	 *
 	 *  @param[in] name
@@ -115,7 +115,7 @@ class Log {
 	 *    If the image was resampled 0 = not resampled, 1 = resampled.
 	 */
 	void printError(const std::string &name, uint8_t fingerCode,
-	    unsigned int score, const std::string &errmsg, const bool quantized,
+	    const std::string &errscore, const std::string &errmsg, const bool quantized,
 	    const bool resampled) const;
 
 	/**

--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2/tool/nfiq2_ui_log.h
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2/tool/nfiq2_ui_log.h
@@ -105,8 +105,6 @@ class Log {
 	 *    The name of the image.
 	 *  @param[in] fingerCode
 	 *    Finger position of the image. Valid values: 0-12.
-	 *  @param[in] score
-	 *    Calculated NFIQ2 Score.
 	 *  @param[in] errmsg
 	 *    Error message if applicable. Will be "NA" otherwise
 	 *  @param[in] quantized
@@ -115,8 +113,8 @@ class Log {
 	 *    If the image was resampled 0 = not resampled, 1 = resampled.
 	 */
 	void printError(const std::string &name, uint8_t fingerCode,
-	    const std::string &errscore, const std::string &errmsg,
-	    const bool quantized, const bool resampled) const;
+	    const std::string &errmsg, const bool quantized,
+	    const bool resampled) const;
 
 	/**
 	 *  @brief

--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2/tool/nfiq2_ui_log.h
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2/tool/nfiq2_ui_log.h
@@ -115,8 +115,8 @@ class Log {
 	 *    If the image was resampled 0 = not resampled, 1 = resampled.
 	 */
 	void printError(const std::string &name, uint8_t fingerCode,
-	    const std::string &errscore, const std::string &errmsg, const bool quantized,
-	    const bool resampled) const;
+	    const std::string &errscore, const std::string &errmsg,
+	    const bool quantized, const bool resampled) const;
 
 	/**
 	 *  @brief

--- a/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_image.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_image.cpp
@@ -51,7 +51,7 @@ NFIQ2UI::getImages(const BE::Memory::uint8Array &dataArray,
 	default:
 		logger->debugMsg("Image type could not be determined. " + name +
 		    " will not be processed");
-		logger->printError(name, 0, "'NA'",
+		logger->printError(name, 0, "NA",
 		    "'Error: Could not determine FileType'", 0, 0);
 
 		return vecCouple;
@@ -78,8 +78,8 @@ NFIQ2UI::getImages(
 		std::string error {
 			"'Error: Could not obtain data from path : "
 		};
-		logger->printError(path, 0, "'NA'",
-		    error.append(e.what()) + "'", false, false);
+		logger->printError(
+		    path, 0, "NA", error.append(e.what()) + "'", false, false);
 	}
 
 	return vecCouple;
@@ -105,7 +105,7 @@ NFIQ2UI::getImagesFromImage(const BE::Memory::uint8Array &dataArray,
 		// Unable to open the image
 		std::string error { "'Error: Could not open image : " };
 		logger->printError(
-		    name, 0, "'NA'", error.append(e.what()) + "'", 0, 0);
+		    name, 0, "NA", error.append(e.what()) + "'", 0, 0);
 	}
 	return vecCouple;
 }
@@ -129,7 +129,7 @@ NFIQ2UI::getImagesFromAN2K(const BE::Memory::uint8Array &dataArray,
 			"'Error AN2K Record could not be opened : "
 		};
 		logger->printError(
-		    name, 0, "'NA'", error.append(e.what()) + "'", 0, 0);
+		    name, 0, "NA", error.append(e.what()) + "'", 0, 0);
 		return vecCouple;
 	}
 
@@ -211,7 +211,7 @@ NFIQ2UI::getImagesFromAN2K(const BE::Memory::uint8Array &dataArray,
 
 			logger->printError(
 			    name + "_" + std::to_string(fingerPosition),
-			    static_cast<uint8_t>(fingerPosition), "'NA'",
+			    static_cast<uint8_t>(fingerPosition), "NA",
 			    "'Error: Invalid FingerPosition for NFIQ2 (not "
 			    "0-12)'",
 			    0, 0);
@@ -245,7 +245,7 @@ NFIQ2UI::getImagesFromANSI2004(const BE::Memory::uint8Array &dataArray,
 			"'ERROR: ANSI2004 RECORD COULD NOT BE OPENED : "
 		};
 		logger->printError(
-		    name, 0, "'NA'", error.append(e.what()) + "'", 0, 0);
+		    name, 0, "NA", error.append(e.what()) + "'", 0, 0);
 		return vecCouple;
 	}
 
@@ -327,7 +327,7 @@ NFIQ2UI::getImagesFromANSI2004(const BE::Memory::uint8Array &dataArray,
 
 			logger->printError(
 			    name + "_" + std::to_string(fingerPosition),
-			    static_cast<uint8_t>(fingerPosition), "'NA'",
+			    static_cast<uint8_t>(fingerPosition), "NA",
 			    "'Error: Invalid finger print position for "
 			    "NFIQ2'",
 			    0, 0);

--- a/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_image.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_image.cpp
@@ -78,8 +78,8 @@ NFIQ2UI::getImages(
 		std::string error {
 			"'Error: Could not obtain data from path : "
 		};
-		logger->printError(
-		    path, 0, "'NA'", error.append(e.what()) + "'", false, false);
+		logger->printError(path, 0, "'NA'",
+		    error.append(e.what()) + "'", false, false);
 	}
 
 	return vecCouple;

--- a/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_image.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_image.cpp
@@ -51,8 +51,8 @@ NFIQ2UI::getImages(const BE::Memory::uint8Array &dataArray,
 	default:
 		logger->debugMsg("Image type could not be determined. " + name +
 		    " will not be processed");
-		logger->printError(name, 0, "NA",
-		    "'Error: Could not determine FileType'", 0, 0);
+		logger->printError(
+		    name, 0, "'Error: Could not determine FileType'", 0, 0);
 
 		return vecCouple;
 	}
@@ -79,7 +79,7 @@ NFIQ2UI::getImages(
 			"'Error: Could not obtain data from path : "
 		};
 		logger->printError(
-		    path, 0, "NA", error.append(e.what()) + "'", false, false);
+		    path, 0, error.append(e.what()) + "'", false, false);
 	}
 
 	return vecCouple;
@@ -104,8 +104,7 @@ NFIQ2UI::getImagesFromImage(const BE::Memory::uint8Array &dataArray,
 	} catch (const BE::Error::Exception &e) {
 		// Unable to open the image
 		std::string error { "'Error: Could not open image : " };
-		logger->printError(
-		    name, 0, "NA", error.append(e.what()) + "'", 0, 0);
+		logger->printError(name, 0, error.append(e.what()) + "'", 0, 0);
 	}
 	return vecCouple;
 }
@@ -128,8 +127,7 @@ NFIQ2UI::getImagesFromAN2K(const BE::Memory::uint8Array &dataArray,
 		std::string error {
 			"'Error AN2K Record could not be opened : "
 		};
-		logger->printError(
-		    name, 0, "NA", error.append(e.what()) + "'", 0, 0);
+		logger->printError(name, 0, error.append(e.what()) + "'", 0, 0);
 		return vecCouple;
 	}
 
@@ -211,7 +209,7 @@ NFIQ2UI::getImagesFromAN2K(const BE::Memory::uint8Array &dataArray,
 
 			logger->printError(
 			    name + "_" + std::to_string(fingerPosition),
-			    static_cast<uint8_t>(fingerPosition), "NA",
+			    static_cast<uint8_t>(fingerPosition),
 			    "'Error: Invalid FingerPosition for NFIQ2 (not "
 			    "0-12)'",
 			    0, 0);
@@ -244,8 +242,7 @@ NFIQ2UI::getImagesFromANSI2004(const BE::Memory::uint8Array &dataArray,
 		std::string error {
 			"'ERROR: ANSI2004 RECORD COULD NOT BE OPENED : "
 		};
-		logger->printError(
-		    name, 0, "NA", error.append(e.what()) + "'", 0, 0);
+		logger->printError(name, 0, error.append(e.what()) + "'", 0, 0);
 		return vecCouple;
 	}
 
@@ -327,7 +324,7 @@ NFIQ2UI::getImagesFromANSI2004(const BE::Memory::uint8Array &dataArray,
 
 			logger->printError(
 			    name + "_" + std::to_string(fingerPosition),
-			    static_cast<uint8_t>(fingerPosition), "NA",
+			    static_cast<uint8_t>(fingerPosition),
 			    "'Error: Invalid finger print position for "
 			    "NFIQ2'",
 			    0, 0);

--- a/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_image.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_image.cpp
@@ -51,7 +51,7 @@ NFIQ2UI::getImages(const BE::Memory::uint8Array &dataArray,
 	default:
 		logger->debugMsg("Image type could not be determined. " + name +
 		    " will not be processed");
-		logger->printError(name, 0, 255,
+		logger->printError(name, 0, "'NA'",
 		    "'Error: Could not determine FileType'", 0, 0);
 
 		return vecCouple;
@@ -79,7 +79,7 @@ NFIQ2UI::getImages(
 			"'Error: Could not obtain data from path : "
 		};
 		logger->printError(
-		    path, 0, 255, error.append(e.what()) + "'", false, false);
+		    path, 0, "'NA'", error.append(e.what()) + "'", false, false);
 	}
 
 	return vecCouple;
@@ -105,7 +105,7 @@ NFIQ2UI::getImagesFromImage(const BE::Memory::uint8Array &dataArray,
 		// Unable to open the image
 		std::string error { "'Error: Could not open image : " };
 		logger->printError(
-		    name, 0, 255, error.append(e.what()) + "'", 0, 0);
+		    name, 0, "'NA'", error.append(e.what()) + "'", 0, 0);
 	}
 	return vecCouple;
 }
@@ -129,7 +129,7 @@ NFIQ2UI::getImagesFromAN2K(const BE::Memory::uint8Array &dataArray,
 			"'Error AN2K Record could not be opened : "
 		};
 		logger->printError(
-		    name, 0, 255, error.append(e.what()) + "'", 0, 0);
+		    name, 0, "'NA'", error.append(e.what()) + "'", 0, 0);
 		return vecCouple;
 	}
 
@@ -211,7 +211,7 @@ NFIQ2UI::getImagesFromAN2K(const BE::Memory::uint8Array &dataArray,
 
 			logger->printError(
 			    name + "_" + std::to_string(fingerPosition),
-			    static_cast<uint8_t>(fingerPosition), 255,
+			    static_cast<uint8_t>(fingerPosition), "'NA'",
 			    "'Error: Invalid FingerPosition for NFIQ2 (not "
 			    "0-12)'",
 			    0, 0);
@@ -245,7 +245,7 @@ NFIQ2UI::getImagesFromANSI2004(const BE::Memory::uint8Array &dataArray,
 			"'ERROR: ANSI2004 RECORD COULD NOT BE OPENED : "
 		};
 		logger->printError(
-		    name, 0, 255, error.append(e.what()) + "'", 0, 0);
+		    name, 0, "'NA'", error.append(e.what()) + "'", 0, 0);
 		return vecCouple;
 	}
 
@@ -327,7 +327,7 @@ NFIQ2UI::getImagesFromANSI2004(const BE::Memory::uint8Array &dataArray,
 
 			logger->printError(
 			    name + "_" + std::to_string(fingerPosition),
-			    static_cast<uint8_t>(fingerPosition), 255,
+			    static_cast<uint8_t>(fingerPosition), "'NA'",
 			    "'Error: Invalid finger print position for "
 			    "NFIQ2'",
 			    0, 0);

--- a/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_log.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_log.cpp
@@ -136,7 +136,7 @@ void
 NFIQ2UI::Log::printError(const std::string &name, uint8_t fingerCode,
     const std::string &errmsg, const bool quantized, const bool resampled) const
 {
-	const std::string errscore { "NA" };
+	static const std::string errscore { "NA" };
 	*(this->out) << name << "," << std::to_string(fingerCode) << ","
 		     << errscore << "," << errmsg << "," << quantized << ","
 		     << resampled << padNA() << "\n";

--- a/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_log.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_log.cpp
@@ -134,11 +134,11 @@ NFIQ2UI::Log::padNA() const
 // Prints out an error score if the image was unable to be processed correctly
 void
 NFIQ2UI::Log::printError(const std::string &name, uint8_t fingerCode,
-    unsigned int score, const std::string &errmsg, const bool quantized,
+    const std::string &errscore, const std::string &errmsg, const bool quantized,
     const bool resampled) const
 {
 	*(this->out) << name << "," << std::to_string(fingerCode) << ","
-		     << score << "," << errmsg << "," << quantized << ","
+		     << errscore << "," << errmsg << "," << quantized << ","
 		     << resampled << padNA() << "\n";
 }
 

--- a/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_log.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_log.cpp
@@ -134,9 +134,9 @@ NFIQ2UI::Log::padNA() const
 // Prints out an error score if the image was unable to be processed correctly
 void
 NFIQ2UI::Log::printError(const std::string &name, uint8_t fingerCode,
-    const std::string &errscore, const std::string &errmsg,
-    const bool quantized, const bool resampled) const
+    const std::string &errmsg, const bool quantized, const bool resampled) const
 {
+	const std::string errscore { "NA" };
 	*(this->out) << name << "," << std::to_string(fingerCode) << ","
 		     << errscore << "," << errmsg << "," << quantized << ","
 		     << resampled << padNA() << "\n";

--- a/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_log.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_log.cpp
@@ -134,8 +134,8 @@ NFIQ2UI::Log::padNA() const
 // Prints out an error score if the image was unable to be processed correctly
 void
 NFIQ2UI::Log::printError(const std::string &name, uint8_t fingerCode,
-    const std::string &errscore, const std::string &errmsg, const bool quantized,
-    const bool resampled) const
+    const std::string &errscore, const std::string &errmsg,
+    const bool quantized, const bool resampled) const
 {
 	*(this->out) << name << "," << std::to_string(fingerCode) << ","
 		     << errscore << "," << errmsg << "," << quantized << ","

--- a/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_refresh.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_refresh.cpp
@@ -96,14 +96,14 @@ NFIQ2UI::executeSingle(std::shared_ptr<BE::Image::Image> img,
 					logger->debugMsg(
 					    "User denied the quantize");
 					logger->printError(name, fingerPosition,
-					    255,
+					    "'NA'",
 					    "'Error: User chose not to "
 					    "quantize image'",
 					    quantized, resampled);
 					return;
 				}
 			} else {
-				logger->printError(name, fingerPosition, 255,
+				logger->printError(name, fingerPosition, "'NA'",
 				    "'Error: image is not 8 bit or 1 bit"
 				    "depth and/or color'",
 				    quantized, resampled);
@@ -135,7 +135,7 @@ NFIQ2UI::executeSingle(std::shared_ptr<BE::Image::Image> img,
 		std::string error {
 			"'Error: Could not get Grayscale raw data from image'"
 		};
-		logger->printError(name, fingerPosition, 255,
+		logger->printError(name, fingerPosition, "'NA'",
 		    error.append(e.what()), quantized, resampled);
 		return;
 	}
@@ -165,7 +165,7 @@ NFIQ2UI::executeSingle(std::shared_ptr<BE::Image::Image> img,
 				    imageDPI, 500, "", "");
 
 			} catch (const cv::Exception &e) {
-				logger->printError(name, fingerPosition, 255,
+				logger->printError(name, fingerPosition, "'NA'",
 				    "'Error: Matrix creation error: " + e.msg +
 					"'",
 				    quantized, resampled);
@@ -173,7 +173,7 @@ NFIQ2UI::executeSingle(std::shared_ptr<BE::Image::Image> img,
 
 			} catch (const NFIR::Miscue &e) {
 				const std::string errStr { e.what() };
-				logger->printError(name, fingerPosition, 255,
+				logger->printError(name, fingerPosition, "'NA'",
 				    "'" + errStr + "'", quantized, resampled);
 				return;
 			}
@@ -204,7 +204,7 @@ NFIQ2UI::executeSingle(std::shared_ptr<BE::Image::Image> img,
 
 					} catch (const cv::Exception &e) {
 						logger->printError(name,
-						    fingerPosition, 255,
+						    fingerPosition, "'NA'",
 						    "'Error: Matrix creation error: " +
 							e.msg + "'",
 						    quantized, resampled);
@@ -215,7 +215,7 @@ NFIQ2UI::executeSingle(std::shared_ptr<BE::Image::Image> img,
 							e.what()
 						};
 						logger->printError(name,
-						    fingerPosition, 255,
+						    fingerPosition, "'NA'",
 						    "'" + errStr + "'",
 						    quantized, resampled);
 						return;
@@ -227,7 +227,7 @@ NFIQ2UI::executeSingle(std::shared_ptr<BE::Image::Image> img,
 					    "User denied the re-sample");
 					if (!singleImage) {
 						logger->printError(name,
-						    fingerPosition, 255,
+						    fingerPosition, "'NA'",
 						    "'Error: User chose not to "
 						    "re-sample image'",
 						    quantized, resampled);
@@ -236,7 +236,7 @@ NFIQ2UI::executeSingle(std::shared_ptr<BE::Image::Image> img,
 				}
 
 			} else {
-				logger->printError(name, fingerPosition, 255,
+				logger->printError(name, fingerPosition, "'NA'",
 				    "'Error: Image is not 500PPI'", quantized,
 				    resampled);
 				return;
@@ -262,7 +262,7 @@ NFIQ2UI::executeSingle(std::shared_ptr<BE::Image::Image> img,
 		corereturn = NFIQ2UI::coreCompute(wrappedImage, model);
 	} catch (const NFIQ::NFIQException &e) {
 		const std::string expMsg { e.what() };
-		logger->printError(name, fingerPosition, 255,
+		logger->printError(name, fingerPosition, "'NA'",
 		    "'NFIQ2 computeQualityScore returned an error code: " +
 			expMsg + "'",
 		    quantized, resampled);
@@ -518,7 +518,7 @@ NFIQ2UI::recordStoreConsume(const std::string &name,
 	} catch (const BE::Error::Exception &e) {
 		std::string error { "'Error: Could not open RecordStore'" };
 		threadedlogger->printError(
-		    name, 0, 255, error.append(e.what()), false, false);
+		    name, 0, "'NA'", error.append(e.what()), false, false);
 		return;
 	}
 
@@ -556,7 +556,7 @@ NFIQ2UI::executeRecordStore(const std::string &filename, const Flags &flags,
 	} catch (const BE::Error::Exception &e) {
 		std::string error { "'Error: Could not open RecordStore'" };
 		logger->printError(
-		    filename, 0, 255, error.append(e.what()), false, false);
+		    filename, 0, "'NA'", error.append(e.what()), false, false);
 		return;
 	}
 

--- a/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_refresh.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_refresh.cpp
@@ -96,14 +96,14 @@ NFIQ2UI::executeSingle(std::shared_ptr<BE::Image::Image> img,
 					logger->debugMsg(
 					    "User denied the quantize");
 					logger->printError(name, fingerPosition,
-					    "'NA'",
+					    "NA",
 					    "'Error: User chose not to "
 					    "quantize image'",
 					    quantized, resampled);
 					return;
 				}
 			} else {
-				logger->printError(name, fingerPosition, "'NA'",
+				logger->printError(name, fingerPosition, "NA",
 				    "'Error: image is not 8 bit or 1 bit"
 				    "depth and/or color'",
 				    quantized, resampled);
@@ -135,7 +135,7 @@ NFIQ2UI::executeSingle(std::shared_ptr<BE::Image::Image> img,
 		std::string error {
 			"'Error: Could not get Grayscale raw data from image'"
 		};
-		logger->printError(name, fingerPosition, "'NA'",
+		logger->printError(name, fingerPosition, "NA",
 		    error.append(e.what()), quantized, resampled);
 		return;
 	}
@@ -165,7 +165,7 @@ NFIQ2UI::executeSingle(std::shared_ptr<BE::Image::Image> img,
 				    imageDPI, 500, "", "");
 
 			} catch (const cv::Exception &e) {
-				logger->printError(name, fingerPosition, "'NA'",
+				logger->printError(name, fingerPosition, "NA",
 				    "'Error: Matrix creation error: " + e.msg +
 					"'",
 				    quantized, resampled);
@@ -173,7 +173,7 @@ NFIQ2UI::executeSingle(std::shared_ptr<BE::Image::Image> img,
 
 			} catch (const NFIR::Miscue &e) {
 				const std::string errStr { e.what() };
-				logger->printError(name, fingerPosition, "'NA'",
+				logger->printError(name, fingerPosition, "NA",
 				    "'" + errStr + "'", quantized, resampled);
 				return;
 			}
@@ -204,7 +204,7 @@ NFIQ2UI::executeSingle(std::shared_ptr<BE::Image::Image> img,
 
 					} catch (const cv::Exception &e) {
 						logger->printError(name,
-						    fingerPosition, "'NA'",
+						    fingerPosition, "NA",
 						    "'Error: Matrix creation error: " +
 							e.msg + "'",
 						    quantized, resampled);
@@ -215,7 +215,7 @@ NFIQ2UI::executeSingle(std::shared_ptr<BE::Image::Image> img,
 							e.what()
 						};
 						logger->printError(name,
-						    fingerPosition, "'NA'",
+						    fingerPosition, "NA",
 						    "'" + errStr + "'",
 						    quantized, resampled);
 						return;
@@ -227,7 +227,7 @@ NFIQ2UI::executeSingle(std::shared_ptr<BE::Image::Image> img,
 					    "User denied the re-sample");
 					if (!singleImage) {
 						logger->printError(name,
-						    fingerPosition, "'NA'",
+						    fingerPosition, "NA",
 						    "'Error: User chose not to "
 						    "re-sample image'",
 						    quantized, resampled);
@@ -236,7 +236,7 @@ NFIQ2UI::executeSingle(std::shared_ptr<BE::Image::Image> img,
 				}
 
 			} else {
-				logger->printError(name, fingerPosition, "'NA'",
+				logger->printError(name, fingerPosition, "NA",
 				    "'Error: Image is not 500PPI'", quantized,
 				    resampled);
 				return;
@@ -262,7 +262,7 @@ NFIQ2UI::executeSingle(std::shared_ptr<BE::Image::Image> img,
 		corereturn = NFIQ2UI::coreCompute(wrappedImage, model);
 	} catch (const NFIQ::NFIQException &e) {
 		const std::string expMsg { e.what() };
-		logger->printError(name, fingerPosition, "'NA'",
+		logger->printError(name, fingerPosition, "NA",
 		    "'NFIQ2 computeQualityScore returned an error code: " +
 			expMsg + "'",
 		    quantized, resampled);
@@ -518,7 +518,7 @@ NFIQ2UI::recordStoreConsume(const std::string &name,
 	} catch (const BE::Error::Exception &e) {
 		std::string error { "'Error: Could not open RecordStore'" };
 		threadedlogger->printError(
-		    name, 0, "'NA'", error.append(e.what()), false, false);
+		    name, 0, "NA", error.append(e.what()), false, false);
 		return;
 	}
 
@@ -556,7 +556,7 @@ NFIQ2UI::executeRecordStore(const std::string &filename, const Flags &flags,
 	} catch (const BE::Error::Exception &e) {
 		std::string error { "'Error: Could not open RecordStore'" };
 		logger->printError(
-		    filename, 0, "'NA'", error.append(e.what()), false, false);
+		    filename, 0, "NA", error.append(e.what()), false, false);
 		return;
 	}
 

--- a/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_refresh.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_refresh.cpp
@@ -96,14 +96,13 @@ NFIQ2UI::executeSingle(std::shared_ptr<BE::Image::Image> img,
 					logger->debugMsg(
 					    "User denied the quantize");
 					logger->printError(name, fingerPosition,
-					    "NA",
 					    "'Error: User chose not to "
 					    "quantize image'",
 					    quantized, resampled);
 					return;
 				}
 			} else {
-				logger->printError(name, fingerPosition, "NA",
+				logger->printError(name, fingerPosition,
 				    "'Error: image is not 8 bit or 1 bit"
 				    "depth and/or color'",
 				    quantized, resampled);
@@ -135,8 +134,8 @@ NFIQ2UI::executeSingle(std::shared_ptr<BE::Image::Image> img,
 		std::string error {
 			"'Error: Could not get Grayscale raw data from image'"
 		};
-		logger->printError(name, fingerPosition, "NA",
-		    error.append(e.what()), quantized, resampled);
+		logger->printError(name, fingerPosition, error.append(e.what()),
+		    quantized, resampled);
 		return;
 	}
 
@@ -165,7 +164,7 @@ NFIQ2UI::executeSingle(std::shared_ptr<BE::Image::Image> img,
 				    imageDPI, 500, "", "");
 
 			} catch (const cv::Exception &e) {
-				logger->printError(name, fingerPosition, "NA",
+				logger->printError(name, fingerPosition,
 				    "'Error: Matrix creation error: " + e.msg +
 					"'",
 				    quantized, resampled);
@@ -173,7 +172,7 @@ NFIQ2UI::executeSingle(std::shared_ptr<BE::Image::Image> img,
 
 			} catch (const NFIR::Miscue &e) {
 				const std::string errStr { e.what() };
-				logger->printError(name, fingerPosition, "NA",
+				logger->printError(name, fingerPosition,
 				    "'" + errStr + "'", quantized, resampled);
 				return;
 			}
@@ -204,7 +203,7 @@ NFIQ2UI::executeSingle(std::shared_ptr<BE::Image::Image> img,
 
 					} catch (const cv::Exception &e) {
 						logger->printError(name,
-						    fingerPosition, "NA",
+						    fingerPosition,
 						    "'Error: Matrix creation error: " +
 							e.msg + "'",
 						    quantized, resampled);
@@ -215,7 +214,7 @@ NFIQ2UI::executeSingle(std::shared_ptr<BE::Image::Image> img,
 							e.what()
 						};
 						logger->printError(name,
-						    fingerPosition, "NA",
+						    fingerPosition,
 						    "'" + errStr + "'",
 						    quantized, resampled);
 						return;
@@ -227,7 +226,7 @@ NFIQ2UI::executeSingle(std::shared_ptr<BE::Image::Image> img,
 					    "User denied the re-sample");
 					if (!singleImage) {
 						logger->printError(name,
-						    fingerPosition, "NA",
+						    fingerPosition,
 						    "'Error: User chose not to "
 						    "re-sample image'",
 						    quantized, resampled);
@@ -236,7 +235,7 @@ NFIQ2UI::executeSingle(std::shared_ptr<BE::Image::Image> img,
 				}
 
 			} else {
-				logger->printError(name, fingerPosition, "NA",
+				logger->printError(name, fingerPosition,
 				    "'Error: Image is not 500PPI'", quantized,
 				    resampled);
 				return;
@@ -262,7 +261,7 @@ NFIQ2UI::executeSingle(std::shared_ptr<BE::Image::Image> img,
 		corereturn = NFIQ2UI::coreCompute(wrappedImage, model);
 	} catch (const NFIQ::NFIQException &e) {
 		const std::string expMsg { e.what() };
-		logger->printError(name, fingerPosition, "NA",
+		logger->printError(name, fingerPosition,
 		    "'NFIQ2 computeQualityScore returned an error code: " +
 			expMsg + "'",
 		    quantized, resampled);
@@ -518,7 +517,7 @@ NFIQ2UI::recordStoreConsume(const std::string &name,
 	} catch (const BE::Error::Exception &e) {
 		std::string error { "'Error: Could not open RecordStore'" };
 		threadedlogger->printError(
-		    name, 0, "NA", error.append(e.what()), false, false);
+		    name, 0, error.append(e.what()), false, false);
 		return;
 	}
 
@@ -556,7 +555,7 @@ NFIQ2UI::executeRecordStore(const std::string &filename, const Flags &flags,
 	} catch (const BE::Error::Exception &e) {
 		std::string error { "'Error: Could not open RecordStore'" };
 		logger->printError(
-		    filename, 0, "NA", error.append(e.what()), false, false);
+		    filename, 0, error.append(e.what()), false, false);
 		return;
 	}
 


### PR DESCRIPTION
Replacing 255 error score with NA in the case where an image fails to generate a NFIQ2 score. This switch was made to more clearly convey the difference between a score and an error. 