### PR TITLE
More consistent use of Map. Added Strict ordering in RF model

### DIFF
--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2.hpp
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2.hpp
@@ -10,6 +10,7 @@
 #include <list>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace NFIQ {
 /** Wrapper to return quality scores for a fingerprint image */
@@ -32,17 +33,6 @@ class NFIQ2Algorithm {
 	 */
 	unsigned int computeQualityScore(
 	    const NFIQ::FingerprintImageData &rawImage) const;
-
-	/**
-	 * @fn computeQualityScore
-	 * @brief Computes the quality score from the extracted image
-	 * quality feature data
-	 * @param qualityfeatureData list of computed feature data values
-	 * @return achieved quality score
-	 */
-	unsigned int computeQualityScore(
-	    const std::vector<NFIQ::QualityFeatureData> &qualityFeatureData)
-	    const;
 
 	/**
 	 * @fn computeQualityScore

--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2.hpp
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2.hpp
@@ -47,6 +47,17 @@ class NFIQ2Algorithm {
 	    const;
 
 	/**
+	 * @fn computeQualityScore
+	 * @brief Computes the quality score from the extracted image
+	 * quality feature data
+	 * @param featureMap map of string, quality feature data pairs
+	 * @return achieved quality score
+	 */
+	unsigned int computeQualityScore(
+	    const std::unordered_map<std::string, NFIQ::QualityFeatureData>
+		&featureMap) const;
+
+	/**
 	 * @brief
 	 * Obtain MD5 checksum of Random Forest parameter file loaded.
 	 *

--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2.hpp
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2.hpp
@@ -50,12 +50,12 @@ class NFIQ2Algorithm {
 	 * @fn computeQualityScore
 	 * @brief Computes the quality score from the extracted image
 	 * quality feature data
-	 * @param featureMap map of string, quality feature data pairs
+	 * @param features map of string, quality feature data pairs
 	 * @return achieved quality score
 	 */
 	unsigned int computeQualityScore(
 	    const std::unordered_map<std::string, NFIQ::QualityFeatureData>
-		&featureMap) const;
+		&features) const;
 
 	/**
 	 * @brief

--- a/NFIQ2/NFIQ2Algorithm/include/prediction/RandomForestML.h
+++ b/NFIQ2/NFIQ2Algorithm/include/prediction/RandomForestML.h
@@ -37,7 +37,7 @@ class RandomForestML {
 
 	void evaluate(
 	    const std::unordered_map<std::string, NFIQ::QualityFeatureData>
-		&feature,
+		&features,
 	    const double &utilityValue, double &qualityValue,
 	    double &deviation) const;
 

--- a/NFIQ2/NFIQ2Algorithm/include/prediction/RandomForestML.h
+++ b/NFIQ2/NFIQ2Algorithm/include/prediction/RandomForestML.h
@@ -35,8 +35,9 @@ class RandomForestML {
 	std::string initModule(
 	    const std::string &fileName, const std::string &fileHash);
 
-	void evaluate(const std::unordered_map<std::string, NFIQ::QualityFeatureData>
-			  &featureMap,
+	void evaluate(
+	    const std::unordered_map<std::string, NFIQ::QualityFeatureData>
+		&feature,
 	    const double &utilityValue, double &qualityValue,
 	    double &deviation) const;
 

--- a/NFIQ2/NFIQ2Algorithm/include/prediction/RandomForestML.h
+++ b/NFIQ2/NFIQ2Algorithm/include/prediction/RandomForestML.h
@@ -8,6 +8,7 @@
 
 #include <list>
 #include <string>
+#include <unordered_map>
 #include <vector>
 #if CV_MAJOR_VERSION <= 2
 #include <opencv/cv.h>
@@ -34,8 +35,8 @@ class RandomForestML {
 	std::string initModule(
 	    const std::string &fileName, const std::string &fileHash);
 
-	void evaluate(
-	    const std::vector<NFIQ::QualityFeatureData> &featureVector,
+	void evaluate(std::unordered_map<std::string, NFIQ::QualityFeatureData>
+			  &featureMap,
 	    const double &utilityValue, double &qualityValue,
 	    double &deviation) const;
 

--- a/NFIQ2/NFIQ2Algorithm/include/prediction/RandomForestML.h
+++ b/NFIQ2/NFIQ2Algorithm/include/prediction/RandomForestML.h
@@ -35,7 +35,7 @@ class RandomForestML {
 	std::string initModule(
 	    const std::string &fileName, const std::string &fileHash);
 
-	void evaluate(std::unordered_map<std::string, NFIQ::QualityFeatureData>
+	void evaluate(const std::unordered_map<std::string, NFIQ::QualityFeatureData>
 			  &featureMap,
 	    const double &utilityValue, double &qualityValue,
 	    double &deviation) const;

--- a/NFIQ2/NFIQ2Algorithm/include/tool/nfiq2_ui_log.h
+++ b/NFIQ2/NFIQ2Algorithm/include/tool/nfiq2_ui_log.h
@@ -73,11 +73,11 @@ class Log {
 	    unsigned int score, const std::string &errmsg, const bool quantized,
 	    const bool resampled,
 	    const std::unordered_map<std::string, NFIQ::QualityFeatureData>
-		&featureMap,
+		&features,
 	    const std::unordered_map<std::string, NFIQ::QualityFeatureSpeed>
-		&speedMap,
+		&speed,
 	    const std::unordered_map<std::string,
-		NFIQ::ActionableQualityFeedback> &actionableMap) const;
+		NFIQ::ActionableQualityFeedback> &actionable) const;
 
 	/**
 	 *  @brief

--- a/NFIQ2/NFIQ2Algorithm/include/tool/nfiq2_ui_log.h
+++ b/NFIQ2/NFIQ2Algorithm/include/tool/nfiq2_ui_log.h
@@ -72,10 +72,12 @@ class Log {
 	void printScore(const std::string &name, uint8_t fingerCode,
 	    unsigned int score, const std::string &errmsg, const bool quantized,
 	    const bool resampled,
-	    const std::vector<NFIQ::QualityFeatureData> &featureVector,
-	    const std::vector<NFIQ::QualityFeatureSpeed> &featureTimings,
-	    const std::vector<NFIQ::ActionableQualityFeedback>
-		&actionableQuality) const;
+	    const std::unordered_map<std::string, NFIQ::QualityFeatureData>
+		&featureMap,
+	    const std::unordered_map<std::string, NFIQ::QualityFeatureSpeed>
+		&speedMap,
+	    const std::unordered_map<std::string,
+		NFIQ::ActionableQualityFeedback> &actionableMap) const;
 
 	/**
 	 *  @brief

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2.cpp
@@ -37,11 +37,12 @@ NFIQ::NFIQ2Algorithm::computeQualityScore(
 	return (this->pimpl->computeQualityScore(features));
 }
 
-unsigned int 
+unsigned int
 NFIQ::NFIQ2Algorithm::computeQualityScore(
-    const std::unordered_map<std::string, NFIQ::QualityFeatureData> &qualityMap) const 
+    const std::unordered_map<std::string, NFIQ::QualityFeatureData> &qualityMap)
+    const
 {
-    return (this->pimpl->computeQualityScore(qualityMap));
+	return (this->pimpl->computeQualityScore(qualityMap));
 }
 
 std::string

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2.cpp
@@ -31,13 +31,6 @@ NFIQ::NFIQ2Algorithm::computeQualityScore(
 
 unsigned int
 NFIQ::NFIQ2Algorithm::computeQualityScore(
-    const std::vector<NFIQ::QualityFeatureData> &qualityFeatureData) const
-{
-	return (this->pimpl->computeQualityScore(qualityFeatureData));
-}
-
-unsigned int
-NFIQ::NFIQ2Algorithm::computeQualityScore(
     const std::vector<std::shared_ptr<NFIQ::QualityFeatures::BaseFeature>>
 	&features) const
 {

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2.cpp
@@ -39,10 +39,10 @@ NFIQ::NFIQ2Algorithm::computeQualityScore(
 
 unsigned int
 NFIQ::NFIQ2Algorithm::computeQualityScore(
-    const std::unordered_map<std::string, NFIQ::QualityFeatureData> &qualityMap)
+    const std::unordered_map<std::string, NFIQ::QualityFeatureData> &features)
     const
 {
-	return (this->pimpl->computeQualityScore(qualityMap));
+	return (this->pimpl->computeQualityScore(features));
 }
 
 std::string

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2.cpp
@@ -37,6 +37,13 @@ NFIQ::NFIQ2Algorithm::computeQualityScore(
 	return (this->pimpl->computeQualityScore(features));
 }
 
+unsigned int 
+NFIQ::NFIQ2Algorithm::computeQualityScore(
+    const std::unordered_map<std::string, NFIQ::QualityFeatureData> &qualityMap) const 
+{
+    return (this->pimpl->computeQualityScore(qualityMap));
+}
+
 std::string
 NFIQ::NFIQ2Algorithm::getParameterHash() const
 {

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures_impl.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures_impl.cpp
@@ -56,25 +56,24 @@ NFIQ::QualityFeatures::Impl::getQualityFeatureData(
 	std::vector<std::string> qualityIdentifiers =
 	    NFIQ::QualityFeatures::Impl::getAllQualityFeatureIDs();
 
-	std::unordered_map<std::string, NFIQ::QualityFeatureData>
-	    featureDataMap {};
+	std::unordered_map<std::string, NFIQ::QualityFeatureData> quality {};
 
 	auto counter = 0;
 	for (const auto &feature : features) {
 		for (auto &result : feature->getFeatures()) {
 			if (result.returnCode == 0) {
-				featureDataMap[qualityIdentifiers.at(counter)] =
+				quality[qualityIdentifiers.at(counter)] =
 				    result.featureData;
 			} else {
 				result.featureData.featureDataDouble = 0;
-				featureDataMap[qualityIdentifiers.at(counter)] =
+				quality[qualityIdentifiers.at(counter)] =
 				    result.featureData;
 			}
 			counter++;
 		}
 	}
 
-	return featureDataMap;
+	return quality;
 }
 
 std::unordered_map<std::string, NFIQ::ActionableQualityFeedback>

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures_impl.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures_impl.cpp
@@ -56,24 +56,25 @@ NFIQ::QualityFeatures::Impl::getQualityFeatureData(
 	std::vector<std::string> qualityIdentifiers =
 	    NFIQ::QualityFeatures::Impl::getAllQualityFeatureIDs();
 
-	std::unordered_map<std::string, NFIQ::QualityFeatureData> qualityMap {};
+	std::unordered_map<std::string, NFIQ::QualityFeatureData>
+	    featureDataMap {};
 
 	auto counter = 0;
 	for (const auto &feature : features) {
 		for (auto &result : feature->getFeatures()) {
 			if (result.returnCode == 0) {
-				qualityMap[qualityIdentifiers.at(counter)] =
+				featureDataMap[qualityIdentifiers.at(counter)] =
 				    result.featureData;
 			} else {
 				result.featureData.featureDataDouble = 0;
-				qualityMap[qualityIdentifiers.at(counter)] =
+				featureDataMap[qualityIdentifiers.at(counter)] =
 				    result.featureData;
 			}
 			counter++;
 		}
 	}
 
-	return qualityMap;
+	return featureDataMap;
 }
 
 std::unordered_map<std::string, NFIQ::ActionableQualityFeedback>

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2impl.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2impl.cpp
@@ -78,7 +78,7 @@ NFIQ2Algorithm::Impl::~Impl()
 
 double
 NFIQ2Algorithm::Impl::getQualityPrediction(
-    std::unordered_map<std::string, NFIQ::QualityFeatureData> &featureMap) const
+    const std::unordered_map<std::string, NFIQ::QualityFeatureData> &featureMap) const
 {
 	const double utility {};
 	double deviation {};
@@ -94,7 +94,7 @@ NFIQ2Algorithm::Impl::computeQualityScore(
 	&features) const
 {
 
-	std::unordered_map<std::string, NFIQ::QualityFeatureData> featureMap =
+	const std::unordered_map<std::string, NFIQ::QualityFeatureData> featureMap =
 	    NFIQ::QualityFeatures::getQualityFeatureData(features);
 
 	if (featureMap.size() == 0) {
@@ -141,7 +141,7 @@ NFIQ2Algorithm::Impl::computeQualityScore(
 		throw NFIQ::NFIQException(e_Error_UnknownError, e.what());
 	}
 
-	std::unordered_map<std::string, NFIQ::QualityFeatureData> featureMap =
+	const std::unordered_map<std::string, NFIQ::QualityFeatureData> featureMap =
 	    NFIQ::QualityFeatures::getQualityFeatureData(features);
 
 	if (featureMap.size() == 0) {
@@ -162,6 +162,13 @@ NFIQ2Algorithm::Impl::computeQualityScore(
 	}
 
 	return (unsigned int)qualityScore;
+}
+
+unsigned int 
+NFIQ2Algorithm::Impl::computeQualityScore(
+    const std::unordered_map<std::string, NFIQ::QualityFeatureData> &featureMap) const 
+{
+   	return (unsigned int)getQualityPrediction(featureMap);
 }
 
 std::string

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2impl.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2impl.cpp
@@ -78,7 +78,8 @@ NFIQ2Algorithm::Impl::~Impl()
 
 double
 NFIQ2Algorithm::Impl::getQualityPrediction(
-    const std::unordered_map<std::string, NFIQ::QualityFeatureData> &featureMap) const
+    const std::unordered_map<std::string, NFIQ::QualityFeatureData> &featureMap)
+    const
 {
 	const double utility {};
 	double deviation {};
@@ -94,8 +95,8 @@ NFIQ2Algorithm::Impl::computeQualityScore(
 	&features) const
 {
 
-	const std::unordered_map<std::string, NFIQ::QualityFeatureData> featureMap =
-	    NFIQ::QualityFeatures::getQualityFeatureData(features);
+	const std::unordered_map<std::string, NFIQ::QualityFeatureData>
+	    featureMap = NFIQ::QualityFeatures::getQualityFeatureData(features);
 
 	if (featureMap.size() == 0) {
 		// no features have been computed
@@ -141,8 +142,8 @@ NFIQ2Algorithm::Impl::computeQualityScore(
 		throw NFIQ::NFIQException(e_Error_UnknownError, e.what());
 	}
 
-	const std::unordered_map<std::string, NFIQ::QualityFeatureData> featureMap =
-	    NFIQ::QualityFeatures::getQualityFeatureData(features);
+	const std::unordered_map<std::string, NFIQ::QualityFeatureData>
+	    featureMap = NFIQ::QualityFeatures::getQualityFeatureData(features);
 
 	if (featureMap.size() == 0) {
 		// no features have been computed
@@ -164,11 +165,12 @@ NFIQ2Algorithm::Impl::computeQualityScore(
 	return (unsigned int)qualityScore;
 }
 
-unsigned int 
+unsigned int
 NFIQ2Algorithm::Impl::computeQualityScore(
-    const std::unordered_map<std::string, NFIQ::QualityFeatureData> &featureMap) const 
+    const std::unordered_map<std::string, NFIQ::QualityFeatureData> &featureMap)
+    const
 {
-   	return (unsigned int)getQualityPrediction(featureMap);
+	return (unsigned int)getQualityPrediction(featureMap);
 }
 
 std::string

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2impl.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2impl.cpp
@@ -78,12 +78,12 @@ NFIQ2Algorithm::Impl::~Impl()
 
 double
 NFIQ2Algorithm::Impl::getQualityPrediction(
-    const std::vector<NFIQ::QualityFeatureData> &featureVector) const
+    std::unordered_map<std::string, NFIQ::QualityFeatureData> &featureMap) const
 {
 	const double utility {};
 	double deviation {};
 	double quality {};
-	m_RandomForestML.evaluate(featureVector, utility, quality, deviation);
+	m_RandomForestML.evaluate(featureMap, utility, quality, deviation);
 
 	return quality;
 }
@@ -97,13 +97,7 @@ NFIQ2Algorithm::Impl::computeQualityScore(
 	std::unordered_map<std::string, NFIQ::QualityFeatureData> featureMap =
 	    NFIQ::QualityFeatures::getQualityFeatureData(features);
 
-	std::vector<NFIQ::QualityFeatureData> featureVector {};
-
-	for (const auto &i : NFIQ::QualityFeatures::getAllQualityFeatureIDs()) {
-		featureVector.push_back(featureMap[i]);
-	}
-
-	if (featureVector.size() == 0) {
+	if (featureMap.size() == 0) {
 		// no features have been computed
 		throw NFIQ::NFIQException(e_Error_FeatureCalculationError,
 		    "No features have been computed");
@@ -115,7 +109,7 @@ NFIQ2Algorithm::Impl::computeQualityScore(
 
 	double qualityScore {};
 	try {
-		qualityScore = getQualityPrediction(featureVector);
+		qualityScore = getQualityPrediction(featureMap);
 	} catch (const NFIQ::NFIQException &) {
 		throw;
 	}
@@ -150,13 +144,7 @@ NFIQ2Algorithm::Impl::computeQualityScore(
 	std::unordered_map<std::string, NFIQ::QualityFeatureData> featureMap =
 	    NFIQ::QualityFeatures::getQualityFeatureData(features);
 
-	std::vector<NFIQ::QualityFeatureData> featureVector {};
-
-	for (const auto &i : NFIQ::QualityFeatures::getAllQualityFeatureIDs()) {
-		featureVector.push_back(featureMap[i]);
-	}
-
-	if (featureVector.size() == 0) {
+	if (featureMap.size() == 0) {
 		// no features have been computed
 		throw NFIQ::NFIQException(e_Error_FeatureCalculationError,
 		    "No features have been computed");
@@ -168,7 +156,7 @@ NFIQ2Algorithm::Impl::computeQualityScore(
 
 	double qualityScore {};
 	try {
-		qualityScore = getQualityPrediction(featureVector);
+		qualityScore = getQualityPrediction(featureMap);
 	} catch (const NFIQ::NFIQException &) {
 		throw;
 	}
@@ -180,11 +168,4 @@ std::string
 NFIQ2Algorithm::Impl::getParameterHash() const
 {
 	return (this->m_parameterHash);
-}
-
-unsigned int
-NFIQ::NFIQ2Algorithm::Impl::computeQualityScore(
-    const std::vector<NFIQ::QualityFeatureData> &qualityFeatureData) const
-{
-	return (unsigned int)getQualityPrediction(qualityFeatureData);
 }

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2impl.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2impl.cpp
@@ -78,13 +78,13 @@ NFIQ2Algorithm::Impl::~Impl()
 
 double
 NFIQ2Algorithm::Impl::getQualityPrediction(
-    const std::unordered_map<std::string, NFIQ::QualityFeatureData> &featureMap)
+    const std::unordered_map<std::string, NFIQ::QualityFeatureData> &features)
     const
 {
 	const double utility {};
 	double deviation {};
 	double quality {};
-	m_RandomForestML.evaluate(featureMap, utility, quality, deviation);
+	m_RandomForestML.evaluate(features, utility, quality, deviation);
 
 	return quality;
 }
@@ -96,9 +96,10 @@ NFIQ2Algorithm::Impl::computeQualityScore(
 {
 
 	const std::unordered_map<std::string, NFIQ::QualityFeatureData>
-	    featureMap = NFIQ::QualityFeatures::getQualityFeatureData(features);
+	    featureDataMap = NFIQ::QualityFeatures::getQualityFeatureData(
+		features);
 
-	if (featureMap.size() == 0) {
+	if (featureDataMap.size() == 0) {
 		// no features have been computed
 		throw NFIQ::NFIQException(e_Error_FeatureCalculationError,
 		    "No features have been computed");
@@ -110,7 +111,7 @@ NFIQ2Algorithm::Impl::computeQualityScore(
 
 	double qualityScore {};
 	try {
-		qualityScore = getQualityPrediction(featureMap);
+		qualityScore = getQualityPrediction(featureDataMap);
 	} catch (const NFIQ::NFIQException &) {
 		throw;
 	}
@@ -143,9 +144,10 @@ NFIQ2Algorithm::Impl::computeQualityScore(
 	}
 
 	const std::unordered_map<std::string, NFIQ::QualityFeatureData>
-	    featureMap = NFIQ::QualityFeatures::getQualityFeatureData(features);
+	    featureDataMap = NFIQ::QualityFeatures::getQualityFeatureData(
+		features);
 
-	if (featureMap.size() == 0) {
+	if (featureDataMap.size() == 0) {
 		// no features have been computed
 		throw NFIQ::NFIQException(e_Error_FeatureCalculationError,
 		    "No features have been computed");
@@ -157,7 +159,7 @@ NFIQ2Algorithm::Impl::computeQualityScore(
 
 	double qualityScore {};
 	try {
-		qualityScore = getQualityPrediction(featureMap);
+		qualityScore = getQualityPrediction(featureDataMap);
 	} catch (const NFIQ::NFIQException &) {
 		throw;
 	}
@@ -167,10 +169,10 @@ NFIQ2Algorithm::Impl::computeQualityScore(
 
 unsigned int
 NFIQ2Algorithm::Impl::computeQualityScore(
-    const std::unordered_map<std::string, NFIQ::QualityFeatureData> &featureMap)
-    const
+    const std::unordered_map<std::string, NFIQ::QualityFeatureData>
+	&featureDataMap) const
 {
-	return (unsigned int)getQualityPrediction(featureMap);
+	return (unsigned int)getQualityPrediction(featureDataMap);
 }
 
 std::string

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2impl.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2impl.cpp
@@ -96,10 +96,9 @@ NFIQ2Algorithm::Impl::computeQualityScore(
 {
 
 	const std::unordered_map<std::string, NFIQ::QualityFeatureData>
-	    featureDataMap = NFIQ::QualityFeatures::getQualityFeatureData(
-		features);
+	    quality = NFIQ::QualityFeatures::getQualityFeatureData(features);
 
-	if (featureDataMap.size() == 0) {
+	if (quality.size() == 0) {
 		// no features have been computed
 		throw NFIQ::NFIQException(e_Error_FeatureCalculationError,
 		    "No features have been computed");
@@ -111,7 +110,7 @@ NFIQ2Algorithm::Impl::computeQualityScore(
 
 	double qualityScore {};
 	try {
-		qualityScore = getQualityPrediction(featureDataMap);
+		qualityScore = getQualityPrediction(quality);
 	} catch (const NFIQ::NFIQException &) {
 		throw;
 	}
@@ -144,10 +143,9 @@ NFIQ2Algorithm::Impl::computeQualityScore(
 	}
 
 	const std::unordered_map<std::string, NFIQ::QualityFeatureData>
-	    featureDataMap = NFIQ::QualityFeatures::getQualityFeatureData(
-		features);
+	    quality = NFIQ::QualityFeatures::getQualityFeatureData(features);
 
-	if (featureDataMap.size() == 0) {
+	if (quality.size() == 0) {
 		// no features have been computed
 		throw NFIQ::NFIQException(e_Error_FeatureCalculationError,
 		    "No features have been computed");
@@ -159,7 +157,7 @@ NFIQ2Algorithm::Impl::computeQualityScore(
 
 	double qualityScore {};
 	try {
-		qualityScore = getQualityPrediction(featureDataMap);
+		qualityScore = getQualityPrediction(quality);
 	} catch (const NFIQ::NFIQException &) {
 		throw;
 	}
@@ -169,10 +167,10 @@ NFIQ2Algorithm::Impl::computeQualityScore(
 
 unsigned int
 NFIQ2Algorithm::Impl::computeQualityScore(
-    const std::unordered_map<std::string, NFIQ::QualityFeatureData>
-	&featureDataMap) const
+    const std::unordered_map<std::string, NFIQ::QualityFeatureData> &features)
+    const
 {
-	return (unsigned int)getQualityPrediction(featureDataMap);
+	return (unsigned int)getQualityPrediction(features);
 }
 
 std::string

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2impl.h
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2impl.h
@@ -68,15 +68,15 @@ class NFIQ2Algorithm::Impl {
 	    const;
 
 	/**
- 	 * @fn computeQualityScore
- 	 * @brief Computes the quality score from the extracted image
- 	 * quality feature data
- 	 * @param featureMap map of string, quality feature data pairs
- 	 * @return achieved quality score
- 	 */
- 	unsigned int computeQualityScore(
- 	    const std::unordered_map<std::string, NFIQ::QualityFeatureData> &featureMap)
- 	    const;
+	 * @fn computeQualityScore
+	 * @brief Computes the quality score from the extracted image
+	 * quality feature data
+	 * @param featureMap map of string, quality feature data pairs
+	 * @return achieved quality score
+	 */
+	unsigned int computeQualityScore(
+	    const std::unordered_map<std::string, NFIQ::QualityFeatureData>
+		&featureMap) const;
 
 	/**
 	 * @brief

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2impl.h
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2impl.h
@@ -57,17 +57,6 @@ class NFIQ2Algorithm::Impl {
 
 	/**
 	 * @fn computeQualityScore
-	 * @brief Computes the quality score from the extracted image
-	 * quality feature data
-	 * @param qualityfeatureData list of computed feature data values
-	 * @return achieved quality score
-	 */
-	unsigned int computeQualityScore(
-	    const std::vector<NFIQ::QualityFeatureData> &qualityFeatureData)
-	    const;
-
-	/**
-	 * @fn computeQualityScore
 	 * @brief Computes the quality score from a vector of extracted feature
 	 * from a cropped fingerprint image
 	 * @param features list of computed feature metrics that contain quality
@@ -103,7 +92,8 @@ class NFIQ2Algorithm::Impl {
 	 * Failure to compute (OpenCV reason contained within message string).
 	 */
 	double getQualityPrediction(
-	    const std::vector<NFIQ::QualityFeatureData> &featureVector) const;
+	    std::unordered_map<std::string, NFIQ::QualityFeatureData>
+		&featureMap) const;
 
 	NFIQ::Prediction::RandomForestML m_RandomForestML;
 	std::string m_parameterHash {};

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2impl.h
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2impl.h
@@ -68,14 +68,15 @@ class NFIQ2Algorithm::Impl {
 	    const;
 
 	/**
-	 * @fn computeQualityFeaturesAndScore
-	 * @brief Computes the quality score from the input fingerprint image
-	 * data
-	 * @param rawImage fingerprint image in raw format
-	 * @return Object containing score, actionable, quality and speed data
-	 */
-	NFIQ::NFIQ2Results computeQualityFeaturesAndScore(
-	    const NFIQ::FingerprintImageData &rawImage) const;
+ 	 * @fn computeQualityScore
+ 	 * @brief Computes the quality score from the extracted image
+ 	 * quality feature data
+ 	 * @param featureMap map of string, quality feature data pairs
+ 	 * @return achieved quality score
+ 	 */
+ 	unsigned int computeQualityScore(
+ 	    const std::unordered_map<std::string, NFIQ::QualityFeatureData> &featureMap)
+ 	    const;
 
 	/**
 	 * @brief
@@ -92,7 +93,7 @@ class NFIQ2Algorithm::Impl {
 	 * Failure to compute (OpenCV reason contained within message string).
 	 */
 	double getQualityPrediction(
-	    std::unordered_map<std::string, NFIQ::QualityFeatureData>
+	    const std::unordered_map<std::string, NFIQ::QualityFeatureData>
 		&featureMap) const;
 
 	NFIQ::Prediction::RandomForestML m_RandomForestML;

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2impl.h
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2impl.h
@@ -71,12 +71,12 @@ class NFIQ2Algorithm::Impl {
 	 * @fn computeQualityScore
 	 * @brief Computes the quality score from the extracted image
 	 * quality feature data
-	 * @param featureMap map of string, quality feature data pairs
+	 * @param features map of string, quality feature data pairs
 	 * @return achieved quality score
 	 */
 	unsigned int computeQualityScore(
 	    const std::unordered_map<std::string, NFIQ::QualityFeatureData>
-		&featureMap) const;
+		&features) const;
 
 	/**
 	 * @brief
@@ -94,7 +94,7 @@ class NFIQ2Algorithm::Impl {
 	 */
 	double getQualityPrediction(
 	    const std::unordered_map<std::string, NFIQ::QualityFeatureData>
-		&featureMap) const;
+		&features) const;
 
 	NFIQ::Prediction::RandomForestML m_RandomForestML;
 	std::string m_parameterHash {};

