### PR TITLE
Placing Features and Prediction into NFIQ namespace

### DIFF
--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2/features/BaseFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2/features/BaseFeature.h
@@ -12,6 +12,8 @@
 #include <string>
 #include <vector>
 
+namespace NFIQ { namespace QualityFeatures {
+
 class BaseFeature {
     public:
 	BaseFeature(bool bOutputSpeed,
@@ -23,6 +25,8 @@ class BaseFeature {
 	bool m_bOutputSpeed;
 	std::list<NFIQ::QualityFeatureSpeed> &m_lSpeedValues;
 };
+
+}}
 
 #endif
 

--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2/features/FDAFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2/features/FDAFeature.h
@@ -16,6 +16,8 @@
 * @brief NFIQ2 Frequency Domain Analysis Quality Feature
 ******************************************************************************/
 
+namespace NFIQ { namespace QualityFeatures {
+
 static double FDAHISTLIMITS[9] = { 0.268, 0.304, 0.33, 0.355, 0.38, 0.407, 0.44,
 	0.50, 1 };
 
@@ -47,5 +49,6 @@ class FDAFeature : BaseFeature {
 	int slantedBlockSizeX, slantedBlockSizeY;
 	bool padFlag; // used by getRotatedBlock
 };
+}}
 
 #endif /* FDAFEATURE_H */

--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2/features/FJFXMinutiaeQualityFeatures.h
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2/features/FJFXMinutiaeQualityFeatures.h
@@ -28,6 +28,8 @@
 #include <opencv2/imgproc/imgproc.hpp>
 #include <stdint.h>
 
+namespace NFIQ { namespace QualityFeatures {
+
 /* Ideal Standard Deviation of pixel values in a neighborhood. */
 #define IDEALSTDEV 64
 /* Ideal Mean of pixel values in a neighborhood. */
@@ -73,6 +75,7 @@ class FJFXMinutiaeQualityFeature : BaseFeature {
 	    unsigned int regionSize);
 };
 
+}}
 #endif
 
 /******************************************************************************/

--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2/features/FeatureFunctions.h
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2/features/FeatureFunctions.h
@@ -7,6 +7,10 @@
 
 #include <list>
 
+namespace NFIQ {
+
+namespace QualityFeatures {
+
 void ridgesegment(const cv::Mat &Image, int blksze, double thresh,
     cv::OutputArray NormImage, cv::Mat &MaskImage, cv::OutputArray MaskIndex);
 
@@ -55,5 +59,7 @@ void addSamplingFeatureNames(
 void addHistogramFeatureNames(
     std::list<std::string> &featureNames, const char *prefix, int binCount);
 #endif
+}
+}
 
 /******************************************************************************/

--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2/features/FingerJetFXFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2/features/FingerJetFXFeature.h
@@ -25,6 +25,8 @@
 #include <fcntl.h>
 #include <stdint.h>
 
+namespace NFIQ { namespace QualityFeatures {
+
 class FingerJetFXFeature : BaseFeature {
     public:
 	typedef enum com_type {
@@ -143,6 +145,7 @@ class FingerJetFXFeature : BaseFeature {
 	    const NFIQ::FingerprintImageData &fingerprintImage,
 	    std::vector<FingerJetFXFeature::Object> vecRectDimensions);
 };
+}}
 
 #endif
 

--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2/features/ImgProcROIFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2/features/ImgProcROIFeature.h
@@ -14,6 +14,8 @@
 #include <string>
 #include <vector>
 
+namespace NFIQ { namespace QualityFeatures {
+
 class ImgProcROIFeature : BaseFeature {
     public:
 	struct ImgProcROIResults {
@@ -58,6 +60,8 @@ class ImgProcROIFeature : BaseFeature {
     private:
 	static bool isBlackPixelAvailable(cv::Mat &img, cv::Point &point);
 };
+
+}}
 
 #endif
 

--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2/features/LCSFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2/features/LCSFeature.h
@@ -11,6 +11,8 @@
 #include <string>
 #include <vector>
 
+namespace NFIQ { namespace QualityFeatures {
+
 static double LCSHISTLIMITS[9] = { 0, 0.70, 0.74, 0.77, 0.79, 0.81, 0.83, 0.85,
 	0.87 };
 
@@ -41,6 +43,8 @@ class LCSFeature : BaseFeature {
 	int scannerRes;
 	bool padFlag;
 };
+
+}}
 
 #endif
 

--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2/features/MuFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2/features/MuFeature.h
@@ -13,6 +13,8 @@
 #include <string>
 #include <vector>
 
+namespace NFIQ { namespace QualityFeatures {
+
 class MuFeature : BaseFeature {
     public:
 	MuFeature(bool bOutputSpeed,
@@ -30,6 +32,8 @@ class MuFeature : BaseFeature {
 	static std::list<std::string> getAllFeatureIDs();
 	static const std::string speedFeatureIDGroup;
 };
+
+}}
 
 #endif
 

--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2/features/OCLHistogramFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2/features/OCLHistogramFeature.h
@@ -16,6 +16,8 @@
 #include <string>
 #include <vector>
 
+namespace NFIQ { namespace QualityFeatures {
+
 static double OCLPHISTLIMITS[9] = { 0.337, 0.479, 0.579, 0.655, 0.716, 0.766,
 	0.81, 0.852, 0.898 };
 
@@ -39,6 +41,8 @@ class OCLHistogramFeature : BaseFeature {
 	// compute OCL value of a given block with block size BSxBS
 	static bool getOCLValueOfBlock(const cv::Mat &block, double &ocl);
 };
+
+}}
 
 #endif
 

--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2/features/OFFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2/features/OFFeature.h
@@ -17,6 +17,8 @@
 * @brief NFIQ2 Orientation Flow Quality Feature
 ******************************************************************************/
 
+namespace NFIQ { namespace QualityFeatures {
+
 static double OFHISTLIMITS[9] = { 1.715e-2, 3.5e-2, 5.57e-2, 8.1e-2, 1.15e-1,
 	1.718e-1, 2.569e-1, 4.758e-1, 7.48e-1 };
 
@@ -53,6 +55,8 @@ class OFFeature : BaseFeature {
 	double angleMin; /*!< Minimum angle change inclusion in the quality
 			    measure */
 };
+
+}}
 
 #endif
 

--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2/features/QualityMapFeatures.h
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2/features/QualityMapFeatures.h
@@ -18,6 +18,8 @@
 #include <string>
 #include <vector>
 
+namespace NFIQ { namespace QualityFeatures {
+
 #define LOW_FLOW_MAP_NO_DIRECTION 0
 #define LOW_FLOW_MAP_LOW_FLOW 127
 #define LOW_FLOW_MAP_HIGH_FLOW 255
@@ -64,6 +66,8 @@ class QualityMapFeatures : BaseFeature {
 	static void computeNumericalGradients(
 	    const cv::Mat &mat, cv::Mat &grad_x, cv::Mat &grad_y);
 };
+
+}}
 
 #endif
 

--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2/features/RVUPHistogramFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2/features/RVUPHistogramFeature.h
@@ -11,6 +11,8 @@
 #include <string>
 #include <vector>
 
+namespace NFIQ { namespace QualityFeatures {
+
 static double RVUPHISTLIMITS[9] = { 0.5, 0.667, 0.8, 1, 1.25, 1.5, 2, 24, 30 };
 
 class RVUPHistogramFeature : BaseFeature {
@@ -42,6 +44,8 @@ class RVUPHistogramFeature : BaseFeature {
 	int screenRes;
 	bool padFlag;
 };
+
+}}
 
 #endif
 

--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2/prediction/RandomForestML.h
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2/prediction/RandomForestML.h
@@ -18,6 +18,8 @@
 
 #undef EMBED_RANDOMFOREST_PARAMETERS
 
+namespace NFIQ { namespace Prediction {
+
 class RandomForestML {
     public:
 	RandomForestML();
@@ -48,6 +50,8 @@ class RandomForestML {
 	std::string joinRFTrainedParamsString();
 #endif
 };
+
+}}
 
 #endif
 

--- a/NFIQ2/NFIQ2Algorithm/src/features/FDAFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FDAFeature.cpp
@@ -22,12 +22,12 @@ using namespace cv;
 double fda(const Mat &block, const double orientation, const int v1sz_x,
     const int v1sz_y, const bool padFlag);
 
-FDAFeature::~FDAFeature()
+NFIQ::QualityFeatures::FDAFeature::~FDAFeature()
 {
 }
 
 std::list<std::string>
-FDAFeature::getAllFeatureIDs()
+NFIQ::QualityFeatures::FDAFeature::getAllFeatureIDs()
 {
 	std::list<std::string> featureIDs;
 	addHistogramFeatureNames(featureIDs, "FDA_Bin10_", 10);
@@ -35,16 +35,17 @@ FDAFeature::getAllFeatureIDs()
 	return featureIDs;
 }
 
-const std::string FDAFeature::speedFeatureIDGroup = "Frequency domain";
+const std::string NFIQ::QualityFeatures::FDAFeature::speedFeatureIDGroup =
+    "Frequency domain";
 
 std::string
-FDAFeature::getModuleID()
+NFIQ::QualityFeatures::FDAFeature::getModuleID()
 {
 	return "NFIQ2_FDA";
 }
 
 std::list<NFIQ::QualityFeatureResult>
-FDAFeature::computeFeatureData(
+NFIQ::QualityFeatures::FDAFeature::computeFeatureData(
     const NFIQ::FingerprintImageData &fingerprintImage)
 {
 	std::list<NFIQ::QualityFeatureResult> featureDataList;
@@ -233,7 +234,8 @@ fda(const Mat &block, const double orientation, const int v1sz_x,
 	// rotate image to get the ridges horizontal using nearest-neighbor
 	// interpolation
 	Mat blockRotated;
-	getRotatedBlock(block, orientation + (M_PI / 2), padFlag, blockRotated);
+	NFIQ::QualityFeatures::getRotatedBlock(
+	    block, orientation + (M_PI / 2), padFlag, blockRotated);
 
 	//% set x and y
 	int xoff = v1sz_x / 2;

--- a/NFIQ2/NFIQ2Algorithm/src/features/FJFXMinutiaeQualityFeatures.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FJFXMinutiaeQualityFeatures.cpp
@@ -8,15 +8,16 @@
 using namespace NFIQ;
 using namespace cv;
 
-FJFXMinutiaeQualityFeature::~FJFXMinutiaeQualityFeature()
+NFIQ::QualityFeatures::FJFXMinutiaeQualityFeature::~FJFXMinutiaeQualityFeature()
 {
 }
 
-const std::string FJFXMinutiaeQualityFeature::speedFeatureIDGroup =
-    "Minutiae quality";
+const std::string
+    NFIQ::QualityFeatures::FJFXMinutiaeQualityFeature::speedFeatureIDGroup =
+	"Minutiae quality";
 
 std::list<NFIQ::QualityFeatureResult>
-FJFXMinutiaeQualityFeature::computeFeatureData(
+NFIQ::QualityFeatures::FJFXMinutiaeQualityFeature::computeFeatureData(
     const NFIQ::FingerprintImageData &fingerprintImage,
     const std::vector<FingerJetFXFeature::Minutia> &minutiaData,
     bool &templateCouldBeExtracted)
@@ -162,13 +163,13 @@ FJFXMinutiaeQualityFeature::computeFeatureData(
 }
 
 std::string
-FJFXMinutiaeQualityFeature::getModuleID()
+NFIQ::QualityFeatures::FJFXMinutiaeQualityFeature::getModuleID()
 {
 	return "NFIQ2_FJFXPos_MinutiaeQuality";
 }
 
 std::list<std::string>
-FJFXMinutiaeQualityFeature::getAllFeatureIDs()
+NFIQ::QualityFeatures::FJFXMinutiaeQualityFeature::getAllFeatureIDs()
 {
 	std::list<std::string> featureIDs;
 	featureIDs.push_back("FJFXPos_Mu_MinutiaeQuality_2");
@@ -176,8 +177,8 @@ FJFXMinutiaeQualityFeature::getAllFeatureIDs()
 	return featureIDs;
 }
 
-std::vector<FJFXMinutiaeQualityFeature::MinutiaData>
-FJFXMinutiaeQualityFeature::computeMuMinQuality(
+std::vector<NFIQ::QualityFeatures::FJFXMinutiaeQualityFeature::MinutiaData>
+NFIQ::QualityFeatures::FJFXMinutiaeQualityFeature::computeMuMinQuality(
     const std::vector<FingerJetFXFeature::Minutia> &minutiaData, int bs,
     const NFIQ::FingerprintImageData &fingerprintImage)
 {
@@ -231,8 +232,8 @@ FJFXMinutiaeQualityFeature::computeMuMinQuality(
 	return vecMinData;
 }
 
-std::vector<FJFXMinutiaeQualityFeature::MinutiaData>
-FJFXMinutiaeQualityFeature::computeOCLMinQuality(
+std::vector<NFIQ::QualityFeatures::FJFXMinutiaeQualityFeature::MinutiaData>
+NFIQ::QualityFeatures::FJFXMinutiaeQualityFeature::computeOCLMinQuality(
     const std::vector<FingerJetFXFeature::Minutia> &minutiaData, int bs,
     const NFIQ::FingerprintImageData &fingerprintImage)
 {

--- a/NFIQ2/NFIQ2Algorithm/src/features/FeatureFunctions.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FeatureFunctions.cpp
@@ -36,8 +36,8 @@ From the matlab code:
 ***/
 
 void
-ridgesegment(const Mat &img, int blksze, double thresh, OutputArray _normImage,
-    Mat &maskImage, OutputArray _maskIndex)
+NFIQ::QualityFeatures::ridgesegment(const Mat &img, int blksze, double thresh,
+    OutputArray _normImage, Mat &maskImage, OutputArray _maskIndex)
 
 {
 	/***Convert the input image to double.
@@ -134,8 +134,8 @@ gradients inside %   a block specified as a parameter
 %
 ***/
 void
-covcoef(const cv::Mat &imblock, double &a, double &b, double &c,
-    ocl_type compMethod)
+NFIQ::QualityFeatures::covcoef(const cv::Mat &imblock, double &a, double &b,
+    double &c, ocl_type compMethod)
 {
 	/*** Compute the gradient of the input block.  In Matlab, this is done
 	as follows:
@@ -225,7 +225,7 @@ function orientang = ridgeorient(a, b, c)
 ***/
 
 double
-ridgeorient(double a, double b, double c)
+NFIQ::QualityFeatures::ridgeorient(double a, double b, double c)
 {
 	double denom, sin2theta, cos2theta, orientang;
 	double temp;
@@ -242,7 +242,7 @@ ridgeorient(double a, double b, double c)
 /////////////////////////////////////////////////////////////////////////
 
 uint8_t
-allfun(const Mat &Image)
+NFIQ::QualityFeatures::allfun(const Mat &Image)
 /*** Returns 1 if all elements are nonzero, 0 otherwise.
 % Equivalent to matlab:
 % all elements of x should be nonzero, otherwise flag a
@@ -272,7 +272,7 @@ forward differences at the edges and central differences elsewhere.
 Spacing is 1.  The input matrix is assumed to be 64-bit floating point
 */
 void
-diffGrad(const Mat &inBlock, Mat &outBlock)
+NFIQ::QualityFeatures::diffGrad(const Mat &inBlock, Mat &outBlock)
 {
 	outBlock.create(inBlock.size(), CV_64F);
 
@@ -295,7 +295,7 @@ diffGrad(const Mat &inBlock, Mat &outBlock)
 
 //////////////////////////////////////////////////////////////
 void
-getRotatedBlock(
+NFIQ::QualityFeatures::getRotatedBlock(
     const Mat &block, const double orientation, bool padFlag, Mat &rotatedBlock)
 {
 	const double Rad2Deg = 180.0 / M_PI;
@@ -339,8 +339,8 @@ getRotatedBlock(
 }
 //////////////////////////////////////////////////////////////////////////////
 void
-getRidgeValleyStructure(const Mat &blockCropped, std::vector<uint8_t> &ridval,
-    std::vector<double> &dt)
+NFIQ::QualityFeatures::getRidgeValleyStructure(const Mat &blockCropped,
+    std::vector<uint8_t> &ridval, std::vector<double> &dt)
 {
 	// average profile of blockCropped: Compute average of each column to
 	// get a projection of the grey values down the ridges.
@@ -432,8 +432,8 @@ getRidgeValleyStructure(const Mat &blockCropped, std::vector<uint8_t> &ridval,
  * @return
  */
 void
-GaborFilterCx(const int ksize, const double theta, const double freq,
-    const int sigma, Mat &FilterOut)
+NFIQ::QualityFeatures::GaborFilterCx(const int ksize, const double theta,
+    const double freq, const int sigma, Mat &FilterOut)
 {
 	int ks2 = (ksize - 1) / 2;
 	double x1, y1;
@@ -461,8 +461,8 @@ GaborFilterCx(const int ksize, const double theta, const double freq,
 ///////////////////////////////////////////////////////////////////////////////
 
 void
-Conv2D(const Mat &imDFT, const Mat &filter, Mat &ConvOut, const Size &imageSize,
-    const Size &dftSize, bool imDFTFlag)
+NFIQ::QualityFeatures::Conv2D(const Mat &imDFT, const Mat &filter, Mat &ConvOut,
+    const Size &imageSize, const Size &dftSize, bool imDFTFlag)
 {
 	int OutType = filter.type();
 	ConvOut.create(imageSize, OutType);
@@ -493,13 +493,13 @@ Conv2D(const Mat &imDFT, const Mat &filter, Mat &ConvOut, const Size &imageSize,
 ////////////////////////////////////////
 // compute coherence for COH/CS
 double
-calccoh(double gxx, double gyy, double gxy)
+NFIQ::QualityFeatures::calccoh(double gxx, double gyy, double gxy)
 {
 	return sqrt((gxx - gyy) * (gxx - gyy) + 4 * gxy * gxy) / (gxx + gyy);
 }
 
 double
-calcof(double gsxavg, double gsyavg)
+NFIQ::QualityFeatures::calcof(double gsxavg, double gsyavg)
 {
 	double theta = 0;
 	double phi = atan2(gsyavg, gsxavg);
@@ -512,7 +512,7 @@ calcof(double gsxavg, double gsyavg)
 }
 
 cv::Mat
-computeNumericalGradientX(const cv::Mat &mat)
+NFIQ::QualityFeatures::computeNumericalGradientX(const cv::Mat &mat)
 {
 	cv::Mat out(mat.rows, mat.cols, CV_64F);
 
@@ -530,7 +530,8 @@ computeNumericalGradientX(const cv::Mat &mat)
 }
 
 void
-computeNumericalGradients(const cv::Mat &mat, cv::Mat &grad_x, cv::Mat &grad_y)
+NFIQ::QualityFeatures::computeNumericalGradients(
+    const cv::Mat &mat, cv::Mat &grad_x, cv::Mat &grad_y)
 {
 	// get x-gradient
 	grad_x = computeNumericalGradientX(mat);
@@ -540,7 +541,8 @@ computeNumericalGradients(const cv::Mat &mat, cv::Mat &grad_x, cv::Mat &grad_y)
 }
 
 void
-addSamplingFeatures(std::list<NFIQ::QualityFeatureResult> &featureDataList,
+NFIQ::QualityFeatures::addSamplingFeatures(
+    std::list<NFIQ::QualityFeatureResult> &featureDataList,
     std::string featurePrefix, std::vector<double> &dataVector)
 {
 	const int sampleSize = dataVector.size();
@@ -577,7 +579,8 @@ addSamplingFeatures(std::list<NFIQ::QualityFeatureResult> &featureDataList,
 }
 
 void
-addHistogramFeatures(std::list<NFIQ::QualityFeatureResult> &featureDataList,
+NFIQ::QualityFeatures::addHistogramFeatures(
+    std::list<NFIQ::QualityFeatureResult> &featureDataList,
     std::string featurePrefix, std::vector<double> &binBoundaries,
     std::vector<double> &dataVector, int binCount)
 {
@@ -660,7 +663,7 @@ addHistogramFeatures(std::list<NFIQ::QualityFeatureResult> &featureDataList,
 }
 
 void
-addSamplingFeatureNames(
+NFIQ::QualityFeatures::addSamplingFeatureNames(
     std::list<std::string> &featureNames, const char *prefix)
 {
 	for (int i = 0; i < maxSampleCount; i++) {
@@ -671,7 +674,7 @@ addSamplingFeatureNames(
 }
 
 void
-addHistogramFeatureNames(
+NFIQ::QualityFeatures::addHistogramFeatureNames(
     std::list<std::string> &featureNames, const char *prefix, int binCount)
 {
 	for (int i = 0; i < binCount; i++) {

--- a/NFIQ2/NFIQ2Algorithm/src/features/FingerJetFXFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FingerJetFXFeature.cpp
@@ -7,14 +7,15 @@
 
 using namespace NFIQ;
 
-FingerJetFXFeature::~FingerJetFXFeature()
+NFIQ::QualityFeatures::FingerJetFXFeature::~FingerJetFXFeature()
 {
 }
 
-const std::string FingerJetFXFeature::speedFeatureIDGroup = "Minutiae";
+const std::string
+    NFIQ::QualityFeatures::FingerJetFXFeature::speedFeatureIDGroup = "Minutiae";
 
 std::pair<unsigned int, unsigned int>
-FingerJetFXFeature::centerOfMinutiaeMass(
+NFIQ::QualityFeatures::FingerJetFXFeature::centerOfMinutiaeMass(
     const std::vector<FingerJetFXFeature::Minutia> &minutiaData)
 {
 	unsigned int lx { 0 }, ly { 0 };
@@ -27,7 +28,8 @@ FingerJetFXFeature::centerOfMinutiaeMass(
 }
 
 std::string
-FingerJetFXFeature::parseFRFXLLError(const FRFXLL_RESULT fxRes)
+NFIQ::QualityFeatures::FingerJetFXFeature::parseFRFXLLError(
+    const FRFXLL_RESULT fxRes)
 {
 	switch (fxRes) {
 	case FRFXLL_ERR_FB_TOO_SMALL_AREA:
@@ -64,7 +66,7 @@ FingerJetFXFeature::parseFRFXLLError(const FRFXLL_RESULT fxRes)
 }
 
 std::list<NFIQ::QualityFeatureResult>
-FingerJetFXFeature::computeFeatureData(
+NFIQ::QualityFeatures::FingerJetFXFeature::computeFeatureData(
     const NFIQ::FingerprintImageData fingerprintImage,
     std::vector<FingerJetFXFeature::Minutia> &minutiaData,
     bool &templateCouldBeExtracted)
@@ -275,13 +277,13 @@ FingerJetFXFeature::computeFeatureData(
 }
 
 std::string
-FingerJetFXFeature::getModuleID()
+NFIQ::QualityFeatures::FingerJetFXFeature::getModuleID()
 {
 	return "NFIQ2_FingerJetFX";
 }
 
 std::list<std::string>
-FingerJetFXFeature::getAllFeatureIDs()
+NFIQ::QualityFeatures::FingerJetFXFeature::getAllFeatureIDs()
 {
 	std::list<std::string> featureIDs;
 	featureIDs.push_back("FingerJetFX_MinCount_COMMinRect200x200");
@@ -290,7 +292,8 @@ FingerJetFXFeature::getAllFeatureIDs()
 }
 
 FRFXLL_RESULT
-FingerJetFXFeature::createContext(FRFXLL_HANDLE_PT phContext)
+NFIQ::QualityFeatures::FingerJetFXFeature::createContext(
+    FRFXLL_HANDLE_PT phContext)
 {
 	FRFXLL_RESULT rc = FRFXLL_OK;
 
@@ -304,8 +307,8 @@ FingerJetFXFeature::createContext(FRFXLL_HANDLE_PT phContext)
 	return rc;
 }
 
-FingerJetFXFeature::FJFXROIResults
-FingerJetFXFeature::computeROI(
+NFIQ::QualityFeatures::FingerJetFXFeature::FJFXROIResults
+NFIQ::QualityFeatures::FingerJetFXFeature::computeROI(
     const std::vector<FingerJetFXFeature::Minutia> &minutiaData, int bs,
     const NFIQ::FingerprintImageData &fingerprintImage,
     std::vector<FingerJetFXFeature::Object> vecRectDimensions)

--- a/NFIQ2/NFIQ2Algorithm/src/features/ImgProcROIFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/ImgProcROIFeature.cpp
@@ -8,14 +8,16 @@
 using namespace NFIQ;
 using namespace cv;
 
-ImgProcROIFeature::~ImgProcROIFeature()
+NFIQ::QualityFeatures::ImgProcROIFeature::~ImgProcROIFeature()
 {
 }
 
-const std::string ImgProcROIFeature::speedFeatureIDGroup = "Region of interest";
+const std::string
+    NFIQ::QualityFeatures::ImgProcROIFeature::speedFeatureIDGroup =
+	"Region of interest";
 
 std::list<NFIQ::QualityFeatureResult>
-ImgProcROIFeature::computeFeatureData(
+NFIQ::QualityFeatures::ImgProcROIFeature::computeFeatureData(
     const NFIQ::FingerprintImageData &fingerprintImage,
     ImgProcROIFeature::ImgProcROIResults &imgProcResults)
 {
@@ -88,21 +90,22 @@ ImgProcROIFeature::computeFeatureData(
 }
 
 std::string
-ImgProcROIFeature::getModuleID()
+NFIQ::QualityFeatures::ImgProcROIFeature::getModuleID()
 {
 	return "NFIQ2_ImgProcROI";
 }
 
 std::list<std::string>
-ImgProcROIFeature::getAllFeatureIDs()
+NFIQ::QualityFeatures::ImgProcROIFeature::getAllFeatureIDs()
 {
 	std::list<std::string> featureIDs;
 	featureIDs.push_back("ImgProcROIArea_Mean");
 	return featureIDs;
 }
 
-ImgProcROIFeature::ImgProcROIResults
-ImgProcROIFeature::computeROI(cv::Mat &img, unsigned int bs)
+NFIQ::QualityFeatures::ImgProcROIFeature::ImgProcROIResults
+NFIQ::QualityFeatures::ImgProcROIFeature::computeROI(
+    cv::Mat &img, unsigned int bs)
 {
 	ImgProcROIResults roiResults;
 
@@ -301,7 +304,8 @@ ImgProcROIFeature::computeROI(cv::Mat &img, unsigned int bs)
 }
 
 bool
-ImgProcROIFeature::isBlackPixelAvailable(cv::Mat &img, cv::Point &point)
+NFIQ::QualityFeatures::ImgProcROIFeature::isBlackPixelAvailable(
+    cv::Mat &img, cv::Point &point)
 {
 	bool found = false;
 	for (int i = 0; i < img.rows; i++) {

--- a/NFIQ2/NFIQ2Algorithm/src/features/LCSFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/LCSFeature.cpp
@@ -18,18 +18,18 @@ using namespace cv;
 double loclar(Mat &block, const double orientation, const int v1sz_x,
     const int v1sz_y, const int scres, const bool padFlag);
 
-LCSFeature::~LCSFeature()
+NFIQ::QualityFeatures::LCSFeature::~LCSFeature()
 {
 }
 
 std::string
-LCSFeature::getModuleID()
+NFIQ::QualityFeatures::LCSFeature::getModuleID()
 {
 	return "NFIQ2_LCS";
 }
 
 std::list<std::string>
-LCSFeature::getAllFeatureIDs()
+NFIQ::QualityFeatures::LCSFeature::getAllFeatureIDs()
 {
 	std::list<std::string> featureIDs;
 	addHistogramFeatureNames(featureIDs, "LCS_Bin10_", 10);
@@ -37,10 +37,11 @@ LCSFeature::getAllFeatureIDs()
 	return featureIDs;
 }
 
-const std::string LCSFeature::speedFeatureIDGroup = "Local clarity";
+const std::string NFIQ::QualityFeatures::LCSFeature::speedFeatureIDGroup =
+    "Local clarity";
 
 std::list<NFIQ::QualityFeatureResult>
-LCSFeature::computeFeatureData(
+NFIQ::QualityFeatures::LCSFeature::computeFeatureData(
     const NFIQ::FingerprintImageData &fingerprintImage)
 {
 	std::list<NFIQ::QualityFeatureResult> featureDataList;
@@ -235,7 +236,8 @@ loclar(Mat &block, const double orientation, const int v1sz_x, const int v1sz_y,
 	}
 
 	Mat blockRotated;
-	getRotatedBlock(block, orientation, padFlag, blockRotated);
+	NFIQ::QualityFeatures::getRotatedBlock(
+	    block, orientation, padFlag, blockRotated);
 
 	//% set x and y
 	int xoff = v1sz_x / 2;
@@ -257,7 +259,7 @@ loclar(Mat &block, const double orientation, const int v1sz_x, const int v1sz_y,
 
 	std::vector<uint8_t> ridval;
 	std::vector<double> dt;
-	getRidgeValleyStructure(v2, ridval, dt);
+	NFIQ::QualityFeatures::getRidgeValleyStructure(v2, ridval, dt);
 
 	// Ridge-valley thickness
 	//  begrid = ridval(1); % begining with ridge?

--- a/NFIQ2/NFIQ2Algorithm/src/features/MuFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/MuFeature.cpp
@@ -7,14 +7,15 @@
 using namespace NFIQ;
 using namespace cv;
 
-MuFeature::~MuFeature()
+NFIQ::QualityFeatures::MuFeature::~MuFeature()
 {
 }
 
-const std::string MuFeature::speedFeatureIDGroup = "Contrast";
+const std::string NFIQ::QualityFeatures::MuFeature::speedFeatureIDGroup =
+    "Contrast";
 
 std::list<NFIQ::QualityFeatureResult>
-MuFeature::computeFeatureData(
+NFIQ::QualityFeatures::MuFeature::computeFeatureData(
     const NFIQ::FingerprintImageData &fingerprintImage, double &sigma)
 {
 	std::list<NFIQ::QualityFeatureResult> featureDataList;
@@ -151,13 +152,13 @@ MuFeature::computeFeatureData(
 }
 
 std::string
-MuFeature::getModuleID()
+NFIQ::QualityFeatures::MuFeature::getModuleID()
 {
 	return "NFIQ2_Mu";
 }
 
 std::list<std::string>
-MuFeature::getAllFeatureIDs()
+NFIQ::QualityFeatures::MuFeature::getAllFeatureIDs()
 {
 	std::list<std::string> featureIDs;
 	featureIDs.push_back("MMB");

--- a/NFIQ2/NFIQ2Algorithm/src/features/OCLHistogramFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/OCLHistogramFeature.cpp
@@ -13,15 +13,16 @@
 using namespace NFIQ;
 using namespace cv;
 
-OCLHistogramFeature::~OCLHistogramFeature()
+NFIQ::QualityFeatures::OCLHistogramFeature::~OCLHistogramFeature()
 {
 }
 
-const std::string OCLHistogramFeature::speedFeatureIDGroup =
-    "Orientation certainty";
+const std::string
+    NFIQ::QualityFeatures::OCLHistogramFeature::speedFeatureIDGroup =
+	"Orientation certainty";
 
 std::list<NFIQ::QualityFeatureResult>
-OCLHistogramFeature::computeFeatureData(
+NFIQ::QualityFeatures::OCLHistogramFeature::computeFeatureData(
     const NFIQ::FingerprintImageData &fingerprintImage)
 {
 	std::list<NFIQ::QualityFeatureResult> featureDataList;
@@ -128,7 +129,8 @@ OCLHistogramFeature::computeFeatureData(
 }
 
 bool
-OCLHistogramFeature::getOCLValueOfBlock(const cv::Mat &block, double &ocl)
+NFIQ::QualityFeatures::OCLHistogramFeature::getOCLValueOfBlock(
+    const cv::Mat &block, double &ocl)
 {
 	double eigv_max = 0.0, eigv_min = 0.0;
 	// compute the numerical gradients of the block
@@ -170,13 +172,13 @@ OCLHistogramFeature::getOCLValueOfBlock(const cv::Mat &block, double &ocl)
 }
 
 std::string
-OCLHistogramFeature::getModuleID()
+NFIQ::QualityFeatures::OCLHistogramFeature::getModuleID()
 {
 	return "NFIQ2_OCLHistogram";
 }
 
 std::list<std::string>
-OCLHistogramFeature::getAllFeatureIDs()
+NFIQ::QualityFeatures::OCLHistogramFeature::getAllFeatureIDs()
 {
 	std::list<std::string> featureIDs;
 	addHistogramFeatureNames(featureIDs, "OCL_Bin10_", 10);

--- a/NFIQ2/NFIQ2Algorithm/src/features/OFFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/OFFeature.cpp
@@ -19,18 +19,18 @@
 using namespace NFIQ;
 using namespace cv;
 
-OFFeature::~OFFeature()
+NFIQ::QualityFeatures::OFFeature::~OFFeature()
 {
 }
 
 std::string
-OFFeature::getModuleID()
+NFIQ::QualityFeatures::OFFeature::getModuleID()
 {
 	return "NFIQ2_OF";
 }
 
 std::list<std::string>
-OFFeature::getAllFeatureIDs()
+NFIQ::QualityFeatures::OFFeature::getAllFeatureIDs()
 {
 	std::list<std::string> featureIDs;
 	addHistogramFeatureNames(featureIDs, "OF_Bin10_", 10);
@@ -38,10 +38,11 @@ OFFeature::getAllFeatureIDs()
 	return featureIDs;
 }
 
-const std::string OFFeature::speedFeatureIDGroup = "Orientation flow";
+const std::string NFIQ::QualityFeatures::OFFeature::speedFeatureIDGroup =
+    "Orientation flow";
 
 std::list<NFIQ::QualityFeatureResult>
-OFFeature::computeFeatureData(
+NFIQ::QualityFeatures::OFFeature::computeFeatureData(
     const NFIQ::FingerprintImageData &fingerprintImage)
 {
 	std::list<NFIQ::QualityFeatureResult> featureDataList;

--- a/NFIQ2/NFIQ2Algorithm/src/features/QualityMapFeatures.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/QualityMapFeatures.cpp
@@ -19,14 +19,16 @@ using namespace NFIQ;
 using namespace cv;
 using namespace std;
 
-QualityMapFeatures::~QualityMapFeatures()
+NFIQ::QualityFeatures::QualityMapFeatures::~QualityMapFeatures()
 {
 }
 
-const std::string QualityMapFeatures::speedFeatureIDGroup = "Quality map";
+const std::string
+    NFIQ::QualityFeatures::QualityMapFeatures::speedFeatureIDGroup =
+	"Quality map";
 
 std::list<NFIQ::QualityFeatureResult>
-QualityMapFeatures::computeFeatureData(
+NFIQ::QualityFeatures::QualityMapFeatures::computeFeatureData(
     const NFIQ::FingerprintImageData &fingerprintImage,
     ImgProcROIFeature::ImgProcROIResults imgProcResults)
 {
@@ -113,9 +115,9 @@ QualityMapFeatures::computeFeatureData(
 }
 
 cv::Mat
-QualityMapFeatures::computeOrientationMap(cv::Mat &img, bool bFilterByROI,
-    double &coherenceSum, double &coherenceRel, unsigned int bs,
-    ImgProcROIFeature::ImgProcROIResults roiResults)
+NFIQ::QualityFeatures::QualityMapFeatures::computeOrientationMap(cv::Mat &img,
+    bool bFilterByROI, double &coherenceSum, double &coherenceRel,
+    unsigned int bs, ImgProcROIFeature::ImgProcROIResults roiResults)
 {
 	coherenceSum = 0.0;
 	coherenceRel = 0.0;
@@ -226,7 +228,7 @@ QualityMapFeatures::computeOrientationMap(cv::Mat &img, bool bFilterByROI,
 }
 
 bool
-QualityMapFeatures::getAngleOfBlock(
+NFIQ::QualityFeatures::QualityMapFeatures::getAngleOfBlock(
     const cv::Mat &block, double &angle, double &coherence)
 {
 	// compute the numerical gradients of the block
@@ -287,7 +289,8 @@ QualityMapFeatures::getAngleOfBlock(
 }
 
 cv::Mat
-QualityMapFeatures::computeNumericalGradientX(const cv::Mat &mat)
+NFIQ::QualityFeatures::QualityMapFeatures::computeNumericalGradientX(
+    const cv::Mat &mat)
 {
 	cv::Mat out(mat.rows, mat.cols, CV_64F, Scalar(0));
 
@@ -308,7 +311,7 @@ QualityMapFeatures::computeNumericalGradientX(const cv::Mat &mat)
 }
 
 void
-QualityMapFeatures::computeNumericalGradients(
+NFIQ::QualityFeatures::QualityMapFeatures::computeNumericalGradients(
     const cv::Mat &mat, cv::Mat &grad_x, cv::Mat &grad_y)
 {
 	// get x-gradient
@@ -319,13 +322,13 @@ QualityMapFeatures::computeNumericalGradients(
 }
 
 std::string
-QualityMapFeatures::getModuleID()
+NFIQ::QualityFeatures::QualityMapFeatures::getModuleID()
 {
 	return "NFIQ2_QualityMap";
 }
 
 std::list<std::string>
-QualityMapFeatures::getAllFeatureIDs()
+NFIQ::QualityFeatures::QualityMapFeatures::getAllFeatureIDs()
 {
 	std::list<std::string> featureIDs;
 	featureIDs.push_back("OrientationMap_ROIFilter_CoherenceRel");

--- a/NFIQ2/NFIQ2Algorithm/src/features/RVUPHistogramFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/RVUPHistogramFeature.cpp
@@ -20,15 +20,16 @@ void rvuhist(Mat block, const double orientation, const int v1sz_x,
     const int v1sz_y, bool padFlag, std::vector<double> &ratios,
     std::vector<uint8_t> &Nans);
 
-RVUPHistogramFeature::~RVUPHistogramFeature()
+NFIQ::QualityFeatures::RVUPHistogramFeature::~RVUPHistogramFeature()
 {
 }
 
-const std::string RVUPHistogramFeature::speedFeatureIDGroup =
-    "Ridge valley uniformity";
+const std::string
+    NFIQ::QualityFeatures::RVUPHistogramFeature::speedFeatureIDGroup =
+	"Ridge valley uniformity";
 
 std::list<NFIQ::QualityFeatureResult>
-RVUPHistogramFeature::computeFeatureData(
+NFIQ::QualityFeatures::RVUPHistogramFeature::computeFeatureData(
     const NFIQ::FingerprintImageData &fingerprintImage)
 {
 	std::list<NFIQ::QualityFeatureResult> featureDataList;
@@ -181,13 +182,13 @@ RVUPHistogramFeature::computeFeatureData(
 }
 
 std::string
-RVUPHistogramFeature::getModuleID()
+NFIQ::QualityFeatures::RVUPHistogramFeature::getModuleID()
 {
 	return "NFIQ2_RVUPHistogram";
 }
 
 std::list<std::string>
-RVUPHistogramFeature::getAllFeatureIDs()
+NFIQ::QualityFeatures::RVUPHistogramFeature::getAllFeatureIDs()
 {
 	std::list<std::string> featureIDs;
 	addHistogramFeatureNames(featureIDs, "RVUP_Bin10_", 10);
@@ -238,7 +239,8 @@ rvuhist(Mat block, const double orientation, const int v1sz_x, const int v1sz_y,
 	}
 
 	Mat blockRotated;
-	getRotatedBlock(block, orientation, padFlag, blockRotated);
+	NFIQ::QualityFeatures::getRotatedBlock(
+	    block, orientation, padFlag, blockRotated);
 
 	//% set x and y
 	int xoff = v1sz_x / 2;
@@ -258,7 +260,8 @@ rvuhist(Mat block, const double orientation, const int v1sz_x, const int v1sz_y,
 
 	std::vector<uint8_t> ridval;
 	std::vector<double> dt;
-	getRidgeValleyStructure(blockCropped, ridval, dt);
+	NFIQ::QualityFeatures::getRidgeValleyStructure(
+	    blockCropped, ridval, dt);
 
 	// Ridge-valley thickness
 	//  change = xor(ridval,circshift(ridval,1)); // find the bin change

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2impl.h
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2impl.h
@@ -86,7 +86,7 @@ class NFIQ2Algorithm::Impl {
 	double getQualityPrediction(
 	    std::list<NFIQ::QualityFeatureData> &featureVector) const;
 
-	RandomForestML m_RandomForestML;
+	NFIQ::Prediction::RandomForestML m_RandomForestML;
 	std::string m_parameterHash {};
 };
 } // namespace NFIQ

--- a/NFIQ2/NFIQ2Algorithm/src/prediction/RandomForestML.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/prediction/RandomForestML.cpp
@@ -23,7 +23,7 @@ using namespace NFIQ;
 using namespace cv;
 
 std::string
-RandomForestML::calculateHashString(const std::string &s)
+NFIQ::Prediction::RandomForestML::calculateHashString(const std::string &s)
 {
 	// calculate and compare the hash
 	digestpp::md5 hasher;
@@ -34,7 +34,7 @@ RandomForestML::calculateHashString(const std::string &s)
 }
 
 void
-RandomForestML::initModule(const std::string &params)
+NFIQ::Prediction::RandomForestML::initModule(const std::string &params)
 {
 	// create file storage with parameters in memory
 	FileStorage fs(params.c_str(),
@@ -52,7 +52,7 @@ RandomForestML::initModule(const std::string &params)
 
 #ifdef EMBED_RANDOMFOREST_PARAMETERS
 std::string
-RandomForestML::joinRFTrainedParamsString()
+NFIQ::Prediction::RandomForestML::joinRFTrainedParamsString()
 {
 	unsigned int size = sizeof(g_strRandomForestTrainedParams) /
 	    sizeof(g_strRandomForestTrainedParams[0]);
@@ -64,14 +64,14 @@ RandomForestML::joinRFTrainedParamsString()
 }
 #endif
 
-RandomForestML::RandomForestML()
+NFIQ::Prediction::RandomForestML::RandomForestML()
 {
 #if CV_MAJOR_VERSION <= 2
 	m_pTrainedRF = NULL;
 #endif
 }
 
-RandomForestML::~RandomForestML()
+NFIQ::Prediction::RandomForestML::~RandomForestML()
 {
 #if CV_MAJOR_VERSION <= 2
 	if (m_pTrainedRF != nullptr) {
@@ -88,7 +88,7 @@ RandomForestML::~RandomForestML()
 
 #ifdef EMBED_RANDOMFOREST_PARAMETERS
 std::string
-RandomForestML::initModule()
+NFIQ::Prediction::RandomForestML::initModule()
 {
 	try {
 		// get parameters from string
@@ -111,7 +111,7 @@ RandomForestML::initModule()
 #endif
 
 std::string
-RandomForestML::initModule(
+NFIQ::Prediction::RandomForestML::initModule(
     const std::string &fileName, const std::string &fileHash)
 {
 	std::ifstream input(fileName);
@@ -137,7 +137,7 @@ RandomForestML::initModule(
 }
 
 void
-RandomForestML::evaluate(
+NFIQ::Prediction::RandomForestML::evaluate(
     const std::list<NFIQ::QualityFeatureData> &featureVector,
     const double &utilityValue, double &qualityValue, double &deviation) const
 {
@@ -199,7 +199,7 @@ RandomForestML::evaluate(
 }
 
 std::string
-RandomForestML::getModuleID()
+NFIQ::Prediction::RandomForestML::getModuleID()
 {
 	return "NFIQ2_RandomForest";
 }


### PR DESCRIPTION
Closes #173 

Placing Feature calculation functions into the NFIQ namespace so that they no longer float in the global namespace. 