### PR TITLE
Adding computeFeatureScore to BaseFeature

### DIFF
--- a/NFIQ2/NFIQ2Algorithm/include/features/BaseFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/BaseFeature.h
@@ -25,8 +25,9 @@ class BaseFeature {
 	/** @return Identifier for this particular feature */
 	virtual std::string getModuleName() const = 0;
 
+	/** @return vector of computed quality features */
 	virtual std::vector<NFIQ::QualityFeatureResult> computeFeatureData(
-	    const NFIQ::FingerprintImageData &fingerprintImage);
+	    const NFIQ::FingerprintImageData &fingerprintImage) = 0;
 
 	bool m_bOutputSpeed;
 	std::vector<NFIQ::QualityFeatureSpeed> &m_lSpeedValues;

--- a/NFIQ2/NFIQ2Algorithm/include/features/BaseFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/BaseFeature.h
@@ -25,6 +25,9 @@ class BaseFeature {
 	/** @return Identifier for this particular feature */
 	virtual std::string getModuleName() const = 0;
 
+	virtual std::vector<NFIQ::QualityFeatureResult> computeFeatureData(
+	    const NFIQ::FingerprintImageData &fingerprintImage);
+
 	bool m_bOutputSpeed;
 	std::vector<NFIQ::QualityFeatureSpeed> &m_lSpeedValues;
 };

--- a/NFIQ2/NFIQ2Algorithm/include/features/FDAFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/FDAFeature.h
@@ -34,7 +34,7 @@ class FDAFeature : BaseFeature {
 
 	virtual ~FDAFeature();
 	virtual std::vector<NFIQ::QualityFeatureResult> computeFeatureData(
-	    const NFIQ::FingerprintImageData &fingerprintImage);
+	    const NFIQ::FingerprintImageData &fingerprintImage) override;
 
 	std::string getModuleName() const override;
 

