### PR TITLE
Remove M_PI check/redefinition

### DIFF
--- a/NFIQ2/NFIQ2Algorithm/src/features/FDAFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FDAFeature.cpp
@@ -5,15 +5,12 @@
 #include <opencv2/core/core.hpp>
 #include <opencv2/highgui/highgui.hpp>
 
+#include <cmath>
 #include <sstream>
 
 #if defined WINDOWS || defined WIN32
 #include <float.h>
 #include <windows.h>
-#endif
-
-#ifndef M_PI
-#define M_PI 3.14159265358979323846
 #endif
 
 using namespace NFIQ;

--- a/NFIQ2/NFIQ2Algorithm/src/features/FeatureFunctions.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FeatureFunctions.cpp
@@ -3,16 +3,10 @@
 #include <opencv2/core/core.hpp>
 #include <opencv2/highgui/highgui.hpp>
 
-#define USE_MATH_DEFINES
-#include <math.h>
-
+#include <cmath>
 #include <cstring>
 #include <iostream>
 #include <limits>
-
-#ifndef M_PI
-#define M_PI 3.14159265358979323846
-#endif
 
 static const int maxSampleCount = 50;
 

--- a/NFIQ2/NFIQ2Algorithm/src/features/OFFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/OFFeature.cpp
@@ -5,15 +5,12 @@
 #include <nfiq2_timer.hpp>
 #include <opencv2/core/core.hpp>
 
+#include <cmath>
 #include <sstream>
 
 #if defined WINDOWS || defined WIN32
 #include <float.h>
 #include <windows.h>
-#endif
-
-#ifndef M_PI
-#define M_PI 3.14159265358979323846
 #endif
 
 using namespace NFIQ;

--- a/NFIQ2/NFIQ2Algorithm/src/features/QualityMapFeatures.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/QualityMapFeatures.cpp
@@ -11,10 +11,6 @@
 #include <windows.h>
 #endif
 
-#ifndef M_PI
-#define M_PI 3.14159265358979323846
-#endif
-
 using namespace NFIQ;
 using namespace cv;
 using namespace std;

--- a/cmake/compiler.cmake
+++ b/cmake/compiler.cmake
@@ -24,6 +24,7 @@ if (("${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang") OR ("${CMAKE_CXX_COMPILER
   else()
     add_definitions("-DLINUX -fPIC")
   endif()
+  add_definitions(_USE_MATH_DEFINES)
 
   if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     add_definitions("-Wno-unused-but-set-variable ")

--- a/cmake/compiler.cmake
+++ b/cmake/compiler.cmake
@@ -24,7 +24,7 @@ if (("${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang") OR ("${CMAKE_CXX_COMPILER
   else()
     add_definitions("-DLINUX -fPIC")
   endif()
-  add_definitions(_USE_MATH_DEFINES)
+  add_definitions("-D_USE_MATH_DEFINES")
 
   if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     add_definitions("-Wno-unused-but-set-variable ")

--- a/cmake/compiler.cmake
+++ b/cmake/compiler.cmake
@@ -1,6 +1,7 @@
 option(USE_SANITIZER "Using the GCC sanitizer" OFF)
 include(CheckCXXSourceRuns)
 
+add_definitions("-D_USE_MATH_DEFINES")
 if (("${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang") OR ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang") OR ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU"))
 #####################################################
   message( STATUS "${Gn}Detected ${CMAKE_CXX_COMPILER_ID} compiler${Na}" )
@@ -24,7 +25,6 @@ if (("${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang") OR ("${CMAKE_CXX_COMPILER
   else()
     add_definitions("-DLINUX -fPIC")
   endif()
-  add_definitions("-D_USE_MATH_DEFINES")
 
   if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     add_definitions("-Wno-unused-but-set-variable ")


### PR DESCRIPTION
cmath *should* always have this defined.

Also, `USE_MATH_DEFINES` is not recognized. The correct definition is `_USE_MATH_DEFINES` for some C libraries.