### PR TITLE
Moving feature constructor bodies from headers to source files

### DIFF
--- a/NFIQ2/NFIQ2Algorithm/include/features/FDAFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/FDAFeature.h
@@ -36,10 +36,11 @@ class FDAFeature : public BaseFeature {
 	static const std::string moduleName;
 
     private:
-	int blocksize;
-	double threshold;
-	int slantedBlockSizeX, slantedBlockSizeY;
-	bool padFlag; // used by getRotatedBlock
+	const int blocksize { 32 };
+	const double threshold { .1 };
+	const int slantedBlockSizeX { 32 };
+	const int slantedBlockSizeY { 16 };
+	const bool padFlag { true }; // used by getRotatedBlock
 };
 }}
 

--- a/NFIQ2/NFIQ2Algorithm/include/features/FDAFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/FDAFeature.h
@@ -23,21 +23,13 @@ static double FDAHISTLIMITS[9] = { 0.268, 0.304, 0.33, 0.355, 0.38, 0.407, 0.44,
 
 class FDAFeature : public BaseFeature {
     public:
-	FDAFeature()
-	    : BaseFeature()
-	    , blocksize(32)
-	    , threshold(0.1)
-	    , slantedBlockSizeX(32)
-	    , slantedBlockSizeY(16)
-	    , padFlag(true) {};
-
+	FDAFeature();
 	virtual ~FDAFeature();
+
 	std::vector<NFIQ::QualityFeatureResult> computeFeatureData(
 	    const NFIQ::FingerprintImageData &fingerprintImage) override;
 
 	std::string getModuleName() const override;
-
-	virtual void initModule() {};
 
 	static std::vector<std::string> getAllFeatureIDs();
 	static const std::string speedFeatureIDGroup;

--- a/NFIQ2/NFIQ2Algorithm/include/features/FJFXMinutiaeQualityFeatures.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/FJFXMinutiaeQualityFeatures.h
@@ -45,18 +45,13 @@ class FJFXMinutiaeQualityFeature : public BaseFeature {
 
 	FJFXMinutiaeQualityFeature(
 	    const std::vector<FingerJetFXFeature::Minutia> &minutiaData,
-	    const bool templateCouldBeExtracted)
-	    : BaseFeature()
-	    , minutiaData_ { minutiaData }
-	    , templateCouldBeExtracted_ { templateCouldBeExtracted } {};
+	    const bool templateCouldBeExtracted);
 	virtual ~FJFXMinutiaeQualityFeature();
 
 	std::vector<NFIQ::QualityFeatureResult> computeFeatureData(
 	    const NFIQ::FingerprintImageData &fingerprintImage) override;
 
 	std::string getModuleName() const override;
-
-	void initModule() { /* not needed here */ };
 
 	static std::vector<std::string> getAllFeatureIDs();
 	static const std::string speedFeatureIDGroup;

--- a/NFIQ2/NFIQ2Algorithm/include/features/FingerJetFXFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/FingerJetFXFeature.h
@@ -114,16 +114,13 @@ class FingerJetFXFeature : public BaseFeature {
 					     ///< the defined circle
 	};
 
-	FingerJetFXFeature()
-	    : BaseFeature() {};
+	FingerJetFXFeature();
 	virtual ~FingerJetFXFeature();
 
 	std::vector<NFIQ::QualityFeatureResult> computeFeatureData(
 	    const NFIQ::FingerprintImageData &fingerprintImage) override;
 
 	std::string getModuleName() const override;
-
-	void initModule() { /* not needed here */ };
 
 	static std::vector<std::string> getAllFeatureIDs();
 	static const std::string speedFeatureIDGroup;

--- a/NFIQ2/NFIQ2Algorithm/include/features/ImgProcROIFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/ImgProcROIFeature.h
@@ -39,16 +39,13 @@ class ImgProcROIFeature : public BaseFeature {
 					  ///< grayvalues of all ROI pixels
 	};
 
-	ImgProcROIFeature()
-	    : BaseFeature() {};
+	ImgProcROIFeature();
 	virtual ~ImgProcROIFeature();
 
 	std::vector<NFIQ::QualityFeatureResult> computeFeatureData(
 	    const NFIQ::FingerprintImageData &fingerprintImage) override;
 
 	std::string getModuleName() const override;
-
-	void initModule() { /* not needed here */ };
 
 	static std::vector<std::string> getAllFeatureIDs();
 	static const std::string speedFeatureIDGroup;

--- a/NFIQ2/NFIQ2Algorithm/include/features/LCSFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/LCSFeature.h
@@ -18,20 +18,13 @@ static double LCSHISTLIMITS[9] = { 0, 0.70, 0.74, 0.77, 0.79, 0.81, 0.83, 0.85,
 
 class LCSFeature : public BaseFeature {
     public:
-	LCSFeature()
-	    : BaseFeature()
-	    , blocksize(32)
-	    , threshold(0.1)
-	    , scannerRes(500)
-	    , padFlag(false) {};
+	LCSFeature();
 	virtual ~LCSFeature();
 
 	std::vector<NFIQ::QualityFeatureResult> computeFeatureData(
 	    const NFIQ::FingerprintImageData &fingerprintImage) override;
 
 	std::string getModuleName() const override;
-
-	virtual void initModule() {};
 
 	static std::vector<std::string> getAllFeatureIDs();
 	static const std::string speedFeatureIDGroup;

--- a/NFIQ2/NFIQ2Algorithm/include/features/LCSFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/LCSFeature.h
@@ -30,11 +30,11 @@ class LCSFeature : public BaseFeature {
 	static const std::string speedFeatureIDGroup;
 	static const std::string moduleName;
 
-    protected:
-	int blocksize;
-	double threshold;
-	int scannerRes;
-	bool padFlag;
+    private:
+	const int blocksize { 32 };
+	const double threshold { .1 };
+	const int scannerRes { 500 };
+	const bool padFlag { false };
 };
 
 }}

--- a/NFIQ2/NFIQ2Algorithm/include/features/MuFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/MuFeature.h
@@ -17,8 +17,7 @@ namespace NFIQ { namespace QualityFeatures {
 
 class MuFeature : public BaseFeature {
     public:
-	MuFeature()
-	    : BaseFeature() {};
+	MuFeature();
 	virtual ~MuFeature();
 
 	std::vector<NFIQ::QualityFeatureResult> computeFeatureData(
@@ -30,8 +29,6 @@ class MuFeature : public BaseFeature {
 	 * Sigma has not yet been calculated.
 	 */
 	double getSigma() const;
-
-	void initModule() { /* not needed here */ };
 
 	static std::vector<std::string> getAllFeatureIDs();
 	static const std::string speedFeatureIDGroup;

--- a/NFIQ2/NFIQ2Algorithm/include/features/OCLHistogramFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/OCLHistogramFeature.h
@@ -23,16 +23,13 @@ static double OCLPHISTLIMITS[9] = { 0.337, 0.479, 0.579, 0.655, 0.716, 0.766,
 
 class OCLHistogramFeature : public BaseFeature {
     public:
-	OCLHistogramFeature()
-	    : BaseFeature() {};
+	OCLHistogramFeature();
 	virtual ~OCLHistogramFeature();
 
 	std::vector<NFIQ::QualityFeatureResult> computeFeatureData(
 	    const NFIQ::FingerprintImageData &fingerprintImage) override;
 
 	std::string getModuleName() const override;
-
-	virtual void initModule() { /* not needed here */ };
 
 	static std::vector<std::string> getAllFeatureIDs();
 	static const std::string speedFeatureIDGroup;

--- a/NFIQ2/NFIQ2Algorithm/include/features/OFFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/OFFeature.h
@@ -24,21 +24,13 @@ static double OFHISTLIMITS[9] = { 1.715e-2, 3.5e-2, 5.57e-2, 8.1e-2, 1.15e-1,
 
 class OFFeature : public BaseFeature {
     public:
-	OFFeature()
-	    : BaseFeature()
-	    , blocksize(16)
-	    , slantedBlockSizeX(32)
-	    , slantedBlockSizeY(16)
-	    , threshold(0.1)
-	    , angleMin(4.0) {};
+	OFFeature();
 	virtual ~OFFeature();
 
 	std::vector<NFIQ::QualityFeatureResult> computeFeatureData(
 	    const NFIQ::FingerprintImageData &fingerprintImage) override;
 
 	std::string getModuleName() const override;
-
-	virtual void initModule() {};
 
 	static std::vector<std::string> getAllFeatureIDs();
 	static const std::string speedFeatureIDGroup;

--- a/NFIQ2/NFIQ2Algorithm/include/features/OFFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/OFFeature.h
@@ -37,15 +37,21 @@ class OFFeature : public BaseFeature {
 	static const std::string moduleName;
 
     private:
-	int blocksize; /*!< Processing is done in subblocks of this size. */
-	int slantedBlockSizeX; /*!< Size of the rotated block in the x dimension
-				*/
-	int slantedBlockSizeY; /*!< Size of the rotated block in the y dimension
-				*/
-	double threshold;      /*!< Threshold for differentiating
-				  foreground/background      blocks */
-	double angleMin; /*!< Minimum angle change inclusion in the quality
-			    measure */
+	const int blocksize {
+		16
+	}; /*!< Processing is done in subblocks of this size. */
+	const int slantedBlockSizeX {
+		32
+	}; /*!< Size of the rotated block in the x dimension
+	    */
+	const int slantedBlockSizeY {
+		16
+	}; /*!< Size of the rotated block in the y dimension
+	    */
+	const double threshold { .1 }; /*!< Threshold for differentiating
+				foreground/background      blocks */
+	const double angleMin { 4.0 }; /*!< Minimum angle change inclusion in
+			       the quality measure */
 };
 
 }}

--- a/NFIQ2/NFIQ2Algorithm/include/features/OFFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/OFFeature.h
@@ -37,23 +37,17 @@ class OFFeature : public BaseFeature {
 	static const std::string moduleName;
 
     private:
-	const int blocksize {
-		16
-	}; /*!< Processing is done in subblocks of this size. */
-	const int slantedBlockSizeX {
-		32
-	}; /*!< Size of the rotated block in the x dimension
-	    */
-	const int slantedBlockSizeY {
-		16
-	}; /*!< Size of the rotated block in the y dimension
-	    */
-	const double threshold { .1 }; /*!< Threshold for differentiating
-				foreground/background      blocks */
-	const double angleMin { 4.0 }; /*!< Minimum angle change inclusion in
-			       the quality measure */
+	/** Processing is done in subblocks of this size. */
+	const int blocksize { 16 };
+	/** Size of the rotated block in the x dimension */
+	const int slantedBlockSizeX { 32 };
+	/** Size of the rotated block in the y dimension */
+	const int slantedBlockSizeY { 16 };
+	/**Threshold for differentiating foreground/background blocks */
+	const double threshold { .1 };
+	/**Minimum angle change inclusion in the quality measure */
+	const double angleMin { 4.0 };
 };
-
 }}
 
 #endif

--- a/NFIQ2/NFIQ2Algorithm/include/features/QualityMapFeatures.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/QualityMapFeatures.h
@@ -27,17 +27,13 @@ namespace NFIQ { namespace QualityFeatures {
 class QualityMapFeatures : public BaseFeature {
     public:
 	QualityMapFeatures(
-	    const ImgProcROIFeature::ImgProcROIResults &imgProcResults)
-	    : BaseFeature()
-	    , imgProcResults_ { imgProcResults } {};
+	    const ImgProcROIFeature::ImgProcROIResults &imgProcResults);
 	virtual ~QualityMapFeatures();
 
 	std::vector<NFIQ::QualityFeatureResult> computeFeatureData(
 	    const NFIQ::FingerprintImageData &fingerprintImage) override;
 
 	std::string getModuleName() const override;
-
-	void initModule() { /* not needed here */ };
 
 	static std::vector<std::string> getAllFeatureIDs();
 	static const std::string speedFeatureIDGroup;

--- a/NFIQ2/NFIQ2Algorithm/include/features/RVUPHistogramFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/RVUPHistogramFeature.h
@@ -29,12 +29,12 @@ class RVUPHistogramFeature : public BaseFeature {
 	static const std::string speedFeatureIDGroup;
 	static const std::string moduleName;
 
-    protected:
-	int blocksize;
-	double threshold;
-	int slantedBlockSizeX, slantedBlockSizeY;
-	int screenRes;
-	bool padFlag;
+    private:
+	const int blocksize { 32 };
+	const double threshold { .1 };
+	const int slantedBlockSizeX { 32 };
+	const int slantedBlockSizeY { 16 };
+	const bool padFlag { true };
 };
 
 }}

--- a/NFIQ2/NFIQ2Algorithm/include/features/RVUPHistogramFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/RVUPHistogramFeature.h
@@ -17,21 +17,13 @@ static double RVUPHISTLIMITS[9] = { 0.5, 0.667, 0.8, 1, 1.25, 1.5, 2, 24, 30 };
 
 class RVUPHistogramFeature : public BaseFeature {
     public:
-	RVUPHistogramFeature()
-	    : BaseFeature()
-	    , blocksize(32)
-	    , threshold(0.1)
-	    , slantedBlockSizeX(32)
-	    , slantedBlockSizeY(32 / 2)
-	    , padFlag(true) {};
+	RVUPHistogramFeature();
 	virtual ~RVUPHistogramFeature();
 
 	std::vector<NFIQ::QualityFeatureResult> computeFeatureData(
 	    const NFIQ::FingerprintImageData &fingerprintImage) override;
 
 	std::string getModuleName() const override;
-
-	virtual void initModule() {};
 
 	static std::vector<std::string> getAllFeatureIDs();
 	static const std::string speedFeatureIDGroup;

--- a/NFIQ2/NFIQ2Algorithm/src/features/FDAFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FDAFeature.cpp
@@ -22,9 +22,15 @@ using namespace cv;
 double fda(const Mat &block, const double orientation, const int v1sz_x,
     const int v1sz_y, const bool padFlag);
 
-NFIQ::QualityFeatures::FDAFeature::~FDAFeature()
-{
-}
+NFIQ::QualityFeatures::FDAFeature::FDAFeature()
+    : BaseFeature()
+    , blocksize(32)
+    , threshold(0.1)
+    , slantedBlockSizeX(32)
+    , slantedBlockSizeY(16)
+    , padFlag(true) {};
+
+NFIQ::QualityFeatures::FDAFeature::~FDAFeature() = default;
 
 std::vector<std::string>
 NFIQ::QualityFeatures::FDAFeature::getAllFeatureIDs()

--- a/NFIQ2/NFIQ2Algorithm/src/features/FDAFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FDAFeature.cpp
@@ -22,13 +22,7 @@ using namespace cv;
 double fda(const Mat &block, const double orientation, const int v1sz_x,
     const int v1sz_y, const bool padFlag);
 
-NFIQ::QualityFeatures::FDAFeature::FDAFeature()
-    : BaseFeature()
-    , blocksize(32)
-    , threshold(0.1)
-    , slantedBlockSizeX(32)
-    , slantedBlockSizeY(16)
-    , padFlag(true) {};
+NFIQ::QualityFeatures::FDAFeature::FDAFeature() = default;
 
 NFIQ::QualityFeatures::FDAFeature::~FDAFeature() = default;
 

--- a/NFIQ2/NFIQ2Algorithm/src/features/FJFXMinutiaeQualityFeatures.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FJFXMinutiaeQualityFeatures.cpp
@@ -11,8 +11,7 @@ using namespace cv;
 NFIQ::QualityFeatures::FJFXMinutiaeQualityFeature::FJFXMinutiaeQualityFeature(
     const std::vector<FingerJetFXFeature::Minutia> &minutiaData,
     const bool templateCouldBeExtracted)
-    : BaseFeature()
-    , minutiaData_ { minutiaData }
+    : minutiaData_ { minutiaData }
     , templateCouldBeExtracted_ { templateCouldBeExtracted } {};
 
 NFIQ::QualityFeatures::FJFXMinutiaeQualityFeature::

--- a/NFIQ2/NFIQ2Algorithm/src/features/FJFXMinutiaeQualityFeatures.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FJFXMinutiaeQualityFeatures.cpp
@@ -8,9 +8,15 @@
 using namespace NFIQ;
 using namespace cv;
 
-NFIQ::QualityFeatures::FJFXMinutiaeQualityFeature::~FJFXMinutiaeQualityFeature()
-{
-}
+NFIQ::QualityFeatures::FJFXMinutiaeQualityFeature::FJFXMinutiaeQualityFeature(
+    const std::vector<FingerJetFXFeature::Minutia> &minutiaData,
+    const bool templateCouldBeExtracted)
+    : BaseFeature()
+    , minutiaData_ { minutiaData }
+    , templateCouldBeExtracted_ { templateCouldBeExtracted } {};
+
+NFIQ::QualityFeatures::FJFXMinutiaeQualityFeature::
+    ~FJFXMinutiaeQualityFeature() = default;
 
 const std::string
     NFIQ::QualityFeatures::FJFXMinutiaeQualityFeature::speedFeatureIDGroup =

--- a/NFIQ2/NFIQ2Algorithm/src/features/FingerJetFXFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FingerJetFXFeature.cpp
@@ -7,9 +7,10 @@
 
 using namespace NFIQ;
 
-NFIQ::QualityFeatures::FingerJetFXFeature::~FingerJetFXFeature()
-{
-}
+NFIQ::QualityFeatures::FingerJetFXFeature::FingerJetFXFeature()
+    : BaseFeature() {};
+
+NFIQ::QualityFeatures::FingerJetFXFeature::~FingerJetFXFeature() = default;
 
 const std::string
     NFIQ::QualityFeatures::FingerJetFXFeature::speedFeatureIDGroup = "Minutiae";

--- a/NFIQ2/NFIQ2Algorithm/src/features/FingerJetFXFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FingerJetFXFeature.cpp
@@ -7,8 +7,7 @@
 
 using namespace NFIQ;
 
-NFIQ::QualityFeatures::FingerJetFXFeature::FingerJetFXFeature()
-    : BaseFeature() {};
+NFIQ::QualityFeatures::FingerJetFXFeature::FingerJetFXFeature() = default;
 
 NFIQ::QualityFeatures::FingerJetFXFeature::~FingerJetFXFeature() = default;
 

--- a/NFIQ2/NFIQ2Algorithm/src/features/ImgProcROIFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/ImgProcROIFeature.cpp
@@ -8,9 +8,10 @@
 using namespace NFIQ;
 using namespace cv;
 
-NFIQ::QualityFeatures::ImgProcROIFeature::~ImgProcROIFeature()
-{
-}
+NFIQ::QualityFeatures::ImgProcROIFeature::ImgProcROIFeature()
+    : BaseFeature() {};
+
+NFIQ::QualityFeatures::ImgProcROIFeature::~ImgProcROIFeature() = default;
 
 const std::string
     NFIQ::QualityFeatures::ImgProcROIFeature::speedFeatureIDGroup =

--- a/NFIQ2/NFIQ2Algorithm/src/features/ImgProcROIFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/ImgProcROIFeature.cpp
@@ -8,8 +8,7 @@
 using namespace NFIQ;
 using namespace cv;
 
-NFIQ::QualityFeatures::ImgProcROIFeature::ImgProcROIFeature()
-    : BaseFeature() {};
+NFIQ::QualityFeatures::ImgProcROIFeature::ImgProcROIFeature() = default;
 
 NFIQ::QualityFeatures::ImgProcROIFeature::~ImgProcROIFeature() = default;
 

--- a/NFIQ2/NFIQ2Algorithm/src/features/LCSFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/LCSFeature.cpp
@@ -18,9 +18,14 @@ using namespace cv;
 double loclar(Mat &block, const double orientation, const int v1sz_x,
     const int v1sz_y, const int scres, const bool padFlag);
 
-NFIQ::QualityFeatures::LCSFeature::~LCSFeature()
-{
-}
+NFIQ::QualityFeatures::LCSFeature::LCSFeature()
+    : BaseFeature()
+    , blocksize(32)
+    , threshold(0.1)
+    , scannerRes(500)
+    , padFlag(false) {};
+
+NFIQ::QualityFeatures::LCSFeature::~LCSFeature() = default;
 
 const std::string NFIQ::QualityFeatures::LCSFeature::moduleName { "NFIQ2_LCS" };
 

--- a/NFIQ2/NFIQ2Algorithm/src/features/LCSFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/LCSFeature.cpp
@@ -18,12 +18,7 @@ using namespace cv;
 double loclar(Mat &block, const double orientation, const int v1sz_x,
     const int v1sz_y, const int scres, const bool padFlag);
 
-NFIQ::QualityFeatures::LCSFeature::LCSFeature()
-    : BaseFeature()
-    , blocksize(32)
-    , threshold(0.1)
-    , scannerRes(500)
-    , padFlag(false) {};
+NFIQ::QualityFeatures::LCSFeature::LCSFeature() = default;
 
 NFIQ::QualityFeatures::LCSFeature::~LCSFeature() = default;
 

--- a/NFIQ2/NFIQ2Algorithm/src/features/MuFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/MuFeature.cpp
@@ -7,9 +7,10 @@
 using namespace NFIQ;
 using namespace cv;
 
-NFIQ::QualityFeatures::MuFeature::~MuFeature()
-{
-}
+NFIQ::QualityFeatures::MuFeature::MuFeature()
+    : BaseFeature() {};
+
+NFIQ::QualityFeatures::MuFeature::~MuFeature() = default;
 
 const std::string NFIQ::QualityFeatures::MuFeature::speedFeatureIDGroup =
     "Contrast";

--- a/NFIQ2/NFIQ2Algorithm/src/features/MuFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/MuFeature.cpp
@@ -7,8 +7,7 @@
 using namespace NFIQ;
 using namespace cv;
 
-NFIQ::QualityFeatures::MuFeature::MuFeature()
-    : BaseFeature() {};
+NFIQ::QualityFeatures::MuFeature::MuFeature() = default;
 
 NFIQ::QualityFeatures::MuFeature::~MuFeature() = default;
 

--- a/NFIQ2/NFIQ2Algorithm/src/features/OCLHistogramFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/OCLHistogramFeature.cpp
@@ -13,8 +13,7 @@
 using namespace NFIQ;
 using namespace cv;
 
-NFIQ::QualityFeatures::OCLHistogramFeature::OCLHistogramFeature()
-    : BaseFeature() {};
+NFIQ::QualityFeatures::OCLHistogramFeature::OCLHistogramFeature() = default;
 
 NFIQ::QualityFeatures::OCLHistogramFeature::~OCLHistogramFeature() = default;
 

--- a/NFIQ2/NFIQ2Algorithm/src/features/OCLHistogramFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/OCLHistogramFeature.cpp
@@ -13,9 +13,10 @@
 using namespace NFIQ;
 using namespace cv;
 
-NFIQ::QualityFeatures::OCLHistogramFeature::~OCLHistogramFeature()
-{
-}
+NFIQ::QualityFeatures::OCLHistogramFeature::OCLHistogramFeature()
+    : BaseFeature() {};
+
+NFIQ::QualityFeatures::OCLHistogramFeature::~OCLHistogramFeature() = default;
 
 const std::string
     NFIQ::QualityFeatures::OCLHistogramFeature::speedFeatureIDGroup =

--- a/NFIQ2/NFIQ2Algorithm/src/features/OFFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/OFFeature.cpp
@@ -19,13 +19,7 @@
 using namespace NFIQ;
 using namespace cv;
 
-NFIQ::QualityFeatures::OFFeature::OFFeature()
-    : BaseFeature()
-    , blocksize(16)
-    , slantedBlockSizeX(32)
-    , slantedBlockSizeY(16)
-    , threshold(0.1)
-    , angleMin(4.0) {};
+NFIQ::QualityFeatures::OFFeature::OFFeature() = default;
 
 NFIQ::QualityFeatures::OFFeature::~OFFeature() = default;
 

--- a/NFIQ2/NFIQ2Algorithm/src/features/OFFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/OFFeature.cpp
@@ -19,9 +19,15 @@
 using namespace NFIQ;
 using namespace cv;
 
-NFIQ::QualityFeatures::OFFeature::~OFFeature()
-{
-}
+NFIQ::QualityFeatures::OFFeature::OFFeature()
+    : BaseFeature()
+    , blocksize(16)
+    , slantedBlockSizeX(32)
+    , slantedBlockSizeY(16)
+    , threshold(0.1)
+    , angleMin(4.0) {};
+
+NFIQ::QualityFeatures::OFFeature::~OFFeature() = default;
 
 const std::string NFIQ::QualityFeatures::OFFeature::moduleName { "NFIQ2_OF" };
 std::string

--- a/NFIQ2/NFIQ2Algorithm/src/features/QualityMapFeatures.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/QualityMapFeatures.cpp
@@ -21,8 +21,7 @@ using namespace std;
 
 NFIQ::QualityFeatures::QualityMapFeatures::QualityMapFeatures(
     const ImgProcROIFeature::ImgProcROIResults &imgProcResults)
-    : BaseFeature()
-    , imgProcResults_ { imgProcResults } {};
+    : imgProcResults_ { imgProcResults } {};
 
 NFIQ::QualityFeatures::QualityMapFeatures::~QualityMapFeatures() = default;
 

--- a/NFIQ2/NFIQ2Algorithm/src/features/QualityMapFeatures.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/QualityMapFeatures.cpp
@@ -19,9 +19,12 @@ using namespace NFIQ;
 using namespace cv;
 using namespace std;
 
-NFIQ::QualityFeatures::QualityMapFeatures::~QualityMapFeatures()
-{
-}
+NFIQ::QualityFeatures::QualityMapFeatures::QualityMapFeatures(
+    const ImgProcROIFeature::ImgProcROIResults &imgProcResults)
+    : BaseFeature()
+    , imgProcResults_ { imgProcResults } {};
+
+NFIQ::QualityFeatures::QualityMapFeatures::~QualityMapFeatures() = default;
 
 const std::string
     NFIQ::QualityFeatures::QualityMapFeatures::speedFeatureIDGroup =

--- a/NFIQ2/NFIQ2Algorithm/src/features/RVUPHistogramFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/RVUPHistogramFeature.cpp
@@ -20,13 +20,7 @@ void rvuhist(Mat block, const double orientation, const int v1sz_x,
     const int v1sz_y, bool padFlag, std::vector<double> &ratios,
     std::vector<uint8_t> &Nans);
 
-NFIQ::QualityFeatures::RVUPHistogramFeature::RVUPHistogramFeature()
-    : BaseFeature()
-    , blocksize(32)
-    , threshold(0.1)
-    , slantedBlockSizeX(32)
-    , slantedBlockSizeY(32 / 2)
-    , padFlag(true) {};
+NFIQ::QualityFeatures::RVUPHistogramFeature::RVUPHistogramFeature() = default;
 
 NFIQ::QualityFeatures::RVUPHistogramFeature::~RVUPHistogramFeature() = default;
 

--- a/NFIQ2/NFIQ2Algorithm/src/features/RVUPHistogramFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/RVUPHistogramFeature.cpp
@@ -20,9 +20,15 @@ void rvuhist(Mat block, const double orientation, const int v1sz_x,
     const int v1sz_y, bool padFlag, std::vector<double> &ratios,
     std::vector<uint8_t> &Nans);
 
-NFIQ::QualityFeatures::RVUPHistogramFeature::~RVUPHistogramFeature()
-{
-}
+NFIQ::QualityFeatures::RVUPHistogramFeature::RVUPHistogramFeature()
+    : BaseFeature()
+    , blocksize(32)
+    , threshold(0.1)
+    , slantedBlockSizeX(32)
+    , slantedBlockSizeY(32 / 2)
+    , padFlag(true) {};
+
+NFIQ::QualityFeatures::RVUPHistogramFeature::~RVUPHistogramFeature() = default;
 
 const std::string
     NFIQ::QualityFeatures::RVUPHistogramFeature::speedFeatureIDGroup =


### PR DESCRIPTION
Moving the implementations of constructor bodies from inside the respective headers to source files. Set destructors = default.