### PR TITLE
Fix issues with g++ 4.8

### DIFF
--- a/NFIQ2/NFIQ2Algorithm/include/features/ImgProcROIFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/ImgProcROIFeature.h
@@ -19,24 +19,25 @@ namespace NFIQ { namespace QualityFeatures {
 class ImgProcROIFeature : public BaseFeature {
     public:
 	struct ImgProcROIResults {
-		unsigned int
-		    chosenBlockSize; ///< the input block size in pixels
-		unsigned int noOfCompleteBlocks; ///< the overall number of
-						 ///< complete blocks (with full
-						 ///< block size) in the image
-		unsigned int noOfAllBlocks; ///< the overall number of blocks
-					    ///< in the image
-		std::vector<cv::Rect> vecROIBlocks; ///< the detected ROI blocks
-						    ///< with position and size
-		unsigned int
-		    noOfROIPixels; ///< the number of ROI pixels detected
-				   ///< in the image (not blocks)
-		unsigned int
-		    noOfImagePixels;	  ///< the number of pixels of the image
-		double meanOfROIPixels;	  ///< the mean of all grayvalues of all
-					  ///< ROI pixels
-		double stdDevOfROIPixels; ///< the standard deviation of all
-					  ///< grayvalues of all ROI pixels
+		/** input block size in pixels */
+		unsigned int chosenBlockSize {};
+		/**
+		 * overall number of complete blocks (with full block size)
+		 * in the image
+		 */
+		unsigned int noOfCompleteBlocks {};
+		/** overall number of blocks in the image */
+		unsigned int noOfAllBlocks {};
+		/** detected ROI blocks with position and size */
+		std::vector<cv::Rect> vecROIBlocks {};
+		/** number of ROI pixels detected in the image (not blocks) */
+		unsigned int noOfROIPixels {};
+		/** number of pixels of the image */
+		unsigned int noOfImagePixels {};
+		/** mean of all grayvalues of all ROI pixels */
+		double meanOfROIPixels {};
+		/** standard deviation of all grayvalues of all ROI pixels */
+		double stdDevOfROIPixels {};
 	};
 
 	ImgProcROIFeature(const NFIQ::FingerprintImageData &fingerprintImage);

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures_impl.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures_impl.cpp
@@ -289,7 +289,7 @@ NFIQ::QualityFeatures::Impl::getAllQualityFeatureIDs()
 
 	for (auto &vec : vov) {
 		qualityFeatureIDs.insert(
-		    qualityFeatureIDs.cend(), vec.cbegin(), vec.cend());
+		    qualityFeatureIDs.end(), vec.cbegin(), vec.cend());
 	}
 
 	return qualityFeatureIDs;


### PR DESCRIPTION
Discovered on CentOS 7.6 (`g++ (GCC) 4.8.5 20150623 (Red Hat 4.8.5-36)`).