--- a/NFIQ2/NFIQ2Algorithm/src/prediction/RandomForestML.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/prediction/RandomForestML.cpp
@@ -150,9 +150,37 @@ NFIQ::Prediction::RandomForestML::initModule(
 
 void
 NFIQ::Prediction::RandomForestML::evaluate(
-    const std::vector<NFIQ::QualityFeatureData> &featureVector,
+    std::unordered_map<std::string, NFIQ::QualityFeatureData> &featureMap,
     const double &utilityValue, double &qualityValue, double &deviation) const
 {
+	std::vector<std::string> rfFeatureOrder { "FDA_Bin10_0", "FDA_Bin10_1",
+		"FDA_Bin10_2", "FDA_Bin10_3", "FDA_Bin10_4", "FDA_Bin10_5",
+		"FDA_Bin10_6", "FDA_Bin10_7", "FDA_Bin10_8", "FDA_Bin10_9",
+		"FDA_Bin10_Mean", "FDA_Bin10_StdDev",
+		"FingerJetFX_MinCount_COMMinRect200x200",
+		"FingerJetFX_MinutiaeCount", "FJFXPos_Mu_MinutiaeQuality_2",
+		"FJFXPos_OCL_MinutiaeQuality_80", "ImgProcROIArea_Mean",
+		"LCS_Bin10_0", "LCS_Bin10_1", "LCS_Bin10_2", "LCS_Bin10_3",
+		"LCS_Bin10_4", "LCS_Bin10_5", "LCS_Bin10_6", "LCS_Bin10_7",
+		"LCS_Bin10_8", "LCS_Bin10_9", "LCS_Bin10_Mean",
+		"LCS_Bin10_StdDev", "MMB", "Mu", "OCL_Bin10_0", "OCL_Bin10_1",
+		"OCL_Bin10_2", "OCL_Bin10_3", "OCL_Bin10_4", "OCL_Bin10_5",
+		"OCL_Bin10_6", "OCL_Bin10_7", "OCL_Bin10_8", "OCL_Bin10_9",
+		"OCL_Bin10_Mean", "OCL_Bin10_StdDev", "OF_Bin10_0",
+		"OF_Bin10_1", "OF_Bin10_2", "OF_Bin10_3", "OF_Bin10_4",
+		"OF_Bin10_5", "OF_Bin10_6", "OF_Bin10_7", "OF_Bin10_8",
+		"OF_Bin10_9", "OF_Bin10_Mean", "OF_Bin10_StdDev",
+		"OrientationMap_ROIFilter_CoherenceRel",
+		"OrientationMap_ROIFilter_CoherenceSum", "RVUP_Bin10_0",
+		"RVUP_Bin10_1", "RVUP_Bin10_2", "RVUP_Bin10_3", "RVUP_Bin10_4",
+		"RVUP_Bin10_5", "RVUP_Bin10_6", "RVUP_Bin10_7", "RVUP_Bin10_8",
+		"RVUP_Bin10_9", "RVUP_Bin10_Mean", "RVUP_Bin10_StdDev" };
+
+	std::vector<NFIQ::QualityFeatureData> featureVector {};
+	for (const auto &i : rfFeatureOrder) {
+		featureVector.push_back(featureMap[i]);
+	}
+
 	try {
 #if CV_MAJOR_VERSION <= 2
 		if (m_pTrainedRF == nullptr) {

--- a/NFIQ2/NFIQ2Algorithm/src/prediction/RandomForestML.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/prediction/RandomForestML.cpp
@@ -153,6 +153,13 @@ NFIQ::Prediction::RandomForestML::evaluate(
     const std::unordered_map<std::string, NFIQ::QualityFeatureData> &featureMap,
     const double &utilityValue, double &qualityValue, double &deviation) const
 {
+	/**
+	   The following ordering of feature keys is critical to the
+	   correct computation of NFIQ 2 scores. Any modification to this
+	   ordering will result in incorrectly generated NFIQ 2 scores. This is
+	   based on the training model currently in use and may be updated in
+	   the future.
+	*/
 	static const std::vector<std::string> rfFeatureOrder { "FDA_Bin10_0",
 		"FDA_Bin10_1", "FDA_Bin10_2", "FDA_Bin10_3", "FDA_Bin10_4",
 		"FDA_Bin10_5", "FDA_Bin10_6", "FDA_Bin10_7", "FDA_Bin10_8",

--- a/NFIQ2/NFIQ2Algorithm/src/prediction/RandomForestML.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/prediction/RandomForestML.cpp
@@ -153,10 +153,10 @@ NFIQ::Prediction::RandomForestML::evaluate(
     const std::unordered_map<std::string, NFIQ::QualityFeatureData> &featureMap,
     const double &utilityValue, double &qualityValue, double &deviation) const
 {
-	static const std::vector<std::string> rfFeatureOrder { "FDA_Bin10_0", "FDA_Bin10_1",
-		"FDA_Bin10_2", "FDA_Bin10_3", "FDA_Bin10_4", "FDA_Bin10_5",
-		"FDA_Bin10_6", "FDA_Bin10_7", "FDA_Bin10_8", "FDA_Bin10_9",
-		"FDA_Bin10_Mean", "FDA_Bin10_StdDev",
+	static const std::vector<std::string> rfFeatureOrder { "FDA_Bin10_0",
+		"FDA_Bin10_1", "FDA_Bin10_2", "FDA_Bin10_3", "FDA_Bin10_4",
+		"FDA_Bin10_5", "FDA_Bin10_6", "FDA_Bin10_7", "FDA_Bin10_8",
+		"FDA_Bin10_9", "FDA_Bin10_Mean", "FDA_Bin10_StdDev",
 		"FingerJetFX_MinCount_COMMinRect200x200",
 		"FingerJetFX_MinutiaeCount", "FJFXPos_Mu_MinutiaeQuality_2",
 		"FJFXPos_OCL_MinutiaeQuality_80", "ImgProcROIArea_Mean",

--- a/NFIQ2/NFIQ2Algorithm/src/prediction/RandomForestML.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/prediction/RandomForestML.cpp
@@ -150,10 +150,10 @@ NFIQ::Prediction::RandomForestML::initModule(
 
 void
 NFIQ::Prediction::RandomForestML::evaluate(
-    std::unordered_map<std::string, NFIQ::QualityFeatureData> &featureMap,
+    const std::unordered_map<std::string, NFIQ::QualityFeatureData> &featureMap,
     const double &utilityValue, double &qualityValue, double &deviation) const
 {
-	std::vector<std::string> rfFeatureOrder { "FDA_Bin10_0", "FDA_Bin10_1",
+	static const std::vector<std::string> rfFeatureOrder { "FDA_Bin10_0", "FDA_Bin10_1",
 		"FDA_Bin10_2", "FDA_Bin10_3", "FDA_Bin10_4", "FDA_Bin10_5",
 		"FDA_Bin10_6", "FDA_Bin10_7", "FDA_Bin10_8", "FDA_Bin10_9",
 		"FDA_Bin10_Mean", "FDA_Bin10_StdDev",
@@ -178,7 +178,7 @@ NFIQ::Prediction::RandomForestML::evaluate(
 
 	std::vector<NFIQ::QualityFeatureData> featureVector {};
 	for (const auto &i : rfFeatureOrder) {
-		featureVector.push_back(featureMap[i]);
+		featureVector.push_back(featureMap.at(i));
 	}
 
 	try {

--- a/NFIQ2/NFIQ2Algorithm/src/prediction/RandomForestML.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/prediction/RandomForestML.cpp
@@ -150,7 +150,7 @@ NFIQ::Prediction::RandomForestML::initModule(
 
 void
 NFIQ::Prediction::RandomForestML::evaluate(
-    const std::unordered_map<std::string, NFIQ::QualityFeatureData> &featureMap,
+    const std::unordered_map<std::string, NFIQ::QualityFeatureData> &features,
     const double &utilityValue, double &qualityValue, double &deviation) const
 {
 	/**
@@ -185,7 +185,7 @@ NFIQ::Prediction::RandomForestML::evaluate(
 
 	std::vector<NFIQ::QualityFeatureData> featureVector {};
 	for (const auto &i : rfFeatureOrder) {
-		featureVector.push_back(featureMap.at(i));
+		featureVector.push_back(features.at(i));
 	}
 
 	try {

--- a/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_log.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_log.cpp
@@ -49,7 +49,6 @@ NFIQ2UI::Log::printScore(const std::string &name, uint8_t fingerCode,
     const std::unordered_map<std::string, NFIQ::ActionableQualityFeedback>
 	&actionableMap) const
 {
-
 	*(this->out) << "\"" << name << "\""
 		     << "," << std::to_string(fingerCode) << "," << score << ","
 		     << errmsg << "," << quantized << "," << resampled;

--- a/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_log.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_log.cpp
@@ -58,13 +58,12 @@ NFIQ2UI::Log::printScore(const std::string &name, uint8_t fingerCode,
 
 	// Print out actionable first
 	if (this->actionable) {
-		bool notFirstElement = false;
-		for (const auto &i :
-		    NFIQ::QualityFeatures::getAllActionableIdentifiers()) {
-			if (notFirstElement) {
+		const auto actionableIDs =
+		    NFIQ::QualityFeatures::getAllActionableIdentifiers();
+		for (const auto &i : actionableIDs) {
+			if (i != actionableIDs.front()) {
 				*(this->out) << ",";
 			}
-			notFirstElement = true;
 
 			*(this->out) << NFIQ2UI::formatDouble(
 			    actionableMap.at(i).actionableQualityValue, 5);
@@ -75,13 +74,12 @@ NFIQ2UI::Log::printScore(const std::string &name, uint8_t fingerCode,
 	}
 
 	if (this->verbose) {
-		bool notFirstElement = false;
-		for (const auto &i :
-		    NFIQ::QualityFeatures::getAllQualityFeatureIDs()) {
-			if (notFirstElement) {
+		const auto featureIDs =
+		    NFIQ::QualityFeatures::getAllQualityFeatureIDs();
+		for (const auto &i : featureIDs) {
+			if (i != featureIDs.front()) {
 				*(this->out) << ",";
 			}
-			notFirstElement = true;
 
 			*(this->out) << NFIQ2UI::formatDouble(
 			    featureMap.at(i).featureDataDouble, 5);
@@ -92,13 +90,12 @@ NFIQ2UI::Log::printScore(const std::string &name, uint8_t fingerCode,
 	}
 
 	if (this->speed) {
-		bool notFirstElement = false;
-		for (const auto &i :
-		    NFIQ::QualityFeatures::getAllSpeedFeatureGroups()) {
-			if (notFirstElement) {
+		const auto speedIDs =
+		    NFIQ::QualityFeatures::getAllSpeedFeatureGroups();
+		for (const auto &i : speedIDs) {
+			if (i != speedIDs.front()) {
 				*(this->out) << ",";
 			}
-			notFirstElement = true;
 
 			*(this->out) << std::setprecision(5)
 				     << speedMap.at(i).featureSpeed;

--- a/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_log.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_log.cpp
@@ -44,10 +44,12 @@ void
 NFIQ2UI::Log::printScore(const std::string &name, uint8_t fingerCode,
     unsigned int score, const std::string &errmsg, const bool quantized,
     const bool resampled,
-    const std::vector<NFIQ::QualityFeatureData> &featureVector,
-    const std::vector<NFIQ::QualityFeatureSpeed> &featureTimings,
-    const std::vector<NFIQ::ActionableQualityFeedback> &actionableQuality) const
+    const std::unordered_map<std::string, NFIQ::QualityFeatureData> &featureMap,
+    const std::unordered_map<std::string, NFIQ::QualityFeatureSpeed> &speedMap,
+    const std::unordered_map<std::string, NFIQ::ActionableQualityFeedback>
+	&actionableMap) const
 {
+
 	*(this->out) << "\"" << name << "\""
 		     << "," << std::to_string(fingerCode) << "," << score << ","
 		     << errmsg << "," << quantized << "," << resampled;
@@ -57,14 +59,16 @@ NFIQ2UI::Log::printScore(const std::string &name, uint8_t fingerCode,
 
 	// Print out actionable first
 	if (this->actionable) {
-		for (auto i = actionableQuality.begin();
-		     i != actionableQuality.end(); ++i) {
-			if (i != actionableQuality.begin()) {
+		bool notFirstElement = false;
+		for (const auto &i :
+		    NFIQ::QualityFeatures::getAllActionableIdentifiers()) {
+			if (notFirstElement) {
 				*(this->out) << ",";
 			}
+			notFirstElement = true;
 
 			*(this->out) << NFIQ2UI::formatDouble(
-			    i->actionableQualityValue, 5);
+			    actionableMap.at(i).actionableQualityValue, 5);
 		}
 		if (this->verbose || this->speed) {
 			*(this->out) << ",";
@@ -72,14 +76,16 @@ NFIQ2UI::Log::printScore(const std::string &name, uint8_t fingerCode,
 	}
 
 	if (this->verbose) {
-		for (auto i = featureVector.begin(); i != featureVector.end();
-		     ++i) {
-			if (i != featureVector.begin()) {
+		bool notFirstElement = false;
+		for (const auto &i :
+		    NFIQ::QualityFeatures::getAllQualityFeatureIDs()) {
+			if (notFirstElement) {
 				*(this->out) << ",";
 			}
+			notFirstElement = true;
 
-			*(this->out)
-			    << NFIQ2UI::formatDouble(i->featureDataDouble, 5);
+			*(this->out) << NFIQ2UI::formatDouble(
+			    featureMap.at(i).featureDataDouble, 5);
 		}
 		if (this->speed) {
 			*(this->out) << ",";
@@ -87,13 +93,16 @@ NFIQ2UI::Log::printScore(const std::string &name, uint8_t fingerCode,
 	}
 
 	if (this->speed) {
-		for (auto i = featureTimings.begin(); i != featureTimings.end();
-		     ++i) {
-			if (i != featureTimings.begin()) {
+		bool notFirstElement = false;
+		for (const auto &i :
+		    NFIQ::QualityFeatures::getAllSpeedFeatureGroups()) {
+			if (notFirstElement) {
 				*(this->out) << ",";
 			}
+			notFirstElement = true;
 
-			*(this->out) << std::setprecision(5) << i->featureSpeed;
+			*(this->out) << std::setprecision(5)
+				     << speedMap.at(i).featureSpeed;
 		}
 	}
 	*(this->out) << "\n";

--- a/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_log.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_log.cpp
@@ -44,10 +44,10 @@ void
 NFIQ2UI::Log::printScore(const std::string &name, uint8_t fingerCode,
     unsigned int score, const std::string &errmsg, const bool quantized,
     const bool resampled,
-    const std::unordered_map<std::string, NFIQ::QualityFeatureData> &featureMap,
-    const std::unordered_map<std::string, NFIQ::QualityFeatureSpeed> &speedMap,
+    const std::unordered_map<std::string, NFIQ::QualityFeatureData> &features,
+    const std::unordered_map<std::string, NFIQ::QualityFeatureSpeed> &speed,
     const std::unordered_map<std::string, NFIQ::ActionableQualityFeedback>
-	&actionableMap) const
+	&actionable) const
 {
 	*(this->out) << "\"" << name << "\""
 		     << "," << std::to_string(fingerCode) << "," << score << ","
@@ -66,7 +66,7 @@ NFIQ2UI::Log::printScore(const std::string &name, uint8_t fingerCode,
 			}
 
 			*(this->out) << NFIQ2UI::formatDouble(
-			    actionableMap.at(i).actionableQualityValue, 5);
+			    actionable.at(i).actionableQualityValue, 5);
 		}
 		if (this->verbose || this->speed) {
 			*(this->out) << ",";
@@ -82,7 +82,7 @@ NFIQ2UI::Log::printScore(const std::string &name, uint8_t fingerCode,
 			}
 
 			*(this->out) << NFIQ2UI::formatDouble(
-			    featureMap.at(i).featureDataDouble, 5);
+			    features.at(i).featureDataDouble, 5);
 		}
 		if (this->speed) {
 			*(this->out) << ",";
@@ -97,8 +97,8 @@ NFIQ2UI::Log::printScore(const std::string &name, uint8_t fingerCode,
 				*(this->out) << ",";
 			}
 
-			*(this->out) << std::setprecision(5)
-				     << speedMap.at(i).featureSpeed;
+			*(this->out)
+			    << std::setprecision(5) << speed.at(i).featureSpeed;
 		}
 	}
 	*(this->out) << "\n";

--- a/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_refresh.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_refresh.cpp
@@ -390,42 +390,13 @@ NFIQ2UI::executeSingle(std::shared_ptr<BE::Image::Image> img,
 
 	} else {
 
-		std::unordered_map<std::string, NFIQ::QualityFeatureData>
-		    featureMap = NFIQ::QualityFeatures::getQualityFeatureData(
-			features);
-
-		std::vector<NFIQ::QualityFeatureData> featureVector {};
-		for (const auto &i :
-		    NFIQ::QualityFeatures::getAllQualityFeatureIDs()) {
-			featureVector.push_back(featureMap[i]);
-		}
-
-		std::unordered_map<std::string, NFIQ::QualityFeatureSpeed>
-		    speedMap = NFIQ::QualityFeatures::getQualityFeatureSpeeds(
-			features);
-
-		std::vector<NFIQ::QualityFeatureSpeed> speedVector {};
-		for (const auto &i :
-		    NFIQ::QualityFeatures::getAllSpeedFeatureGroups()) {
-			speedVector.push_back(speedMap[i]);
-		}
-
-		std::unordered_map<std::string, NFIQ::ActionableQualityFeedback>
-		    actionableMap =
-			NFIQ::QualityFeatures::getActionableQualityFeedback(
-			    features);
-
-		std::vector<NFIQ::ActionableQualityFeedback>
-		    actionableVector {};
-		for (const auto &i :
-		    NFIQ::QualityFeatures::getAllActionableIdentifiers()) {
-			actionableVector.push_back(actionableMap[i]);
-		}
-
 		// Print full score with optional headers
 		logger->printScore(name, fingerPosition, score, warning,
-		    imageProps.quantized, imageProps.resampled, featureVector,
-		    speedVector, actionableVector);
+		    imageProps.quantized, imageProps.resampled,
+		    NFIQ::QualityFeatures::getQualityFeatureData(features),
+		    NFIQ::QualityFeatures::getQualityFeatureSpeeds(features),
+		    NFIQ::QualityFeatures::getActionableQualityFeedback(
+			features));
 	}
 }
 


### PR DESCRIPTION
Closes #223 

Since the RF model depends on a specific ordering of features, we needed to hardcode the ordering so that we keep NFIQ2 scores consistent.
Replaced the use of vectors in some places with maps to provide more flexibility in recording the csv output in the future. 
Replaced an API function with one that takes a map as an argument