### PR TITLE
Make computeFeatureData have a consistent sig

### DIFF
--- a/NFIQ2/NFIQ2Algorithm/include/features/FJFXMinutiaeQualityFeatures.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/FJFXMinutiaeQualityFeatures.h
@@ -51,7 +51,7 @@ class FJFXMinutiaeQualityFeature : BaseFeature {
 	std::vector<NFIQ::QualityFeatureResult> computeFeatureData(
 	    const NFIQ::FingerprintImageData &fingerprintImage,
 	    const std::vector<FingerJetFXFeature::Minutia> &minutiaData,
-	    const bool &templateCouldBeExtracted);
+	    bool &templateCouldBeExtracted);
 
 	std::string getModuleName() const override;
 

--- a/NFIQ2/NFIQ2Algorithm/include/features/FJFXMinutiaeQualityFeatures.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/FJFXMinutiaeQualityFeatures.h
@@ -51,7 +51,7 @@ class FJFXMinutiaeQualityFeature : BaseFeature {
 	std::vector<NFIQ::QualityFeatureResult> computeFeatureData(
 	    const NFIQ::FingerprintImageData &fingerprintImage,
 	    const std::vector<FingerJetFXFeature::Minutia> &minutiaData,
-	    bool &templateCouldBeExtracted);
+	    const bool &templateCouldBeExtracted);
 
 	std::string getModuleName() const override;
 

--- a/NFIQ2/NFIQ2Algorithm/include/features/FJFXMinutiaeQualityFeatures.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/FJFXMinutiaeQualityFeatures.h
@@ -63,7 +63,11 @@ class FJFXMinutiaeQualityFeature : BaseFeature {
 	static const std::string speedFeatureIDGroup;
 	static const std::string moduleName;
 
+	/** @throw NFIQ::NFIQException
+	 * Template could not be extracted.
+	 */
 	std::vector<FingerJetFXFeature::Minutia> getMinutiaData() const;
+
 	bool getTemplateStatus() const;
 
     private:

--- a/NFIQ2/NFIQ2Algorithm/include/features/FJFXMinutiaeQualityFeatures.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/FJFXMinutiaeQualityFeatures.h
@@ -44,14 +44,16 @@ class FJFXMinutiaeQualityFeature : BaseFeature {
 	};
 
 	FJFXMinutiaeQualityFeature(bool bOutputSpeed,
-	    std::vector<NFIQ::QualityFeatureSpeed> &speedValues)
-	    : BaseFeature(bOutputSpeed, speedValues) {};
+	    std::vector<NFIQ::QualityFeatureSpeed> &speedValues,
+	    const std::vector<FingerJetFXFeature::Minutia> &minutiaData,
+	    const bool templateCouldBeExtracted)
+	    : BaseFeature(bOutputSpeed, speedValues)
+	    , minutiaData_ { minutiaData }
+	    , templateCouldBeExtracted_ { templateCouldBeExtracted } {};
 	virtual ~FJFXMinutiaeQualityFeature();
 
 	std::vector<NFIQ::QualityFeatureResult> computeFeatureData(
-	    const NFIQ::FingerprintImageData &fingerprintImage,
-	    const std::vector<FingerJetFXFeature::Minutia> &minutiaData,
-	    const bool &templateCouldBeExtracted);
+	    const NFIQ::FingerprintImageData &fingerprintImage);
 
 	std::string getModuleName() const override;
 
@@ -61,17 +63,19 @@ class FJFXMinutiaeQualityFeature : BaseFeature {
 	static const std::string speedFeatureIDGroup;
 	static const std::string moduleName;
 
+	std::vector<FingerJetFXFeature::Minutia> getMinutiaData() const;
+	bool getTemplateStatus() const;
+
     private:
+	std::vector<FingerJetFXFeature::Minutia> minutiaData_ {};
+	bool templateCouldBeExtracted_ { false };
 	std::vector<MinutiaData> computeMuMinQuality(
-	    const std::vector<FingerJetFXFeature::Minutia> &minutiaData, int bs,
-	    const NFIQ::FingerprintImageData &fingerprintImage);
+	    int bs, const NFIQ::FingerprintImageData &fingerprintImage);
 
 	std::vector<MinutiaData> computeOCLMinQuality(
-	    const std::vector<FingerJetFXFeature::Minutia> &minutiaData, int bs,
-	    const NFIQ::FingerprintImageData &fingerprintImage);
+	    int bs, const NFIQ::FingerprintImageData &fingerprintImage);
 
-	double computeMMBBasedOnCOM(
-	    const std::vector<FingerJetFXFeature::Minutia> &minutiaData, int bs,
+	double computeMMBBasedOnCOM(int bs,
 	    const NFIQ::FingerprintImageData &fingerprintImage,
 	    unsigned int regionSize);
 };