--- a/NFIQ2/NFIQ2Algorithm/include/features/FDAFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/FDAFeature.h
@@ -33,7 +33,7 @@ class FDAFeature : BaseFeature {
 	    , padFlag(true) {};
 
 	virtual ~FDAFeature();
-	virtual std::vector<NFIQ::QualityFeatureResult> computeFeatureData(
+	std::vector<NFIQ::QualityFeatureResult> computeFeatureData(
 	    const NFIQ::FingerprintImageData &fingerprintImage) override;
 
 	std::string getModuleName() const override;

--- a/NFIQ2/NFIQ2Algorithm/include/features/FJFXMinutiaeQualityFeatures.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/FJFXMinutiaeQualityFeatures.h
@@ -52,7 +52,7 @@ class FJFXMinutiaeQualityFeature : BaseFeature {
 	    , templateCouldBeExtracted_ { templateCouldBeExtracted } {};
 	virtual ~FJFXMinutiaeQualityFeature();
 
-	virtual std::vector<NFIQ::QualityFeatureResult> computeFeatureData(
+	std::vector<NFIQ::QualityFeatureResult> computeFeatureData(
 	    const NFIQ::FingerprintImageData &fingerprintImage) override;
 
 	std::string getModuleName() const override;

--- a/NFIQ2/NFIQ2Algorithm/include/features/FJFXMinutiaeQualityFeatures.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/FJFXMinutiaeQualityFeatures.h
@@ -52,8 +52,8 @@ class FJFXMinutiaeQualityFeature : BaseFeature {
 	    , templateCouldBeExtracted_ { templateCouldBeExtracted } {};
 	virtual ~FJFXMinutiaeQualityFeature();
 
-	std::vector<NFIQ::QualityFeatureResult> computeFeatureData(
-	    const NFIQ::FingerprintImageData &fingerprintImage);
+	virtual std::vector<NFIQ::QualityFeatureResult> computeFeatureData(
+	    const NFIQ::FingerprintImageData &fingerprintImage) override;
 
 	std::string getModuleName() const override;
 

--- a/NFIQ2/NFIQ2Algorithm/include/features/FingerJetFXFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/FingerJetFXFeature.h
@@ -119,7 +119,7 @@ class FingerJetFXFeature : BaseFeature {
 	    : BaseFeature(bOutputSpeed, speedValues) {};
 	virtual ~FingerJetFXFeature();
 
-	virtual std::vector<NFIQ::QualityFeatureResult> computeFeatureData(
+	std::vector<NFIQ::QualityFeatureResult> computeFeatureData(
 	    const NFIQ::FingerprintImageData &fingerprintImage) override;
 
 	std::string getModuleName() const override;

--- a/NFIQ2/NFIQ2Algorithm/include/features/FingerJetFXFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/FingerJetFXFeature.h
@@ -119,8 +119,8 @@ class FingerJetFXFeature : BaseFeature {
 	    : BaseFeature(bOutputSpeed, speedValues) {};
 	virtual ~FingerJetFXFeature();
 
-	std::vector<NFIQ::QualityFeatureResult> computeFeatureData(
-	    const NFIQ::FingerprintImageData &fingerprintImage);
+	virtual std::vector<NFIQ::QualityFeatureResult> computeFeatureData(
+	    const NFIQ::FingerprintImageData &fingerprintImage) override;
 
 	std::string getModuleName() const override;
 

--- a/NFIQ2/NFIQ2Algorithm/include/features/ImgProcROIFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/ImgProcROIFeature.h
@@ -44,7 +44,7 @@ class ImgProcROIFeature : BaseFeature {
 	    : BaseFeature(bOutputSpeed, speedValues) {};
 	virtual ~ImgProcROIFeature();
 
-	virtual std::vector<NFIQ::QualityFeatureResult> computeFeatureData(
+	std::vector<NFIQ::QualityFeatureResult> computeFeatureData(
 	    const NFIQ::FingerprintImageData &fingerprintImage) override;
 
 	std::string getModuleName() const override;

--- a/NFIQ2/NFIQ2Algorithm/include/features/ImgProcROIFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/ImgProcROIFeature.h
@@ -44,8 +44,8 @@ class ImgProcROIFeature : BaseFeature {
 	    : BaseFeature(bOutputSpeed, speedValues) {};
 	virtual ~ImgProcROIFeature();
 
-	std::vector<NFIQ::QualityFeatureResult> computeFeatureData(
-	    const NFIQ::FingerprintImageData &fingerprintImage);
+	virtual std::vector<NFIQ::QualityFeatureResult> computeFeatureData(
+	    const NFIQ::FingerprintImageData &fingerprintImage) override;
 
 	std::string getModuleName() const override;
 

--- a/NFIQ2/NFIQ2Algorithm/include/features/LCSFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/LCSFeature.h
@@ -27,7 +27,7 @@ class LCSFeature : BaseFeature {
 	    , padFlag(false) {};
 	virtual ~LCSFeature();
 
-	virtual std::vector<NFIQ::QualityFeatureResult> computeFeatureData(
+	std::vector<NFIQ::QualityFeatureResult> computeFeatureData(
 	    const NFIQ::FingerprintImageData &fingerprintImage) override;
 
 	std::string getModuleName() const override;

--- a/NFIQ2/NFIQ2Algorithm/include/features/LCSFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/LCSFeature.h
@@ -28,7 +28,7 @@ class LCSFeature : BaseFeature {
 	virtual ~LCSFeature();
 
 	virtual std::vector<NFIQ::QualityFeatureResult> computeFeatureData(
-	    const NFIQ::FingerprintImageData &fingerprintImage);
+	    const NFIQ::FingerprintImageData &fingerprintImage) override;
 
 	std::string getModuleName() const override;
 

--- a/NFIQ2/NFIQ2Algorithm/include/features/MuFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/MuFeature.h
@@ -22,7 +22,7 @@ class MuFeature : BaseFeature {
 	    : BaseFeature(bOutputSpeed, speedValues) {};
 	virtual ~MuFeature();
 
-	virtual std::vector<NFIQ::QualityFeatureResult> computeFeatureData(
+	std::vector<NFIQ::QualityFeatureResult> computeFeatureData(
 	    const NFIQ::FingerprintImageData &fingerprintImage) override;
 
 	std::string getModuleName() const override;

--- a/NFIQ2/NFIQ2Algorithm/include/features/MuFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/MuFeature.h
@@ -22,8 +22,8 @@ class MuFeature : BaseFeature {
 	    : BaseFeature(bOutputSpeed, speedValues) {};
 	virtual ~MuFeature();
 
-	std::vector<NFIQ::QualityFeatureResult> computeFeatureData(
-	    const NFIQ::FingerprintImageData &fingerprintImage);
+	virtual std::vector<NFIQ::QualityFeatureResult> computeFeatureData(
+	    const NFIQ::FingerprintImageData &fingerprintImage) override;
 
 	std::string getModuleName() const override;
 

--- a/NFIQ2/NFIQ2Algorithm/include/features/OCLHistogramFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/OCLHistogramFeature.h
@@ -29,7 +29,7 @@ class OCLHistogramFeature : BaseFeature {
 	virtual ~OCLHistogramFeature();
 
 	virtual std::vector<NFIQ::QualityFeatureResult> computeFeatureData(
-	    const NFIQ::FingerprintImageData &fingerprintImage);
+	    const NFIQ::FingerprintImageData &fingerprintImage) override;
 
 	std::string getModuleName() const override;
 

--- a/NFIQ2/NFIQ2Algorithm/include/features/OCLHistogramFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/OCLHistogramFeature.h
@@ -28,7 +28,7 @@ class OCLHistogramFeature : BaseFeature {
 	    : BaseFeature(bOutputSpeed, speedValues) {};
 	virtual ~OCLHistogramFeature();
 
-	virtual std::vector<NFIQ::QualityFeatureResult> computeFeatureData(
+	std::vector<NFIQ::QualityFeatureResult> computeFeatureData(
 	    const NFIQ::FingerprintImageData &fingerprintImage) override;
 
 	std::string getModuleName() const override;

--- a/NFIQ2/NFIQ2Algorithm/include/features/OFFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/OFFeature.h
@@ -34,7 +34,7 @@ class OFFeature : BaseFeature {
 	    , angleMin(4.0) {};
 	virtual ~OFFeature();
 
-	virtual std::vector<NFIQ::QualityFeatureResult> computeFeatureData(
+	std::vector<NFIQ::QualityFeatureResult> computeFeatureData(
 	    const NFIQ::FingerprintImageData &fingerprintImage) override;
 
 	std::string getModuleName() const override;

--- a/NFIQ2/NFIQ2Algorithm/include/features/OFFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/OFFeature.h
@@ -35,7 +35,7 @@ class OFFeature : BaseFeature {
 	virtual ~OFFeature();
 
 	virtual std::vector<NFIQ::QualityFeatureResult> computeFeatureData(
-	    const NFIQ::FingerprintImageData &fingerprintImage);
+	    const NFIQ::FingerprintImageData &fingerprintImage) override;
 
 	std::string getModuleName() const override;
 

--- a/NFIQ2/NFIQ2Algorithm/include/features/QualityMapFeatures.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/QualityMapFeatures.h
@@ -33,8 +33,8 @@ class QualityMapFeatures : BaseFeature {
 	    , imgProcResults_ { imgProcResults } {};
 	virtual ~QualityMapFeatures();
 
-	std::vector<NFIQ::QualityFeatureResult> computeFeatureData(
-	    const NFIQ::FingerprintImageData &fingerprintImage);
+	virtual std::vector<NFIQ::QualityFeatureResult> computeFeatureData(
+	    const NFIQ::FingerprintImageData &fingerprintImage) override;
 
 	std::string getModuleName() const override;
 

--- a/NFIQ2/NFIQ2Algorithm/include/features/QualityMapFeatures.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/QualityMapFeatures.h
@@ -33,7 +33,7 @@ class QualityMapFeatures : BaseFeature {
 	    , imgProcResults_ { imgProcResults } {};
 	virtual ~QualityMapFeatures();
 
-	virtual std::vector<NFIQ::QualityFeatureResult> computeFeatureData(
+	std::vector<NFIQ::QualityFeatureResult> computeFeatureData(
 	    const NFIQ::FingerprintImageData &fingerprintImage) override;
 
 	std::string getModuleName() const override;

--- a/NFIQ2/NFIQ2Algorithm/include/features/RVUPHistogramFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/RVUPHistogramFeature.h
@@ -28,7 +28,7 @@ class RVUPHistogramFeature : BaseFeature {
 	virtual ~RVUPHistogramFeature();
 
 	virtual std::vector<NFIQ::QualityFeatureResult> computeFeatureData(
-	    const NFIQ::FingerprintImageData &fingerprintImage);
+	    const NFIQ::FingerprintImageData &fingerprintImage) override;
 
 	std::string getModuleName() const override;
 

--- a/NFIQ2/NFIQ2Algorithm/include/features/RVUPHistogramFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/RVUPHistogramFeature.h
@@ -27,7 +27,7 @@ class RVUPHistogramFeature : BaseFeature {
 	    , padFlag(true) {};
 	virtual ~RVUPHistogramFeature();
 
-	virtual std::vector<NFIQ::QualityFeatureResult> computeFeatureData(
+	std::vector<NFIQ::QualityFeatureResult> computeFeatureData(
 	    const NFIQ::FingerprintImageData &fingerprintImage) override;
 
 	std::string getModuleName() const override;


### PR DESCRIPTION
Closes #190 

Adding computeFeatureScore to BaseFeature, overriding the method in the children subclasses.