### PR TITLE
Define getModuleName in BaseFeature

### DIFF
--- a/NFIQ2/NFIQ2Algorithm/include/features/BaseFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/BaseFeature.h
@@ -22,6 +22,9 @@ class BaseFeature {
 	    , m_lSpeedValues(speedValues) {};
 	virtual ~BaseFeature() {};
 
+	/** @return Identifier for this particular feature */
+	virtual std::string getModuleName() const = 0;
+
 	bool m_bOutputSpeed;
 	std::vector<NFIQ::QualityFeatureSpeed> &m_lSpeedValues;
 };

--- a/NFIQ2/NFIQ2Algorithm/include/features/FDAFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/FDAFeature.h
@@ -36,12 +36,13 @@ class FDAFeature : BaseFeature {
 	virtual std::vector<NFIQ::QualityFeatureResult> computeFeatureData(
 	    const NFIQ::FingerprintImageData &fingerprintImage);
 
-	virtual std::string getModuleID();
+	std::string getModuleName() const override;
 
 	virtual void initModule() {};
 
 	static std::vector<std::string> getAllFeatureIDs();
 	static const std::string speedFeatureIDGroup;
+	static const std::string moduleName;
 
     private:
 	int blocksize;

--- a/NFIQ2/NFIQ2Algorithm/include/features/FJFXMinutiaeQualityFeatures.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/FJFXMinutiaeQualityFeatures.h
@@ -53,12 +53,13 @@ class FJFXMinutiaeQualityFeature : BaseFeature {
 	    const std::vector<FingerJetFXFeature::Minutia> &minutiaData,
 	    bool &templateCouldBeExtracted);
 
-	std::string getModuleID();
+	std::string getModuleName() const override;
 
 	void initModule() { /* not needed here */ };
 
 	static std::vector<std::string> getAllFeatureIDs();
 	static const std::string speedFeatureIDGroup;
+	static const std::string moduleName;
 
     private:
 	std::vector<MinutiaData> computeMuMinQuality(

--- a/NFIQ2/NFIQ2Algorithm/include/features/FingerJetFXFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/FingerJetFXFeature.h
@@ -124,12 +124,13 @@ class FingerJetFXFeature : BaseFeature {
 	    std::vector<FingerJetFXFeature::Minutia> &minutiaData,
 	    bool &templateCouldBeExtracted);
 
-	std::string getModuleID();
+	std::string getModuleName() const override;
 
 	void initModule() { /* not needed here */ };
 
 	static std::vector<std::string> getAllFeatureIDs();
 	static const std::string speedFeatureIDGroup;
+	static const std::string moduleName;
 
 	static std::pair<unsigned int, unsigned int> centerOfMinutiaeMass(
 	    const std::vector<FingerJetFXFeature::Minutia> &minutiaData);

--- a/NFIQ2/NFIQ2Algorithm/include/features/ImgProcROIFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/ImgProcROIFeature.h
@@ -48,12 +48,13 @@ class ImgProcROIFeature : BaseFeature {
 	    const NFIQ::FingerprintImageData &fingerprintImage,
 	    ImgProcROIFeature::ImgProcROIResults &imgProcResults);
 
-	std::string getModuleID();
+	std::string getModuleName() const override;
 
 	void initModule() { /* not needed here */ };
 
 	static std::vector<std::string> getAllFeatureIDs();
 	static const std::string speedFeatureIDGroup;
+	static const std::string moduleName;
 
 	static ImgProcROIResults computeROI(cv::Mat &img, unsigned int bs);
 

--- a/NFIQ2/NFIQ2Algorithm/include/features/LCSFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/LCSFeature.h
@@ -30,12 +30,13 @@ class LCSFeature : BaseFeature {
 	virtual std::vector<NFIQ::QualityFeatureResult> computeFeatureData(
 	    const NFIQ::FingerprintImageData &fingerprintImage);
 
-	virtual std::string getModuleID();
+	std::string getModuleName() const override;
 
 	virtual void initModule() {};
 
 	static std::vector<std::string> getAllFeatureIDs();
 	static const std::string speedFeatureIDGroup;
+	static const std::string moduleName;
 
     protected:
 	int blocksize;

--- a/NFIQ2/NFIQ2Algorithm/include/features/MuFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/MuFeature.h
@@ -25,12 +25,13 @@ class MuFeature : BaseFeature {
 	std::vector<NFIQ::QualityFeatureResult> computeFeatureData(
 	    const NFIQ::FingerprintImageData &fingerprintImage, double &sigma);
 
-	std::string getModuleID();
+	std::string getModuleName() const override;
 
 	void initModule() { /* not needed here */ };
 
 	static std::vector<std::string> getAllFeatureIDs();
 	static const std::string speedFeatureIDGroup;
+	static const std::string moduleName;
 };
 
 }}

--- a/NFIQ2/NFIQ2Algorithm/include/features/OCLHistogramFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/OCLHistogramFeature.h
@@ -31,12 +31,13 @@ class OCLHistogramFeature : BaseFeature {
 	virtual std::vector<NFIQ::QualityFeatureResult> computeFeatureData(
 	    const NFIQ::FingerprintImageData &fingerprintImage);
 
-	virtual std::string getModuleID();
+	std::string getModuleName() const override;
 
 	virtual void initModule() { /* not needed here */ };
 
 	static std::vector<std::string> getAllFeatureIDs();
 	static const std::string speedFeatureIDGroup;
+	static const std::string moduleName;
 
 	// compute OCL value of a given block with block size BSxBS
 	static bool getOCLValueOfBlock(const cv::Mat &block, double &ocl);

--- a/NFIQ2/NFIQ2Algorithm/include/features/OFFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/OFFeature.h
@@ -37,12 +37,13 @@ class OFFeature : BaseFeature {
 	virtual std::vector<NFIQ::QualityFeatureResult> computeFeatureData(
 	    const NFIQ::FingerprintImageData &fingerprintImage);
 
-	virtual std::string getModuleID();
+	std::string getModuleName() const override;
 
 	virtual void initModule() {};
 
 	static std::vector<std::string> getAllFeatureIDs();
 	static const std::string speedFeatureIDGroup;
+	static const std::string moduleName;
 
     private:
 	int blocksize; /*!< Processing is done in subblocks of this size. */

--- a/NFIQ2/NFIQ2Algorithm/include/features/QualityMapFeatures.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/QualityMapFeatures.h
@@ -35,12 +35,13 @@ class QualityMapFeatures : BaseFeature {
 	    const NFIQ::FingerprintImageData &fingerprintImage,
 	    ImgProcROIFeature::ImgProcROIResults imgProcResults);
 
-	std::string getModuleID();
+	std::string getModuleName() const override;
 
 	void initModule() { /* not needed here */ };
 
 	static std::vector<std::string> getAllFeatureIDs();
 	static const std::string speedFeatureIDGroup;
+	static const std::string moduleName;
 
 	// compute orientation angle of a block
 	static bool getAngleOfBlock(

--- a/NFIQ2/NFIQ2Algorithm/include/features/RVUPHistogramFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/RVUPHistogramFeature.h
@@ -30,12 +30,13 @@ class RVUPHistogramFeature : BaseFeature {
 	virtual std::vector<NFIQ::QualityFeatureResult> computeFeatureData(
 	    const NFIQ::FingerprintImageData &fingerprintImage);
 
-	virtual std::string getModuleID();
+	std::string getModuleName() const override;
 
 	virtual void initModule() {};
 
 	static std::vector<std::string> getAllFeatureIDs();
 	static const std::string speedFeatureIDGroup;
+	static const std::string moduleName;
 
     protected:
 	int blocksize;

--- a/NFIQ2/NFIQ2Algorithm/include/prediction/RandomForestML.h
+++ b/NFIQ2/NFIQ2Algorithm/include/prediction/RandomForestML.h
@@ -25,7 +25,8 @@ class RandomForestML {
 	RandomForestML();
 	virtual ~RandomForestML();
 
-	std::string getModuleID();
+	static const std::string moduleName;
+	std::string getModuleName() const;
 
 #ifdef EMBED_RANDOMFOREST_PARAMETERS
 	std::string initModule();

--- a/NFIQ2/NFIQ2Algorithm/src/features/FDAFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FDAFeature.cpp
@@ -38,10 +38,11 @@ NFIQ::QualityFeatures::FDAFeature::getAllFeatureIDs()
 const std::string NFIQ::QualityFeatures::FDAFeature::speedFeatureIDGroup =
     "Frequency domain";
 
+const std::string NFIQ::QualityFeatures::FDAFeature::moduleName { "NFIQ2_FDA" };
 std::string
-NFIQ::QualityFeatures::FDAFeature::getModuleID()
+NFIQ::QualityFeatures::FDAFeature::getModuleName() const
 {
-	return "NFIQ2_FDA";
+	return moduleName;
 }
 
 std::vector<NFIQ::QualityFeatureResult>

--- a/NFIQ2/NFIQ2Algorithm/src/features/FJFXMinutiaeQualityFeatures.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FJFXMinutiaeQualityFeatures.cpp
@@ -162,10 +162,14 @@ NFIQ::QualityFeatures::FJFXMinutiaeQualityFeature::computeFeatureData(
 	return featureDataList;
 }
 
+const std::string
+    NFIQ::QualityFeatures::FJFXMinutiaeQualityFeature::moduleName {
+	    "NFIQ2_FJFXPos_MinutiaeQuality"
+    };
 std::string
-NFIQ::QualityFeatures::FJFXMinutiaeQualityFeature::getModuleID()
+NFIQ::QualityFeatures::FJFXMinutiaeQualityFeature::getModuleName() const
 {
-	return "NFIQ2_FJFXPos_MinutiaeQuality";
+	return moduleName;
 }
 
 std::vector<std::string>

--- a/NFIQ2/NFIQ2Algorithm/src/features/FingerJetFXFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FingerJetFXFeature.cpp
@@ -276,10 +276,13 @@ NFIQ::QualityFeatures::FingerJetFXFeature::computeFeatureData(
 	return featureDataList;
 }
 
+const std::string NFIQ::QualityFeatures::FingerJetFXFeature::moduleName {
+	"NFIQ2_FingerJetFX"
+};
 std::string
-NFIQ::QualityFeatures::FingerJetFXFeature::getModuleID()
+NFIQ::QualityFeatures::FingerJetFXFeature::getModuleName() const
 {
-	return "NFIQ2_FingerJetFX";
+	return moduleName;
 }
 
 std::vector<std::string>

--- a/NFIQ2/NFIQ2Algorithm/src/features/ImgProcROIFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/ImgProcROIFeature.cpp
@@ -89,10 +89,14 @@ NFIQ::QualityFeatures::ImgProcROIFeature::computeFeatureData(
 	return featureDataList;
 }
 
+const std::string NFIQ::QualityFeatures::ImgProcROIFeature::moduleName {
+	"NFIQ2_ImgProcROI"
+};
+
 std::string
-NFIQ::QualityFeatures::ImgProcROIFeature::getModuleID()
+NFIQ::QualityFeatures::ImgProcROIFeature::getModuleName() const
 {
-	return "NFIQ2_ImgProcROI";
+	return moduleName;
 }
 
 std::vector<std::string>

--- a/NFIQ2/NFIQ2Algorithm/src/features/LCSFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/LCSFeature.cpp
@@ -22,10 +22,12 @@ NFIQ::QualityFeatures::LCSFeature::~LCSFeature()
 {
 }
 
+const std::string NFIQ::QualityFeatures::LCSFeature::moduleName { "NFIQ2_LCS" };
+
 std::string
-NFIQ::QualityFeatures::LCSFeature::getModuleID()
+NFIQ::QualityFeatures::LCSFeature::getModuleName() const
 {
-	return "NFIQ2_LCS";
+	return moduleName;
 }
 
 std::vector<std::string>

--- a/NFIQ2/NFIQ2Algorithm/src/features/MuFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/MuFeature.cpp
@@ -151,10 +151,12 @@ NFIQ::QualityFeatures::MuFeature::computeFeatureData(
 	return featureDataList;
 }
 
+const std::string NFIQ::QualityFeatures::MuFeature::moduleName { "NFIQ2_Mu" };
+
 std::string
-NFIQ::QualityFeatures::MuFeature::getModuleID()
+NFIQ::QualityFeatures::MuFeature::getModuleName() const
 {
-	return "NFIQ2_Mu";
+	return moduleName;
 }
 
 std::vector<std::string>

--- a/NFIQ2/NFIQ2Algorithm/src/features/OCLHistogramFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/OCLHistogramFeature.cpp
@@ -171,8 +171,12 @@ NFIQ::QualityFeatures::OCLHistogramFeature::getOCLValueOfBlock(
 	return true;
 }
 
+const std::string NFIQ::QualityFeatures::OCLHistogramFeature::moduleName {
+	"NFIQ2_OCLHistogram"
+};
+
 std::string
-NFIQ::QualityFeatures::OCLHistogramFeature::getModuleID()
+NFIQ::QualityFeatures::OCLHistogramFeature::getModuleName() const
 {
 	return "NFIQ2_OCLHistogram";
 }

--- a/NFIQ2/NFIQ2Algorithm/src/features/OFFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/OFFeature.cpp
@@ -23,10 +23,11 @@ NFIQ::QualityFeatures::OFFeature::~OFFeature()
 {
 }
 
+const std::string NFIQ::QualityFeatures::OFFeature::moduleName { "NFIQ2_OF" };
 std::string
-NFIQ::QualityFeatures::OFFeature::getModuleID()
+NFIQ::QualityFeatures::OFFeature::getModuleName() const
 {
-	return "NFIQ2_OF";
+	return moduleName;
 }
 
 std::vector<std::string>

--- a/NFIQ2/NFIQ2Algorithm/src/features/QualityMapFeatures.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/QualityMapFeatures.cpp
@@ -321,10 +321,13 @@ NFIQ::QualityFeatures::QualityMapFeatures::computeNumericalGradients(
 	grad_y = computeNumericalGradientX(mat.t()).t();
 }
 
+const std::string NFIQ::QualityFeatures::QualityMapFeatures::moduleName {
+	"NFIQ2_QualityMap"
+};
 std::string
-NFIQ::QualityFeatures::QualityMapFeatures::getModuleID()
+NFIQ::QualityFeatures::QualityMapFeatures::getModuleName() const
 {
-	return "NFIQ2_QualityMap";
+	return moduleName;
 }
 
 std::vector<std::string>

--- a/NFIQ2/NFIQ2Algorithm/src/features/RVUPHistogramFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/RVUPHistogramFeature.cpp
@@ -181,8 +181,12 @@ NFIQ::QualityFeatures::RVUPHistogramFeature::computeFeatureData(
 	return featureDataList;
 }
 
+const std::string NFIQ::QualityFeatures::RVUPHistogramFeature::moduleName {
+	"NFIQ2_RVUPHistogram"
+};
+
 std::string
-NFIQ::QualityFeatures::RVUPHistogramFeature::getModuleID()
+NFIQ::QualityFeatures::RVUPHistogramFeature::getModuleName() const
 {
 	return "NFIQ2_RVUPHistogram";
 }

--- a/NFIQ2/NFIQ2Algorithm/src/prediction/RandomForestML.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/prediction/RandomForestML.cpp
@@ -198,8 +198,12 @@ NFIQ::Prediction::RandomForestML::evaluate(
 	}
 }
 
+const std::string NFIQ::Prediction::RandomForestML::moduleName {
+	"NFIQ2_RandomForest"
+};
+
 std::string
-NFIQ::Prediction::RandomForestML::getModuleID()
+NFIQ::Prediction::RandomForestML::getModuleName() const
 {
-	return "NFIQ2_RandomForest";
+	return moduleName;
 }


### PR DESCRIPTION
 * Define static const string for module name (was re-created every time)
 * Change from getModuleID() to getModuleName(), since ID might convey uniqueness.