--- a/NFIQ2/NFIQ2Algorithm/include/features/FingerJetFXFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/FingerJetFXFeature.h
@@ -120,9 +120,7 @@ class FingerJetFXFeature : BaseFeature {
 	virtual ~FingerJetFXFeature();
 
 	std::vector<NFIQ::QualityFeatureResult> computeFeatureData(
-	    const NFIQ::FingerprintImageData fingerprintImage,
-	    std::vector<FingerJetFXFeature::Minutia> &minutiaData,
-	    bool &templateCouldBeExtracted);
+	    const NFIQ::FingerprintImageData fingerprintImage);
 
 	std::string getModuleName() const override;
 
@@ -132,17 +130,21 @@ class FingerJetFXFeature : BaseFeature {
 	static const std::string speedFeatureIDGroup;
 	static const std::string moduleName;
 
-	static std::pair<unsigned int, unsigned int> centerOfMinutiaeMass(
-	    const std::vector<FingerJetFXFeature::Minutia> &minutiaData);
+	std::pair<unsigned int, unsigned int> centerOfMinutiaeMass();
 
 	static std::string parseFRFXLLError(const FRFXLL_RESULT fxRes);
+
+	std::vector<FingerJetFXFeature::Minutia> getMinutiaData() const;
+	bool getTemplateStatus() const;
 
     private:
 	FRFXLL_RESULT
 	createContext(FRFXLL_HANDLE_PT phContext);
 
-	FJFXROIResults computeROI(
-	    const std::vector<FingerJetFXFeature::Minutia> &minutiaData, int bs,
+	std::vector<FingerJetFXFeature::Minutia> minutiaData {};
+	bool templateCouldBeExtracted { false };
+
+	FJFXROIResults computeROI(int bs,
 	    const NFIQ::FingerprintImageData &fingerprintImage,
 	    std::vector<FingerJetFXFeature::Object> vecRectDimensions);
 };

--- a/NFIQ2/NFIQ2Algorithm/include/features/FingerJetFXFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/FingerJetFXFeature.h
@@ -141,8 +141,8 @@ class FingerJetFXFeature : BaseFeature {
 	FRFXLL_RESULT
 	createContext(FRFXLL_HANDLE_PT phContext);
 
-	std::vector<FingerJetFXFeature::Minutia> minutiaData {};
-	bool templateCouldBeExtracted { false };
+	std::vector<FingerJetFXFeature::Minutia> minutiaData_ {};
+	bool templateCouldBeExtracted_ { false };
 
 	FJFXROIResults computeROI(int bs,
 	    const NFIQ::FingerprintImageData &fingerprintImage,

--- a/NFIQ2/NFIQ2Algorithm/include/features/FingerJetFXFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/FingerJetFXFeature.h
@@ -134,7 +134,11 @@ class FingerJetFXFeature : BaseFeature {
 
 	static std::string parseFRFXLLError(const FRFXLL_RESULT fxRes);
 
+	/** @throw NFIQ::NFIQException
+	 * Template could not be extracted.
+	 */
 	std::vector<FingerJetFXFeature::Minutia> getMinutiaData() const;
+
 	bool getTemplateStatus() const;
 
     private:

--- a/NFIQ2/NFIQ2Algorithm/include/features/FingerJetFXFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/FingerJetFXFeature.h
@@ -120,7 +120,9 @@ class FingerJetFXFeature : BaseFeature {
 	virtual ~FingerJetFXFeature();
 
 	std::vector<NFIQ::QualityFeatureResult> computeFeatureData(
-	    const NFIQ::FingerprintImageData fingerprintImage);
+	    const NFIQ::FingerprintImageData fingerprintImage,
+	    std::vector<FingerJetFXFeature::Minutia> &minutiaData,
+	    bool &templateCouldBeExtracted);
 
 	std::string getModuleName() const override;
 
@@ -130,21 +132,17 @@ class FingerJetFXFeature : BaseFeature {
 	static const std::string speedFeatureIDGroup;
 	static const std::string moduleName;
 
-	std::pair<unsigned int, unsigned int> centerOfMinutiaeMass();
+	static std::pair<unsigned int, unsigned int> centerOfMinutiaeMass(
+	    const std::vector<FingerJetFXFeature::Minutia> &minutiaData);
 
 	static std::string parseFRFXLLError(const FRFXLL_RESULT fxRes);
-
-	std::vector<FingerJetFXFeature::Minutia> getMinutiaData() const;
-	bool getTemplateStatus() const;
 
     private:
 	FRFXLL_RESULT
 	createContext(FRFXLL_HANDLE_PT phContext);
 
-	std::vector<FingerJetFXFeature::Minutia> minutiaData {};
-	bool templateCouldBeExtracted { false };
-
-	FJFXROIResults computeROI(int bs,
+	FJFXROIResults computeROI(
+	    const std::vector<FingerJetFXFeature::Minutia> &minutiaData, int bs,
 	    const NFIQ::FingerprintImageData &fingerprintImage,
 	    std::vector<FingerJetFXFeature::Object> vecRectDimensions);
 };

--- a/NFIQ2/NFIQ2Algorithm/include/features/FingerJetFXFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/FingerJetFXFeature.h
@@ -120,7 +120,7 @@ class FingerJetFXFeature : BaseFeature {
 	virtual ~FingerJetFXFeature();
 
 	std::vector<NFIQ::QualityFeatureResult> computeFeatureData(
-	    const NFIQ::FingerprintImageData fingerprintImage);
+	    const NFIQ::FingerprintImageData &fingerprintImage);
 
 	std::string getModuleName() const override;
 
@@ -130,7 +130,9 @@ class FingerJetFXFeature : BaseFeature {
 	static const std::string speedFeatureIDGroup;
 	static const std::string moduleName;
 
-	std::pair<unsigned int, unsigned int> centerOfMinutiaeMass();
+	static std::pair<unsigned int, unsigned int>
+	centerOfMinutiaeMass(const std::vector<
+	    NFIQ::QualityFeatures::FingerJetFXFeature::Minutia> &minutiaData);
 
 	static std::string parseFRFXLLError(const FRFXLL_RESULT fxRes);
 

--- a/NFIQ2/NFIQ2Algorithm/include/features/FingerJetFXFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/FingerJetFXFeature.h
@@ -130,9 +130,8 @@ class FingerJetFXFeature : BaseFeature {
 	static const std::string speedFeatureIDGroup;
 	static const std::string moduleName;
 
-	static std::pair<unsigned int, unsigned int>
-	centerOfMinutiaeMass(const std::vector<
-	    NFIQ::QualityFeatures::FingerJetFXFeature::Minutia> &minutiaData);
+	static std::pair<unsigned int, unsigned int> centerOfMinutiaeMass(
+	    const std::vector<FingerJetFXFeature::Minutia> &minutiaData);
 
 	static std::string parseFRFXLLError(const FRFXLL_RESULT fxRes);
 

--- a/NFIQ2/NFIQ2Algorithm/include/features/ImgProcROIFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/ImgProcROIFeature.h
@@ -45,8 +45,7 @@ class ImgProcROIFeature : BaseFeature {
 	virtual ~ImgProcROIFeature();
 
 	std::vector<NFIQ::QualityFeatureResult> computeFeatureData(
-	    const NFIQ::FingerprintImageData &fingerprintImage,
-	    ImgProcROIFeature::ImgProcROIResults &imgProcResults);
+	    const NFIQ::FingerprintImageData &fingerprintImage);
 
 	std::string getModuleName() const override;
 
@@ -58,7 +57,10 @@ class ImgProcROIFeature : BaseFeature {
 
 	static ImgProcROIResults computeROI(cv::Mat &img, unsigned int bs);
 
+	ImgProcROIResults getImgProcResults();
+
     private:
+	ImgProcROIResults imgProcResults_ {};
 	static bool isBlackPixelAvailable(cv::Mat &img, cv::Point &point);
 };
 

--- a/NFIQ2/NFIQ2Algorithm/include/features/ImgProcROIFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/ImgProcROIFeature.h
@@ -57,10 +57,14 @@ class ImgProcROIFeature : BaseFeature {
 
 	static ImgProcROIResults computeROI(cv::Mat &img, unsigned int bs);
 
+	/** @throw NFIQ::NFIQException
+	 * Img Proc Results could not be computed.
+	 */
 	ImgProcROIResults getImgProcResults();
 
     private:
 	ImgProcROIResults imgProcResults_ {};
+	bool imgProcComputed_ { false };
 	static bool isBlackPixelAvailable(cv::Mat &img, cv::Point &point);
 };
 

--- a/NFIQ2/NFIQ2Algorithm/include/features/QualityMapFeatures.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/QualityMapFeatures.h
@@ -27,13 +27,14 @@ namespace NFIQ { namespace QualityFeatures {
 class QualityMapFeatures : BaseFeature {
     public:
 	QualityMapFeatures(bool bOutputSpeed,
-	    std::vector<NFIQ::QualityFeatureSpeed> &speedValues)
-	    : BaseFeature(bOutputSpeed, speedValues) {};
+	    std::vector<NFIQ::QualityFeatureSpeed> &speedValues,
+	    const ImgProcROIFeature::ImgProcROIResults &imgProcResults)
+	    : BaseFeature(bOutputSpeed, speedValues)
+	    , imgProcResults_ { imgProcResults } {};
 	virtual ~QualityMapFeatures();
 
 	std::vector<NFIQ::QualityFeatureResult> computeFeatureData(
-	    const NFIQ::FingerprintImageData &fingerprintImage,
-	    ImgProcROIFeature::ImgProcROIResults imgProcResults);
+	    const NFIQ::FingerprintImageData &fingerprintImage);
 
 	std::string getModuleName() const override;
 
@@ -66,6 +67,9 @@ class QualityMapFeatures : BaseFeature {
 	static cv::Mat computeNumericalGradientX(const cv::Mat &mat);
 	static void computeNumericalGradients(
 	    const cv::Mat &mat, cv::Mat &grad_x, cv::Mat &grad_y);
+
+    private:
+	ImgProcROIFeature::ImgProcROIResults imgProcResults_ {};
 };
 
 }}

--- a/NFIQ2/NFIQ2Algorithm/src/features/FJFXMinutiaeQualityFeatures.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FJFXMinutiaeQualityFeatures.cpp
@@ -20,7 +20,7 @@ std::vector<NFIQ::QualityFeatureResult>
 NFIQ::QualityFeatures::FJFXMinutiaeQualityFeature::computeFeatureData(
     const NFIQ::FingerprintImageData &fingerprintImage,
     const std::vector<FingerJetFXFeature::Minutia> &minutiaData,
-    const bool &templateCouldBeExtracted)
+    bool &templateCouldBeExtracted)
 {
 	std::vector<NFIQ::QualityFeatureResult> featureDataList;
 

--- a/NFIQ2/NFIQ2Algorithm/src/features/FJFXMinutiaeQualityFeatures.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FJFXMinutiaeQualityFeatures.cpp
@@ -20,7 +20,7 @@ std::vector<NFIQ::QualityFeatureResult>
 NFIQ::QualityFeatures::FJFXMinutiaeQualityFeature::computeFeatureData(
     const NFIQ::FingerprintImageData &fingerprintImage,
     const std::vector<FingerJetFXFeature::Minutia> &minutiaData,
-    bool &templateCouldBeExtracted)
+    const bool &templateCouldBeExtracted)
 {
 	std::vector<NFIQ::QualityFeatureResult> featureDataList;
 

--- a/NFIQ2/NFIQ2Algorithm/src/features/FingerJetFXFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FingerJetFXFeature.cpp
@@ -15,16 +15,15 @@ const std::string
     NFIQ::QualityFeatures::FingerJetFXFeature::speedFeatureIDGroup = "Minutiae";
 
 std::pair<unsigned int, unsigned int>
-NFIQ::QualityFeatures::FingerJetFXFeature::centerOfMinutiaeMass(
-    const std::vector<FingerJetFXFeature::Minutia> &minutiaData)
+NFIQ::QualityFeatures::FingerJetFXFeature::centerOfMinutiaeMass()
 {
 	unsigned int lx { 0 }, ly { 0 };
-	for (const auto &m : minutiaData) {
+	for (const auto &m : this->minutiaData) {
 		lx += m.x;
 		ly += m.y;
 	}
 	return std::make_pair<unsigned int, unsigned int>(
-	    lx / minutiaData.size(), ly / minutiaData.size());
+	    lx / this->minutiaData.size(), ly / this->minutiaData.size());
 }
 
 std::string
@@ -65,13 +64,28 @@ NFIQ::QualityFeatures::FingerJetFXFeature::parseFRFXLLError(
 	}
 }
 
+bool
+NFIQ::QualityFeatures::FingerJetFXFeature::getTemplateStatus() const
+{
+	return (this->templateCouldBeExtracted);
+}
+
+std::vector<NFIQ::QualityFeatures::FingerJetFXFeature::Minutia>
+NFIQ::QualityFeatures::FingerJetFXFeature::getMinutiaData() const
+{
+	if (!this->templateCouldBeExtracted) {
+		throw NFIQ::NFIQException { e_Error_NoDataAvailable,
+			"Template could not be extracted." };
+	}
+
+	return (this->minutiaData);
+}
+
 std::vector<NFIQ::QualityFeatureResult>
 NFIQ::QualityFeatures::FingerJetFXFeature::computeFeatureData(
-    const NFIQ::FingerprintImageData fingerprintImage,
-    std::vector<FingerJetFXFeature::Minutia> &minutiaData,
-    bool &templateCouldBeExtracted)
+    const NFIQ::FingerprintImageData fingerprintImage)
 {
-	templateCouldBeExtracted = false;
+	this->templateCouldBeExtracted = false;
 
 	std::vector<NFIQ::QualityFeatureResult> featureDataList;
 
@@ -181,10 +195,11 @@ NFIQ::QualityFeatures::FingerJetFXFeature::computeFeatureData(
 			FingerJetFXFeature::parseFRFXLLError(fxResData));
 	}
 
-	minutiaData.clear();
-	minutiaData.reserve(minCnt);
+	this->minutiaData.clear();
+	this->minutiaData.reserve(minCnt);
 	for (int i = 0; i < minCnt; i++) {
-		minutiaData.emplace_back(static_cast<unsigned int>(mdata[i].x),
+		this->minutiaData.emplace_back(
+		    static_cast<unsigned int>(mdata[i].x),
 		    static_cast<unsigned int>(mdata[i].y),
 		    static_cast<unsigned int>(mdata[i].a),
 		    static_cast<unsigned int>(mdata[i].q),
@@ -196,7 +211,7 @@ NFIQ::QualityFeatures::FingerJetFXFeature::computeFeatureData(
 	// close handle
 	FRFXLLCloseHandle(&hFeatureSet);
 
-	templateCouldBeExtracted = true;
+	this->templateCouldBeExtracted = true;
 
 	if (minCnt == 0) {
 		// return features
@@ -235,7 +250,7 @@ NFIQ::QualityFeatures::FingerJetFXFeature::computeFeatureData(
 	vecRectDimensions.push_back(rect200x200);
 
 	FingerJetFXFeature::FJFXROIResults roiResults = computeROI(
-	    minutiaData, 32, fingerprintImage, vecRectDimensions);
+	    32, fingerprintImage, vecRectDimensions);
 	double noOfMinInRect200x200 = 0;
 	for (unsigned int i = 0;
 	     i < roiResults.vecNoOfMinutiaeInRectangular.size(); i++) {
@@ -311,8 +326,7 @@ NFIQ::QualityFeatures::FingerJetFXFeature::createContext(
 }
 
 NFIQ::QualityFeatures::FingerJetFXFeature::FJFXROIResults
-NFIQ::QualityFeatures::FingerJetFXFeature::computeROI(
-    const std::vector<FingerJetFXFeature::Minutia> &minutiaData, int bs,
+NFIQ::QualityFeatures::FingerJetFXFeature::computeROI(int bs,
     const NFIQ::FingerprintImageData &fingerprintImage,
     std::vector<FingerJetFXFeature::Object> vecRectDimensions)
 {
@@ -325,7 +339,7 @@ NFIQ::QualityFeatures::FingerJetFXFeature::computeROI(
 	// compute Centre of Mass based on minutiae
 	std::tie(roiResults.centreOfMassMinutiae.x,
 	    roiResults.centreOfMassMinutiae.y) =
-	    FingerJetFXFeature::centerOfMinutiaeMass(minutiaData);
+	    FingerJetFXFeature::centerOfMinutiaeMass();
 
 	// get number of minutiae that lie inside a block defined by the Centre
 	// of Mass (COM)
@@ -362,7 +376,7 @@ NFIQ::QualityFeatures::FingerJetFXFeature::computeROI(
 		}
 
 		unsigned int noOfMinutiaeInRect = 0;
-		for (const auto &m : minutiaData) {
+		for (const auto &m : this->minutiaData) {
 			if (m.x >= startX && m.x <= endX && m.y >= startY &&
 			    m.y <= endY) {
 				// minutia is inside rectangular

--- a/NFIQ2/NFIQ2Algorithm/src/features/FingerJetFXFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FingerJetFXFeature.cpp
@@ -16,8 +16,7 @@ const std::string
 
 std::pair<unsigned int, unsigned int>
 NFIQ::QualityFeatures::FingerJetFXFeature::centerOfMinutiaeMass(
-    const std::vector<NFIQ::QualityFeatures::FingerJetFXFeature::Minutia>
-	&minutiaData)
+    const std::vector<FingerJetFXFeature::Minutia> &minutiaData)
 {
 	unsigned int lx { 0 }, ly { 0 };
 	for (const auto &m : minutiaData) {

--- a/NFIQ2/NFIQ2Algorithm/src/features/FingerJetFXFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FingerJetFXFeature.cpp
@@ -15,15 +15,17 @@ const std::string
     NFIQ::QualityFeatures::FingerJetFXFeature::speedFeatureIDGroup = "Minutiae";
 
 std::pair<unsigned int, unsigned int>
-NFIQ::QualityFeatures::FingerJetFXFeature::centerOfMinutiaeMass()
+NFIQ::QualityFeatures::FingerJetFXFeature::centerOfMinutiaeMass(
+    const std::vector<NFIQ::QualityFeatures::FingerJetFXFeature::Minutia>
+	&minutiaData)
 {
 	unsigned int lx { 0 }, ly { 0 };
-	for (const auto &m : this->minutiaData_) {
+	for (const auto &m : minutiaData) {
 		lx += m.x;
 		ly += m.y;
 	}
 	return std::make_pair<unsigned int, unsigned int>(
-	    lx / this->minutiaData_.size(), ly / this->minutiaData_.size());
+	    lx / minutiaData.size(), ly / minutiaData.size());
 }
 
 std::string
@@ -83,7 +85,7 @@ NFIQ::QualityFeatures::FingerJetFXFeature::getMinutiaData() const
 
 std::vector<NFIQ::QualityFeatureResult>
 NFIQ::QualityFeatures::FingerJetFXFeature::computeFeatureData(
-    const NFIQ::FingerprintImageData fingerprintImage)
+    const NFIQ::FingerprintImageData &fingerprintImage)
 {
 	this->templateCouldBeExtracted_ = false;
 
@@ -339,7 +341,7 @@ NFIQ::QualityFeatures::FingerJetFXFeature::computeROI(int bs,
 	// compute Centre of Mass based on minutiae
 	std::tie(roiResults.centreOfMassMinutiae.x,
 	    roiResults.centreOfMassMinutiae.y) =
-	    FingerJetFXFeature::centerOfMinutiaeMass();
+	    FingerJetFXFeature::centerOfMinutiaeMass(this->minutiaData_);
 
 	// get number of minutiae that lie inside a block defined by the Centre
 	// of Mass (COM)

--- a/NFIQ2/NFIQ2Algorithm/src/features/FingerJetFXFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FingerJetFXFeature.cpp
@@ -18,12 +18,12 @@ std::pair<unsigned int, unsigned int>
 NFIQ::QualityFeatures::FingerJetFXFeature::centerOfMinutiaeMass()
 {
 	unsigned int lx { 0 }, ly { 0 };
-	for (const auto &m : this->minutiaData) {
+	for (const auto &m : this->minutiaData_) {
 		lx += m.x;
 		ly += m.y;
 	}
 	return std::make_pair<unsigned int, unsigned int>(
-	    lx / this->minutiaData.size(), ly / this->minutiaData.size());
+	    lx / this->minutiaData_.size(), ly / this->minutiaData_.size());
 }
 
 std::string
@@ -67,25 +67,25 @@ NFIQ::QualityFeatures::FingerJetFXFeature::parseFRFXLLError(
 bool
 NFIQ::QualityFeatures::FingerJetFXFeature::getTemplateStatus() const
 {
-	return (this->templateCouldBeExtracted);
+	return (this->templateCouldBeExtracted_);
 }
 
 std::vector<NFIQ::QualityFeatures::FingerJetFXFeature::Minutia>
 NFIQ::QualityFeatures::FingerJetFXFeature::getMinutiaData() const
 {
-	if (!this->templateCouldBeExtracted) {
+	if (!this->templateCouldBeExtracted_) {
 		throw NFIQ::NFIQException { e_Error_NoDataAvailable,
 			"Template could not be extracted." };
 	}
 
-	return (this->minutiaData);
+	return (this->minutiaData_);
 }
 
 std::vector<NFIQ::QualityFeatureResult>
 NFIQ::QualityFeatures::FingerJetFXFeature::computeFeatureData(
     const NFIQ::FingerprintImageData fingerprintImage)
 {
-	this->templateCouldBeExtracted = false;
+	this->templateCouldBeExtracted_ = false;
 
 	std::vector<NFIQ::QualityFeatureResult> featureDataList;
 
@@ -195,10 +195,10 @@ NFIQ::QualityFeatures::FingerJetFXFeature::computeFeatureData(
 			FingerJetFXFeature::parseFRFXLLError(fxResData));
 	}
 
-	this->minutiaData.clear();
-	this->minutiaData.reserve(minCnt);
+	this->minutiaData_.clear();
+	this->minutiaData_.reserve(minCnt);
 	for (int i = 0; i < minCnt; i++) {
-		this->minutiaData.emplace_back(
+		this->minutiaData_.emplace_back(
 		    static_cast<unsigned int>(mdata[i].x),
 		    static_cast<unsigned int>(mdata[i].y),
 		    static_cast<unsigned int>(mdata[i].a),
@@ -211,7 +211,7 @@ NFIQ::QualityFeatures::FingerJetFXFeature::computeFeatureData(
 	// close handle
 	FRFXLLCloseHandle(&hFeatureSet);
 
-	this->templateCouldBeExtracted = true;
+	this->templateCouldBeExtracted_ = true;
 
 	if (minCnt == 0) {
 		// return features
@@ -376,7 +376,7 @@ NFIQ::QualityFeatures::FingerJetFXFeature::computeROI(int bs,
 		}
 
 		unsigned int noOfMinutiaeInRect = 0;
-		for (const auto &m : this->minutiaData) {
+		for (const auto &m : this->minutiaData_) {
 			if (m.x >= startX && m.x <= endX && m.y >= startY &&
 			    m.y <= endY) {
 				// minutia is inside rectangular

--- a/NFIQ2/NFIQ2Algorithm/src/features/ImgProcROIFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/ImgProcROIFeature.cpp
@@ -16,10 +16,15 @@ const std::string
     NFIQ::QualityFeatures::ImgProcROIFeature::speedFeatureIDGroup =
 	"Region of interest";
 
+NFIQ::QualityFeatures::ImgProcROIFeature::ImgProcROIResults
+NFIQ::QualityFeatures::ImgProcROIFeature::getImgProcResults()
+{
+	return (this->imgProcResults_);
+}
+
 std::vector<NFIQ::QualityFeatureResult>
 NFIQ::QualityFeatures::ImgProcROIFeature::computeFeatureData(
-    const NFIQ::FingerprintImageData &fingerprintImage,
-    ImgProcROIFeature::ImgProcROIResults &imgProcResults)
+    const NFIQ::FingerprintImageData &fingerprintImage)
 {
 	std::vector<NFIQ::QualityFeatureResult> featureDataList;
 
@@ -50,7 +55,7 @@ NFIQ::QualityFeatures::ImgProcROIFeature::computeFeatureData(
 	// compute ROI (and other features based on ROI)
 	// ---------------------------------------------
 	try {
-		imgProcResults = computeROI(
+		this->imgProcResults_ = computeROI(
 		    img, 16); // block size = 16x16 pixels
 
 		NFIQ::QualityFeatureData fd_roi_pixel_area_mean;
@@ -58,7 +63,7 @@ NFIQ::QualityFeatures::ImgProcROIFeature::computeFeatureData(
 		fd_roi_pixel_area_mean.featureDataType =
 		    NFIQ::e_QualityFeatureDataTypeDouble;
 		fd_roi_pixel_area_mean.featureDataDouble =
-		    imgProcResults.meanOfROIPixels;
+		    this->imgProcResults_.meanOfROIPixels;
 		NFIQ::QualityFeatureResult res_roi_pixel_area_mean;
 		res_roi_pixel_area_mean.featureData = fd_roi_pixel_area_mean;
 		res_roi_pixel_area_mean.returnCode = 0;

--- a/NFIQ2/NFIQ2Algorithm/src/features/ImgProcROIFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/ImgProcROIFeature.cpp
@@ -19,6 +19,11 @@ const std::string
 NFIQ::QualityFeatures::ImgProcROIFeature::ImgProcROIResults
 NFIQ::QualityFeatures::ImgProcROIFeature::getImgProcResults()
 {
+	if (!this->imgProcComputed_) {
+		throw NFIQ::NFIQException { e_Error_NoDataAvailable,
+			"Img Proc Results could not be computed." };
+	}
+
 	return (this->imgProcResults_);
 }
 
@@ -90,6 +95,8 @@ NFIQ::QualityFeatures::ImgProcROIFeature::computeFeatureData(
 		throw NFIQ::NFIQException(NFIQ::e_Error_FeatureCalculationError,
 		    "Unknown exception occurred!");
 	}
+
+	this->imgProcComputed_ = true;
 
 	return featureDataList;
 }

--- a/NFIQ2/NFIQ2Algorithm/src/features/QualityMapFeatures.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/QualityMapFeatures.cpp
@@ -29,8 +29,7 @@ const std::string
 
 std::vector<NFIQ::QualityFeatureResult>
 NFIQ::QualityFeatures::QualityMapFeatures::computeFeatureData(
-    const NFIQ::FingerprintImageData &fingerprintImage,
-    ImgProcROIFeature::ImgProcROIResults imgProcResults)
+    const NFIQ::FingerprintImageData &fingerprintImage)
 {
 	std::vector<NFIQ::QualityFeatureResult> featureDataList;
 
@@ -67,7 +66,8 @@ NFIQ::QualityFeatures::QualityMapFeatures::computeFeatureData(
 		double coherenceSumFilter = 0.0;
 		double coherenceRelFilter = 0.0;
 		Mat orientationMapImgFilter = computeOrientationMap(img, true,
-		    coherenceSumFilter, coherenceRelFilter, 16, imgProcResults);
+		    coherenceSumFilter, coherenceRelFilter, 16,
+		    this->imgProcResults_);
 
 		// return features based on coherence values of orientation map
 		NFIQ::QualityFeatureData fd_om_2;

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures_impl.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures_impl.cpp
@@ -285,10 +285,10 @@ NFIQ::QualityFeatures::Impl::computeQualityFeatures(
 	// compute quality map features
 	// OrientationMap_ROIFilter_CoherenceRel
 	// OrientationMap_ROIFilter_CoherenceSum
-	QualityMapFeatures qmFeatureModule(bOutputSpeed, speedValues);
+	QualityMapFeatures qmFeatureModule(
+	    bOutputSpeed, speedValues, roiFeatureModule.getImgProcResults());
 	std::vector<NFIQ::QualityFeatureResult> qmFeatures =
-	    qmFeatureModule.computeFeatureData(
-		rawImage, roiFeatureModule.getImgProcResults());
+	    qmFeatureModule.computeFeatureData(rawImage);
 
 	// append to feature vector
 	std::vector<NFIQ::QualityFeatureResult>::iterator it_qmFeatures;

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures_impl.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures_impl.cpp
@@ -148,13 +148,12 @@ NFIQ::QualityFeatures::Impl::computeQualityFeatures(
 	// compute FJFX minutiae quality features
 	// FJFXPos_Mu_MinutiaeQuality_2
 	// FJFXPos_OCL_MinutiaeQuality_80
-	FJFXMinutiaeQualityFeature fjfxMinQualFeatureModule(
-	    bOutputSpeed, speedValues);
+	FJFXMinutiaeQualityFeature fjfxMinQualFeatureModule(bOutputSpeed,
+	    speedValues, fjfxFeatureModule.getMinutiaData(),
+	    fjfxFeatureModule.getTemplateStatus());
 	// this module uses the already computed FJFX minutiae template
 	std::vector<NFIQ::QualityFeatureResult> fjfxMinQualFeatures =
-	    fjfxMinQualFeatureModule.computeFeatureData(rawImage,
-		fjfxFeatureModule.getMinutiaData(),
-		fjfxFeatureModule.getTemplateStatus());
+	    fjfxMinQualFeatureModule.computeFeatureData(rawImage);
 
 	// append to feature vector
 	std::vector<NFIQ::QualityFeatureResult>::iterator

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures_impl.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures_impl.cpp
@@ -111,8 +111,11 @@ NFIQ::QualityFeatures::Impl::computeQualityFeatures(
 	// this module returns the FJFX minutiae template to be used in other
 	// modules
 
+	std::vector<FingerJetFXFeature::Minutia> minutiaData {};
+	bool templateCouldBeExtracted = false;
 	std::vector<NFIQ::QualityFeatureResult> fjfxFeatures =
-	    fjfxFeatureModule.computeFeatureData(rawImage);
+	    fjfxFeatureModule.computeFeatureData(
+		rawImage, minutiaData, templateCouldBeExtracted);
 
 	// append to feature vector
 	std::vector<NFIQ::QualityFeatureResult>::iterator it_fjfxFeatures;
@@ -152,9 +155,8 @@ NFIQ::QualityFeatures::Impl::computeQualityFeatures(
 	    bOutputSpeed, speedValues);
 	// this module uses the already computed FJFX minutiae template
 	std::vector<NFIQ::QualityFeatureResult> fjfxMinQualFeatures =
-	    fjfxMinQualFeatureModule.computeFeatureData(rawImage,
-		fjfxFeatureModule.getMinutiaData(),
-		fjfxFeatureModule.getTemplateStatus());
+	    fjfxMinQualFeatureModule.computeFeatureData(
+		rawImage, minutiaData, templateCouldBeExtracted);
 
 	// append to feature vector
 	std::vector<NFIQ::QualityFeatureResult>::iterator

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures_impl.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures_impl.cpp
@@ -176,10 +176,9 @@ NFIQ::QualityFeatures::Impl::computeQualityFeatures(
 	// compute ROI features
 	// ImgProcROIArea_Mean
 	ImgProcROIFeature roiFeatureModule(bOutputSpeed, speedValues);
-	// this module returns ROI information to be used within other modules
-	ImgProcROIFeature::ImgProcROIResults imgProcResults;
+
 	std::vector<NFIQ::QualityFeatureResult> roiFeatures =
-	    roiFeatureModule.computeFeatureData(rawImage, imgProcResults);
+	    roiFeatureModule.computeFeatureData(rawImage);
 
 	// append to feature vector
 	std::vector<NFIQ::QualityFeatureResult>::iterator it_roiFeatures;
@@ -197,8 +196,9 @@ NFIQ::QualityFeatures::Impl::computeQualityFeatures(
 	// add ROI information to actionable quality feedback
 	NFIQ::ActionableQualityFeedback fb_roi;
 	fb_roi.actionableQualityValue =
-	    imgProcResults.noOfROIPixels; // absolute number of ROI pixels
-					  // (foreground)
+	    roiFeatureModule.getImgProcResults()
+		.noOfROIPixels; // absolute number of ROI pixels
+				// (foreground)
 	fb_roi.identifier = NFIQ::
 	    ActionableQualityFeedbackIdentifier_SufficientFingerprintForeground;
 	actionableQuality.push_back(fb_roi);
@@ -287,7 +287,8 @@ NFIQ::QualityFeatures::Impl::computeQualityFeatures(
 	// OrientationMap_ROIFilter_CoherenceSum
 	QualityMapFeatures qmFeatureModule(bOutputSpeed, speedValues);
 	std::vector<NFIQ::QualityFeatureResult> qmFeatures =
-	    qmFeatureModule.computeFeatureData(rawImage, imgProcResults);
+	    qmFeatureModule.computeFeatureData(
+		rawImage, roiFeatureModule.getImgProcResults());
 
 	// append to feature vector
 	std::vector<NFIQ::QualityFeatureResult>::iterator it_qmFeatures;

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures_impl.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures_impl.cpp
@@ -111,11 +111,8 @@ NFIQ::QualityFeatures::Impl::computeQualityFeatures(
 	// this module returns the FJFX minutiae template to be used in other
 	// modules
 
-	std::vector<FingerJetFXFeature::Minutia> minutiaData {};
-	bool templateCouldBeExtracted = false;
 	std::vector<NFIQ::QualityFeatureResult> fjfxFeatures =
-	    fjfxFeatureModule.computeFeatureData(
-		rawImage, minutiaData, templateCouldBeExtracted);
+	    fjfxFeatureModule.computeFeatureData(rawImage);
 
 	// append to feature vector
 	std::vector<NFIQ::QualityFeatureResult>::iterator it_fjfxFeatures;
@@ -155,8 +152,9 @@ NFIQ::QualityFeatures::Impl::computeQualityFeatures(
 	    bOutputSpeed, speedValues);
 	// this module uses the already computed FJFX minutiae template
 	std::vector<NFIQ::QualityFeatureResult> fjfxMinQualFeatures =
-	    fjfxMinQualFeatureModule.computeFeatureData(
-		rawImage, minutiaData, templateCouldBeExtracted);
+	    fjfxMinQualFeatureModule.computeFeatureData(rawImage,
+		fjfxFeatureModule.getMinutiaData(),
+		fjfxFeatureModule.getTemplateStatus());
 
 	// append to feature vector
 	std::vector<NFIQ::QualityFeatureResult>::iterator


### PR DESCRIPTION
This PR paves the way for a more OO oriented design for feature computation. computeFeatureData signatures across the different features has been modified to posses the same function signature. 