### PR TITLE
Remove using namespace std, NFIQ

### DIFF
--- a/NFIQ2/NFIQ2Algorithm/src/features/FDAFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FDAFeature.cpp
@@ -16,7 +16,6 @@
 #define M_PI 3.14159265358979323846
 #endif
 
-using namespace NFIQ;
 using namespace cv;
 
 double fda(const Mat &block, const double orientation, const int v1sz_x,

--- a/NFIQ2/NFIQ2Algorithm/src/features/FJFXMinutiaeQualityFeatures.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FJFXMinutiaeQualityFeatures.cpp
@@ -5,7 +5,6 @@
 
 #include <sstream>
 
-using namespace NFIQ;
 using namespace cv;
 
 NFIQ::QualityFeatures::FJFXMinutiaeQualityFeature::FJFXMinutiaeQualityFeature(

--- a/NFIQ2/NFIQ2Algorithm/src/features/FeatureFunctions.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FeatureFunctions.cpp
@@ -16,7 +16,6 @@
 
 static const int maxSampleCount = 50;
 
-using namespace NFIQ;
 using namespace cv;
 /***
 From the matlab code:

--- a/NFIQ2/NFIQ2Algorithm/src/features/FingerJetFXFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FingerJetFXFeature.cpp
@@ -5,8 +5,6 @@
 
 #include <sstream>
 
-using namespace NFIQ;
-
 NFIQ::QualityFeatures::FingerJetFXFeature::FingerJetFXFeature(
     const NFIQ::FingerprintImageData &fingerprintImage)
 {

--- a/NFIQ2/NFIQ2Algorithm/src/features/ImgProcROIFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/ImgProcROIFeature.cpp
@@ -5,7 +5,6 @@
 
 #include <sstream>
 
-using namespace NFIQ;
 using namespace cv;
 
 NFIQ::QualityFeatures::ImgProcROIFeature::ImgProcROIFeature(

--- a/NFIQ2/NFIQ2Algorithm/src/features/LCSFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/LCSFeature.cpp
@@ -12,7 +12,6 @@
 #include <windows.h>
 #endif
 
-using namespace NFIQ;
 using namespace cv;
 
 double loclar(Mat &block, const double orientation, const int v1sz_x,

--- a/NFIQ2/NFIQ2Algorithm/src/features/MuFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/MuFeature.cpp
@@ -4,7 +4,6 @@
 
 #include <sstream>
 
-using namespace NFIQ;
 using namespace cv;
 
 NFIQ::QualityFeatures::MuFeature::MuFeature(

--- a/NFIQ2/NFIQ2Algorithm/src/features/OCLHistogramFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/OCLHistogramFeature.cpp
@@ -10,7 +10,6 @@
 #include <windows.h>
 #endif
 
-using namespace NFIQ;
 using namespace cv;
 
 NFIQ::QualityFeatures::OCLHistogramFeature::OCLHistogramFeature(

--- a/NFIQ2/NFIQ2Algorithm/src/features/OFFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/OFFeature.cpp
@@ -16,7 +16,6 @@
 #define M_PI 3.14159265358979323846
 #endif
 
-using namespace NFIQ;
 using namespace cv;
 
 NFIQ::QualityFeatures::OFFeature::OFFeature(

--- a/NFIQ2/NFIQ2Algorithm/src/features/QualityMapFeatures.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/QualityMapFeatures.cpp
@@ -16,7 +16,6 @@
 #endif
 
 using namespace cv;
-using namespace std;
 
 NFIQ::QualityFeatures::QualityMapFeatures::QualityMapFeatures(
     const NFIQ::FingerprintImageData &fingerprintImage,

--- a/NFIQ2/NFIQ2Algorithm/src/features/QualityMapFeatures.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/QualityMapFeatures.cpp
@@ -15,7 +15,6 @@
 #define M_PI 3.14159265358979323846
 #endif
 
-using namespace NFIQ;
 using namespace cv;
 using namespace std;
 

--- a/NFIQ2/NFIQ2Algorithm/src/features/RVUPHistogramFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/RVUPHistogramFeature.cpp
@@ -12,7 +12,6 @@
 #include <windows.h>
 #endif
 
-using namespace NFIQ;
 using namespace cv;
 using namespace std;
 

--- a/NFIQ2/NFIQ2Algorithm/src/features/RVUPHistogramFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/RVUPHistogramFeature.cpp
@@ -13,7 +13,6 @@
 #endif
 
 using namespace cv;
-using namespace std;
 
 void rvuhist(Mat block, const double orientation, const int v1sz_x,
     const int v1sz_y, bool padFlag, std::vector<double> &ratios,

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/data.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/data.cpp
@@ -4,33 +4,32 @@
 #include <sstream>
 
 using namespace std;
-using namespace NFIQ;
 
-Data::Data()
+NFIQ::Data::Data()
 {
 }
 
-Data::Data(const uint8_t *pData, uint32_t dataSize)
+NFIQ::Data::Data(const uint8_t *pData, uint32_t dataSize)
     : std::basic_string<uint8_t>(pData, dataSize)
 {
 }
 
-Data::Data(const Data &otherData)
+NFIQ::Data::Data(const Data &otherData)
     : std::basic_string<uint8_t>(otherData)
 {
 }
 
-Data::Data(const std::basic_string<uint8_t> &otherData)
+NFIQ::Data::Data(const std::basic_string<uint8_t> &otherData)
     : std::basic_string<uint8_t>(otherData)
 {
 }
 
-Data::~Data()
+NFIQ::Data::~Data()
 {
 }
 
 void
-Data::writeToFile(const std::string &filename) const
+NFIQ::Data::writeToFile(const std::string &filename) const
 {
 	bool success = false;
 	if (!filename.empty()) {
@@ -53,7 +52,7 @@ Data::writeToFile(const std::string &filename) const
 }
 
 void
-Data::readFromFile(const std::string &filename)
+NFIQ::Data::readFromFile(const std::string &filename)
 {
 	bool success = false;
 	if (!filename.empty()) {
@@ -91,7 +90,7 @@ Data::readFromFile(const std::string &filename)
 }
 
 std::string
-Data::toHexString() const
+NFIQ::Data::toHexString() const
 {
 	if (this->size() <= 0) {
 		throw NFIQ::NFIQException(NFIQ::e_Error_NoDataAvailable);
@@ -112,7 +111,7 @@ Data::toHexString() const
 }
 
 void
-Data::fromBase64String(const std::string &base64String)
+NFIQ::Data::fromBase64String(const std::string &base64String)
 {
 	const char *ptr = base64String.data();
 	size_t len = base64String.size();
@@ -168,7 +167,7 @@ Data::fromBase64String(const std::string &base64String)
 }
 
 std::string
-Data::toBase64String() const
+NFIQ::Data::toBase64String() const
 {
 	const char base64Lookup[65] = { 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H',
 		'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U',

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/data.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/data.cpp
@@ -3,8 +3,6 @@
 #include <iomanip>
 #include <sstream>
 
-using namespace std;
-
 NFIQ::Data::Data()
 {
 }
@@ -97,7 +95,7 @@ NFIQ::Data::toHexString() const
 	}
 
 	std::stringstream ss;
-	ss << setfill('0') << right;
+	ss << std::setfill('0') << std::right;
 
 	for (unsigned long nPos = 0; nPos < this->size(); nPos++) {
 		if (nPos > 0) {

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/fingerprintimagedata.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/fingerprintimagedata.cpp
@@ -8,12 +8,10 @@ int debug = 0;
 #include <stdlib.h>
 #include <string.h>
 
-using namespace NFIQ;
-
 static double computeMuFromRow(unsigned int rowIndex, cv::Mat &img);
 static double computeMuFromColumn(unsigned int columnIndex, cv::Mat &img);
 
-FingerprintImageData::FingerprintImageData()
+NFIQ::FingerprintImageData::FingerprintImageData()
     : Data()
     , m_ImageWidth(0)
     , m_ImageHeight(0)
@@ -22,7 +20,7 @@ FingerprintImageData::FingerprintImageData()
 {
 }
 
-FingerprintImageData::FingerprintImageData(uint32_t imageWidth,
+NFIQ::FingerprintImageData::FingerprintImageData(uint32_t imageWidth,
     uint32_t imageHeight, uint8_t fingerCode, uint16_t imageDPI)
     : Data()
     , m_ImageWidth(imageWidth)
@@ -32,7 +30,7 @@ FingerprintImageData::FingerprintImageData(uint32_t imageWidth,
 {
 }
 
-FingerprintImageData::FingerprintImageData(const uint8_t *pData,
+NFIQ::FingerprintImageData::FingerprintImageData(const uint8_t *pData,
     uint32_t dataSize, uint32_t imageWidth, uint32_t imageHeight,
     uint8_t fingerCode, uint16_t imageDPI)
     : Data(pData, dataSize)
@@ -43,7 +41,7 @@ FingerprintImageData::FingerprintImageData(const uint8_t *pData,
 {
 }
 
-FingerprintImageData::FingerprintImageData(
+NFIQ::FingerprintImageData::FingerprintImageData(
     const FingerprintImageData &otherData)
     : Data(otherData)
 {
@@ -53,12 +51,12 @@ FingerprintImageData::FingerprintImageData(
 	m_ImageDPI = otherData.m_ImageDPI;
 }
 
-FingerprintImageData::~FingerprintImageData()
+NFIQ::FingerprintImageData::~FingerprintImageData()
 {
 }
 
 NFIQ::FingerprintImageData
-FingerprintImageData::removeWhiteFrameAroundFingerprint() const
+NFIQ::FingerprintImageData::removeWhiteFrameAroundFingerprint() const
 {
 	// make local copy of internal fingerprint image
 	NFIQ::FingerprintImageData localFingerprintImage(this->m_ImageWidth,

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_nfiq2algorithm_impl.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_nfiq2algorithm_impl.cpp
@@ -29,12 +29,11 @@ set_fpu(unsigned int mode)
 }
 #endif
 
-using namespace NFIQ;
 using namespace std;
 using namespace cv;
 
 #ifdef EMBED_RANDOMFOREST_PARAMETERS
-NFIQ2Algorithm::Impl::Impl()
+NFIQ::NFIQ2Algorithm::Impl::Impl()
 {
 #if defined(__linux) && defined(__i386__)
 	set_fpu(0x27F); /* use double-precision rounding */
@@ -44,7 +43,7 @@ NFIQ2Algorithm::Impl::Impl()
 }
 #endif
 
-NFIQ2Algorithm::Impl::Impl(
+NFIQ::NFIQ2Algorithm::Impl::Impl(
     const std::string &fileName, const std::string &fileHash)
 {
 #if defined(__linux) && defined(__i386__)
@@ -71,12 +70,12 @@ NFIQ2Algorithm::Impl::Impl(
 	}
 }
 
-NFIQ2Algorithm::Impl::~Impl()
+NFIQ::NFIQ2Algorithm::Impl::~Impl()
 {
 }
 
 double
-NFIQ2Algorithm::Impl::getQualityPrediction(
+NFIQ::NFIQ2Algorithm::Impl::getQualityPrediction(
     const std::unordered_map<std::string, NFIQ::QualityFeatureData> &features)
     const
 {
@@ -89,7 +88,7 @@ NFIQ2Algorithm::Impl::getQualityPrediction(
 }
 
 unsigned int
-NFIQ2Algorithm::Impl::computeQualityScore(
+NFIQ::NFIQ2Algorithm::Impl::computeQualityScore(
     const std::vector<std::shared_ptr<NFIQ::QualityFeatures::BaseFeature>>
 	&features) const
 {
@@ -118,7 +117,7 @@ NFIQ2Algorithm::Impl::computeQualityScore(
 }
 
 unsigned int
-NFIQ2Algorithm::Impl::computeQualityScore(
+NFIQ::NFIQ2Algorithm::Impl::computeQualityScore(
     const NFIQ::FingerprintImageData &rawImage) const
 {
 
@@ -165,7 +164,7 @@ NFIQ2Algorithm::Impl::computeQualityScore(
 }
 
 unsigned int
-NFIQ2Algorithm::Impl::computeQualityScore(
+NFIQ::NFIQ2Algorithm::Impl::computeQualityScore(
     const std::unordered_map<std::string, NFIQ::QualityFeatureData> &features)
     const
 {
@@ -173,7 +172,7 @@ NFIQ2Algorithm::Impl::computeQualityScore(
 }
 
 std::string
-NFIQ2Algorithm::Impl::getParameterHash() const
+NFIQ::NFIQ2Algorithm::Impl::getParameterHash() const
 {
 	return (this->m_parameterHash);
 }

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_nfiq2algorithm_impl.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_nfiq2algorithm_impl.cpp
@@ -29,7 +29,6 @@ set_fpu(unsigned int mode)
 }
 #endif
 
-using namespace std;
 using namespace cv;
 
 #ifdef EMBED_RANDOMFOREST_PARAMETERS

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiqexception.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiqexception.cpp
@@ -1,7 +1,5 @@
 #include <nfiq2_nfiqexception.hpp>
 
-using namespace NFIQ;
-
 /**
  * Predefined error messages for the corresponding error codes
  */
@@ -67,7 +65,7 @@ const std::string c_ErrorMessages[] = {
 	/* 55 */ "Invalid Image Size"
 };
 
-NFIQException::NFIQException(uint32_t returnCode)
+NFIQ::NFIQException::NFIQException(uint32_t returnCode)
     : m_ReturnCode(returnCode)
 {
 	m_ErrorMessage = c_ErrorMessages[returnCode];
@@ -76,18 +74,19 @@ NFIQException::NFIQException(uint32_t returnCode)
 	}
 }
 
-NFIQException::NFIQException(uint32_t returnCode, std::string errorMessage)
+NFIQ::NFIQException::NFIQException(
+    uint32_t returnCode, std::string errorMessage)
     : m_ReturnCode(returnCode)
     , m_ErrorMessage(errorMessage)
 {
 }
 
-NFIQException::~NFIQException() noexcept
+NFIQ::NFIQException::~NFIQException() noexcept
 {
 }
 
 const char *
-NFIQException::what() const noexcept
+NFIQ::NFIQException::what() const noexcept
 {
 	return m_ErrorMessage.c_str();
 }

--- a/NFIQ2/NFIQ2Algorithm/src/prediction/RandomForestML.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/prediction/RandomForestML.cpp
@@ -31,7 +31,6 @@
 #include "digestpp.hpp"
 #include <numeric> // std::accumulate
 
-using namespace NFIQ;
 using namespace cv;
 
 std::string


### PR DESCRIPTION
Removes uses of `using namespace std` and `using namespace NFIQ` in all code.

Toward #173.