### PR TITLE
Changing 'NFIQ' namespace to 'NFIQ2'

### DIFF
--- a/NFIQ2/NFIQ2Algorithm/include/features/BaseFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/BaseFeature.h
@@ -7,7 +7,7 @@
 #include <string>
 #include <vector>
 
-namespace NFIQ { namespace QualityFeatures {
+namespace NFIQ2 { namespace QualityFeatures {
 
 class BaseFeature {
     public:
@@ -19,21 +19,21 @@ class BaseFeature {
 	virtual std::string getModuleName() const = 0;
 
 	/** @return computed quality feature speed */
-	virtual NFIQ::QualityFeatureSpeed getSpeed() const;
+	virtual NFIQ2::QualityFeatureSpeed getSpeed() const;
 
 	/** @return computed quality features */
-	virtual std::vector<NFIQ::QualityFeatureResult> getFeatures() const;
+	virtual std::vector<NFIQ2::QualityFeatureResult> getFeatures() const;
 
     protected:
-	void setSpeed(const NFIQ::QualityFeatureSpeed &featureSpeed);
+	void setSpeed(const NFIQ2::QualityFeatureSpeed &featureSpeed);
 
 	void setFeatures(
-	    const std::vector<NFIQ::QualityFeatureResult> &featureResult);
+	    const std::vector<NFIQ2::QualityFeatureResult> &featureResult);
 
     private:
-	NFIQ::QualityFeatureSpeed speed {};
+	NFIQ2::QualityFeatureSpeed speed {};
 
-	std::vector<NFIQ::QualityFeatureResult> features {};
+	std::vector<NFIQ2::QualityFeatureResult> features {};
 };
 
 }}

--- a/NFIQ2/NFIQ2Algorithm/include/features/FDAFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/FDAFeature.h
@@ -13,14 +13,14 @@
 * @brief NFIQ2 Frequency Domain Analysis Quality Feature
 ******************************************************************************/
 
-namespace NFIQ { namespace QualityFeatures {
+namespace NFIQ2 { namespace QualityFeatures {
 
 static double FDAHISTLIMITS[9] = { 0.268, 0.304, 0.33, 0.355, 0.38, 0.407, 0.44,
 	0.50, 1 };
 
 class FDAFeature : public BaseFeature {
     public:
-	FDAFeature(const NFIQ::FingerprintImageData &fingerprintImage);
+	FDAFeature(const NFIQ2::FingerprintImageData &fingerprintImage);
 	virtual ~FDAFeature();
 
 	std::string getModuleName() const override;
@@ -30,8 +30,8 @@ class FDAFeature : public BaseFeature {
 	static const std::string moduleName;
 
     private:
-	std::vector<NFIQ::QualityFeatureResult> computeFeatureData(
-	    const NFIQ::FingerprintImageData &fingerprintImage);
+	std::vector<NFIQ2::QualityFeatureResult> computeFeatureData(
+	    const NFIQ2::FingerprintImageData &fingerprintImage);
 
 	const int blocksize { 32 };
 	const double threshold { .1 };

--- a/NFIQ2/NFIQ2Algorithm/include/features/FJFXMinutiaeQualityFeatures.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/FJFXMinutiaeQualityFeatures.h
@@ -13,7 +13,7 @@
 #include <string>
 #include <vector>
 
-namespace NFIQ { namespace QualityFeatures {
+namespace NFIQ2 { namespace QualityFeatures {
 
 /* Ideal Standard Deviation of pixel values in a neighborhood. */
 #define IDEALSTDEV 64
@@ -29,7 +29,7 @@ class FJFXMinutiaeQualityFeature : public BaseFeature {
 	};
 
 	FJFXMinutiaeQualityFeature(
-	    const NFIQ::FingerprintImageData &fingerprintImage,
+	    const NFIQ2::FingerprintImageData &fingerprintImage,
 	    const std::vector<FingerJetFXFeature::Minutia> &minutiaData,
 	    const bool templateCouldBeExtracted);
 
@@ -41,7 +41,7 @@ class FJFXMinutiaeQualityFeature : public BaseFeature {
 	static const std::string speedFeatureIDGroup;
 	static const std::string moduleName;
 
-	/** @throw NFIQ::NFIQException
+	/** @throw NFIQ2::NFIQException
 	 * Template could not be extracted.
 	 */
 	std::vector<FingerJetFXFeature::Minutia> getMinutiaData() const;
@@ -49,19 +49,19 @@ class FJFXMinutiaeQualityFeature : public BaseFeature {
 	bool getTemplateStatus() const;
 
     private:
-	std::vector<NFIQ::QualityFeatureResult> computeFeatureData(
-	    const NFIQ::FingerprintImageData &fingerprintImage);
+	std::vector<NFIQ2::QualityFeatureResult> computeFeatureData(
+	    const NFIQ2::FingerprintImageData &fingerprintImage);
 
 	std::vector<FingerJetFXFeature::Minutia> minutiaData_ {};
 	bool templateCouldBeExtracted_ { false };
 	std::vector<MinutiaData> computeMuMinQuality(
-	    int bs, const NFIQ::FingerprintImageData &fingerprintImage);
+	    int bs, const NFIQ2::FingerprintImageData &fingerprintImage);
 
 	std::vector<MinutiaData> computeOCLMinQuality(
-	    int bs, const NFIQ::FingerprintImageData &fingerprintImage);
+	    int bs, const NFIQ2::FingerprintImageData &fingerprintImage);
 
 	double computeMMBBasedOnCOM(int bs,
-	    const NFIQ::FingerprintImageData &fingerprintImage,
+	    const NFIQ2::FingerprintImageData &fingerprintImage,
 	    unsigned int regionSize);
 };
 

--- a/NFIQ2/NFIQ2Algorithm/include/features/FeatureFunctions.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/FeatureFunctions.h
@@ -4,7 +4,7 @@
 #include <nfiq2_interfacedefinitions.hpp>
 #include <opencv2/core.hpp>
 
-namespace NFIQ {
+namespace NFIQ2 {
 
 namespace QualityFeatures {
 
@@ -46,10 +46,10 @@ void computeNumericalGradients(
     const cv::Mat &mat, cv::Mat &grad_x, cv::Mat &grad_y);
 
 void addSamplingFeatures(
-    std::vector<NFIQ::QualityFeatureResult> &featureDataList,
+    std::vector<NFIQ2::QualityFeatureResult> &featureDataList,
     std::string featurePrefix, std::vector<double> &dataVector);
 void addHistogramFeatures(
-    std::vector<NFIQ::QualityFeatureResult> &featureDataList,
+    std::vector<NFIQ2::QualityFeatureResult> &featureDataList,
     std::string featurePrefix, std::vector<double> &binBoundaries,
     std::vector<double> &dataVector, int binCount);
 void addSamplingFeatureNames(

--- a/NFIQ2/NFIQ2Algorithm/include/features/FingerJetFXFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/FingerJetFXFeature.h
@@ -10,7 +10,7 @@
 #include <string>
 #include <vector>
 
-namespace NFIQ { namespace QualityFeatures {
+namespace NFIQ2 { namespace QualityFeatures {
 
 class FingerJetFXFeature : public BaseFeature {
     public:
@@ -99,7 +99,7 @@ class FingerJetFXFeature : public BaseFeature {
 					     ///< the defined circle
 	};
 
-	FingerJetFXFeature(const NFIQ::FingerprintImageData &fingerprintImage);
+	FingerJetFXFeature(const NFIQ2::FingerprintImageData &fingerprintImage);
 	virtual ~FingerJetFXFeature();
 
 	std::string getModuleName() const override;
@@ -113,7 +113,7 @@ class FingerJetFXFeature : public BaseFeature {
 
 	static std::string parseFRFXLLError(const FRFXLL_RESULT fxRes);
 
-	/** @throw NFIQ::NFIQException
+	/** @throw NFIQ2::NFIQException
 	 * Template could not be extracted.
 	 */
 	std::vector<FingerJetFXFeature::Minutia> getMinutiaData() const;
@@ -121,8 +121,8 @@ class FingerJetFXFeature : public BaseFeature {
 	bool getTemplateStatus() const;
 
     private:
-	std::vector<NFIQ::QualityFeatureResult> computeFeatureData(
-	    const NFIQ::FingerprintImageData &fingerprintImage);
+	std::vector<NFIQ2::QualityFeatureResult> computeFeatureData(
+	    const NFIQ2::FingerprintImageData &fingerprintImage);
 
 	FRFXLL_RESULT
 	createContext(FRFXLL_HANDLE_PT phContext);
@@ -131,7 +131,7 @@ class FingerJetFXFeature : public BaseFeature {
 	bool templateCouldBeExtracted_ { false };
 
 	FJFXROIResults computeROI(int bs,
-	    const NFIQ::FingerprintImageData &fingerprintImage,
+	    const NFIQ2::FingerprintImageData &fingerprintImage,
 	    std::vector<FingerJetFXFeature::Object> vecRectDimensions);
 };
 }}

--- a/NFIQ2/NFIQ2Algorithm/include/features/ImgProcROIFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/ImgProcROIFeature.h
@@ -9,7 +9,7 @@
 #include <string>
 #include <vector>
 
-namespace NFIQ { namespace QualityFeatures {
+namespace NFIQ2 { namespace QualityFeatures {
 
 class ImgProcROIFeature : public BaseFeature {
     public:
@@ -35,7 +35,7 @@ class ImgProcROIFeature : public BaseFeature {
 		double stdDevOfROIPixels {};
 	};
 
-	ImgProcROIFeature(const NFIQ::FingerprintImageData &fingerprintImage);
+	ImgProcROIFeature(const NFIQ2::FingerprintImageData &fingerprintImage);
 	virtual ~ImgProcROIFeature();
 
 	std::string getModuleName() const override;
@@ -46,14 +46,14 @@ class ImgProcROIFeature : public BaseFeature {
 
 	static ImgProcROIResults computeROI(cv::Mat &img, unsigned int bs);
 
-	/** @throw NFIQ::NFIQException
+	/** @throw NFIQ2::NFIQException
 	 * Img Proc Results could not be computed.
 	 */
 	ImgProcROIResults getImgProcResults();
 
     private:
-	std::vector<NFIQ::QualityFeatureResult> computeFeatureData(
-	    const NFIQ::FingerprintImageData &fingerprintImage);
+	std::vector<NFIQ2::QualityFeatureResult> computeFeatureData(
+	    const NFIQ2::FingerprintImageData &fingerprintImage);
 
 	ImgProcROIResults imgProcResults_ {};
 	bool imgProcComputed_ { false };

--- a/NFIQ2/NFIQ2Algorithm/include/features/LCSFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/LCSFeature.h
@@ -8,14 +8,14 @@
 #include <string>
 #include <vector>
 
-namespace NFIQ { namespace QualityFeatures {
+namespace NFIQ2 { namespace QualityFeatures {
 
 static double LCSHISTLIMITS[9] = { 0, 0.70, 0.74, 0.77, 0.79, 0.81, 0.83, 0.85,
 	0.87 };
 
 class LCSFeature : public BaseFeature {
     public:
-	LCSFeature(const NFIQ::FingerprintImageData &fingerprintImage);
+	LCSFeature(const NFIQ2::FingerprintImageData &fingerprintImage);
 	virtual ~LCSFeature();
 
 	std::string getModuleName() const override;
@@ -25,8 +25,8 @@ class LCSFeature : public BaseFeature {
 	static const std::string moduleName;
 
     private:
-	std::vector<NFIQ::QualityFeatureResult> computeFeatureData(
-	    const NFIQ::FingerprintImageData &fingerprintImage);
+	std::vector<NFIQ2::QualityFeatureResult> computeFeatureData(
+	    const NFIQ2::FingerprintImageData &fingerprintImage);
 
 	const int blocksize { 32 };
 	const double threshold { .1 };

--- a/NFIQ2/NFIQ2Algorithm/include/features/MuFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/MuFeature.h
@@ -8,16 +8,16 @@
 #include <string>
 #include <vector>
 
-namespace NFIQ { namespace QualityFeatures {
+namespace NFIQ2 { namespace QualityFeatures {
 
 class MuFeature : public BaseFeature {
     public:
-	MuFeature(const NFIQ::FingerprintImageData &fingerprintImage);
+	MuFeature(const NFIQ2::FingerprintImageData &fingerprintImage);
 	virtual ~MuFeature();
 
 	std::string getModuleName() const override;
 
-	/** @throw NFIQ::NFIQException
+	/** @throw NFIQ2::NFIQException
 	 * Sigma has not yet been calculated.
 	 */
 	double getSigma() const;
@@ -27,8 +27,8 @@ class MuFeature : public BaseFeature {
 	static const std::string moduleName;
 
     private:
-	std::vector<NFIQ::QualityFeatureResult> computeFeatureData(
-	    const NFIQ::FingerprintImageData &fingerprintImage);
+	std::vector<NFIQ2::QualityFeatureResult> computeFeatureData(
+	    const NFIQ2::FingerprintImageData &fingerprintImage);
 
 	bool sigmaComputed { false };
 	double sigma {};

--- a/NFIQ2/NFIQ2Algorithm/include/features/OCLHistogramFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/OCLHistogramFeature.h
@@ -11,14 +11,15 @@
 #include <string>
 #include <vector>
 
-namespace NFIQ { namespace QualityFeatures {
+namespace NFIQ2 { namespace QualityFeatures {
 
 static double OCLPHISTLIMITS[9] = { 0.337, 0.479, 0.579, 0.655, 0.716, 0.766,
 	0.81, 0.852, 0.898 };
 
 class OCLHistogramFeature : public BaseFeature {
     public:
-	OCLHistogramFeature(const NFIQ::FingerprintImageData &fingerprintImage);
+	OCLHistogramFeature(
+	    const NFIQ2::FingerprintImageData &fingerprintImage);
 	virtual ~OCLHistogramFeature();
 
 	std::string getModuleName() const override;
@@ -31,8 +32,8 @@ class OCLHistogramFeature : public BaseFeature {
 	static bool getOCLValueOfBlock(const cv::Mat &block, double &ocl);
 
     private:
-	std::vector<NFIQ::QualityFeatureResult> computeFeatureData(
-	    const NFIQ::FingerprintImageData &fingerprintImage);
+	std::vector<NFIQ2::QualityFeatureResult> computeFeatureData(
+	    const NFIQ2::FingerprintImageData &fingerprintImage);
 };
 
 }}

--- a/NFIQ2/NFIQ2Algorithm/include/features/OFFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/OFFeature.h
@@ -14,14 +14,14 @@
 * @brief NFIQ2 Orientation Flow Quality Feature
 ******************************************************************************/
 
-namespace NFIQ { namespace QualityFeatures {
+namespace NFIQ2 { namespace QualityFeatures {
 
 static double OFHISTLIMITS[9] = { 1.715e-2, 3.5e-2, 5.57e-2, 8.1e-2, 1.15e-1,
 	1.718e-1, 2.569e-1, 4.758e-1, 7.48e-1 };
 
 class OFFeature : public BaseFeature {
     public:
-	OFFeature(const NFIQ::FingerprintImageData &fingerprintImage);
+	OFFeature(const NFIQ2::FingerprintImageData &fingerprintImage);
 	virtual ~OFFeature();
 
 	std::string getModuleName() const override;
@@ -31,8 +31,8 @@ class OFFeature : public BaseFeature {
 	static const std::string moduleName;
 
     private:
-	std::vector<NFIQ::QualityFeatureResult> computeFeatureData(
-	    const NFIQ::FingerprintImageData &fingerprintImage);
+	std::vector<NFIQ2::QualityFeatureResult> computeFeatureData(
+	    const NFIQ2::FingerprintImageData &fingerprintImage);
 
 	/** Processing is done in subblocks of this size. */
 	const int blocksize { 16 };

--- a/NFIQ2/NFIQ2Algorithm/include/features/QualityMapFeatures.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/QualityMapFeatures.h
@@ -11,7 +11,7 @@
 #include <string>
 #include <vector>
 
-namespace NFIQ { namespace QualityFeatures {
+namespace NFIQ2 { namespace QualityFeatures {
 
 #define LOW_FLOW_MAP_NO_DIRECTION 0
 #define LOW_FLOW_MAP_LOW_FLOW 127
@@ -19,7 +19,7 @@ namespace NFIQ { namespace QualityFeatures {
 
 class QualityMapFeatures : public BaseFeature {
     public:
-	QualityMapFeatures(const NFIQ::FingerprintImageData &fingerprintImage,
+	QualityMapFeatures(const NFIQ2::FingerprintImageData &fingerprintImage,
 	    const ImgProcROIFeature::ImgProcROIResults &imgProcResults);
 	virtual ~QualityMapFeatures();
 
@@ -54,8 +54,8 @@ class QualityMapFeatures : public BaseFeature {
 	    const cv::Mat &mat, cv::Mat &grad_x, cv::Mat &grad_y);
 
     private:
-	std::vector<NFIQ::QualityFeatureResult> computeFeatureData(
-	    const NFIQ::FingerprintImageData &fingerprintImage);
+	std::vector<NFIQ2::QualityFeatureResult> computeFeatureData(
+	    const NFIQ2::FingerprintImageData &fingerprintImage);
 
 	ImgProcROIFeature::ImgProcROIResults imgProcResults_ {};
 };

--- a/NFIQ2/NFIQ2Algorithm/include/features/RVUPHistogramFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/RVUPHistogramFeature.h
@@ -8,14 +8,14 @@
 #include <string>
 #include <vector>
 
-namespace NFIQ { namespace QualityFeatures {
+namespace NFIQ2 { namespace QualityFeatures {
 
 static double RVUPHISTLIMITS[9] = { 0.5, 0.667, 0.8, 1, 1.25, 1.5, 2, 24, 30 };
 
 class RVUPHistogramFeature : public BaseFeature {
     public:
 	RVUPHistogramFeature(
-	    const NFIQ::FingerprintImageData &fingerprintImage);
+	    const NFIQ2::FingerprintImageData &fingerprintImage);
 	virtual ~RVUPHistogramFeature();
 
 	std::string getModuleName() const override;
@@ -25,8 +25,8 @@ class RVUPHistogramFeature : public BaseFeature {
 	static const std::string moduleName;
 
     private:
-	std::vector<NFIQ::QualityFeatureResult> computeFeatureData(
-	    const NFIQ::FingerprintImageData &fingerprintImage);
+	std::vector<NFIQ2::QualityFeatureResult> computeFeatureData(
+	    const NFIQ2::FingerprintImageData &fingerprintImage);
 
 	const int blocksize { 32 };
 	const double threshold { .1 };

--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2_data.hpp
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2_data.hpp
@@ -7,7 +7,7 @@
 #include <string>
 #include <vector>
 
-namespace NFIQ {
+namespace NFIQ2 {
 /**
 ******************************************************************************
 * @class Data

--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2_fingerprintimagedata.hpp
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2_fingerprintimagedata.hpp
@@ -5,7 +5,7 @@
 
 #define MU_THRESHOLD 250
 
-namespace NFIQ {
+namespace NFIQ2 {
 
 /**
  * This type represents the resolution of an image (in dpi)
@@ -76,7 +76,7 @@ class FingerprintImageData : public Data {
 	 * @return The cropped/segmented fingerprint image in raw format.
 	 * @throws NFIQException
 	 */
-	NFIQ::FingerprintImageData removeWhiteFrameAroundFingerprint() const;
+	NFIQ2::FingerprintImageData removeWhiteFrameAroundFingerprint() const;
 };
 } // namespace NFIQ
 

--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2_interfacedefinitions.hpp
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2_interfacedefinitions.hpp
@@ -6,7 +6,7 @@
 #include <string>
 #include <vector>
 
-namespace NFIQ {
+namespace NFIQ2 {
 namespace ActionableQualityFeedbackIdentifier {
 
 static const std::string EmptyImageOrContrastTooLow {
@@ -59,14 +59,14 @@ typedef struct image_id_t {
  */
 typedef struct feature_data_t {
 	std::string featureID; ///< The unique ID of the feature data
-	NFIQ::QualityFeatureDataType
-	    featureDataType;	      ///< The type of feature data
-	double featureDataDouble;     ///< The feature value in floating point
-				      ///< format (if type is
-				      ///< e_QualityFeatureDataTypeDouble)
-	NFIQ::Data featureDataBinary; ///< The feature value in binary data
-				      ///< format (if type is
-				      ///< e_QualityFeatureDataTypeBinary)
+	NFIQ2::QualityFeatureDataType
+	    featureDataType;	       ///< The type of feature data
+	double featureDataDouble;      ///< The feature value in floating point
+				       ///< format (if type is
+				       ///< e_QualityFeatureDataTypeDouble)
+	NFIQ2::Data featureDataBinary; ///< The feature value in binary data
+				       ///< format (if type is
+				       ///< e_QualityFeatureDataTypeBinary)
 } QualityFeatureData;
 
 /**
@@ -94,7 +94,7 @@ typedef struct database_information_t {
  * This type represents the result of a quality feature extraction
  */
 typedef struct quality_feature_result_t {
-	NFIQ::QualityFeatureData featureData; ///< The quality feature data
+	NFIQ2::QualityFeatureData featureData; ///< The quality feature data
 	uint32_t returnCode; ///< The return code of the quality feature
 			     ///< extraction operation
 } QualityFeatureResult;
@@ -103,9 +103,10 @@ typedef struct quality_feature_result_t {
  * This type represents the result of a comparison scores computation
  */
 typedef struct comparison_result_t {
-	NFIQ::ImageID referenceImageID; ///< The image ID of the reference image
-	NFIQ::ImageID probeImageID;	///< The image ID of the probe image
-	double comparisonScore;		///< The comparison score
+	NFIQ2::ImageID
+	    referenceImageID;	     ///< The image ID of the reference image
+	NFIQ2::ImageID probeImageID; ///< The image ID of the probe image
+	double comparisonScore;	     ///< The comparison score
 	uint32_t returnCode; ///< The return code of the comparison operation
 } ComparisonResult;
 
@@ -125,8 +126,8 @@ typedef struct utility_result_t {
 typedef struct utility_sample_t {
 	std::string databaseID; ///< The database ID where the fingerprint
 				///< image is stored
-	NFIQ::ImageID fingerprintImageID; ///< The ID of the fingerprint image
-	NFIQ::UtilityResult
+	NFIQ2::ImageID fingerprintImageID; ///< The ID of the fingerprint image
+	NFIQ2::UtilityResult
 	    utilityResult; ///< The result of the utility
 			   ///< computation (value + return code)
 } UtilitySample;
@@ -138,7 +139,7 @@ typedef struct utility_sample_t {
 typedef struct utility_provider_content_t {
 	std::string providerID; ///< The provider ID for which the utility was
 				///< computed
-	std::vector<NFIQ::UtilitySample>
+	std::vector<NFIQ2::UtilitySample>
 	    utilitySamples; ///< A list of utility values and its
 			    ///< information (imageID, return code)
 } UtilityProviderContent;
@@ -150,7 +151,7 @@ typedef struct utility_content_t {
 	std::string databaseID;		      ///< The ID of the database
 	std::string utilityID;		      ///< The utility ID
 	std::vector<std::string> providerIDs; ///< A list of provider IDs
-	std::vector<NFIQ::UtilitySample>
+	std::vector<NFIQ2::UtilitySample>
 	    samples; ///< Results of the utility computation for images of
 		     ///< the database
 } UtilityContent;
@@ -159,8 +160,8 @@ typedef struct utility_content_t {
  * This type represents the content of a quality feature exchange file
  */
 typedef struct quality_feature_sample_t {
-	NFIQ::ImageID fingerprintImageID; ///< The ID of the fingerprint image
-	NFIQ::QualityFeatureResult
+	NFIQ2::ImageID fingerprintImageID; ///< The ID of the fingerprint image
+	NFIQ2::QualityFeatureResult
 	    featureResult; ///< The result of the quality
 			   ///< feature computation (value
 			   ///< + return code)
@@ -172,7 +173,7 @@ typedef struct quality_feature_sample_t {
 typedef struct quality_feature_content_t {
 	std::string databaseID; ///< The ID of the database
 	std::string featureID;	///< The feature ID
-	std::vector<NFIQ::QualityFeatureSample>
+	std::vector<NFIQ2::QualityFeatureSample>
 	    samples; ///< Results of the quality feature computation for
 		     ///< images of the database
 } QualityFeatureContent;
@@ -182,14 +183,14 @@ typedef struct quality_feature_content_t {
  * computation
  */
 typedef struct comparison_probe_result_t {
-	NFIQ::ImageID probeImageID; ///< The ID of the probe/verification
-				    ///< fingerprint image
+	NFIQ2::ImageID probeImageID; ///< The ID of the probe/verification
+				     ///< fingerprint image
 	std::string
 	    comparisonType; ///< The comparison type: "g" ... Genuine
 			    ///< comparison, "i" ... Impostor comparison,
 			    ///< "x"
 			    ///< ... Cross-comparison between same person
-	NFIQ::ComparisonResult
+	NFIQ2::ComparisonResult
 	    comparisonResult; ///< Achieved score and return code between
 			      ///< probe and reference image
 } ComparisonProbeResult;
@@ -198,9 +199,9 @@ typedef struct comparison_probe_result_t {
  * This type represents the structure of a comparison scores sample
  */
 typedef struct comparison_scores_sample_t {
-	NFIQ::ImageID referenceImageID; ///< The ID of the reference/enrolment
-					///< fingerprint image
-	std::vector<NFIQ::ComparisonProbeResult>
+	NFIQ2::ImageID referenceImageID; ///< The ID of the reference/enrolment
+					 ///< fingerprint image
+	std::vector<NFIQ2::ComparisonProbeResult>
 	    probes; ///< A list of probe images + results for which
 		    ///< comparisons where conducted
 } ComparisonScoresSample;
@@ -212,7 +213,7 @@ typedef struct comparison_scores_content_t {
 	std::string databaseID; ///< The ID of the database
 	std::string providerID; ///< The ID of the provider used for comparison
 				///< scores computation
-	std::vector<NFIQ::ComparisonScoresSample>
+	std::vector<NFIQ2::ComparisonScoresSample>
 	    references; ///< Results of the comparison scores computation
 			///< for this reference fingerprint image
 } ComparisonScoresContent;
@@ -221,7 +222,7 @@ typedef struct comparison_scores_content_t {
  * This type represents the structure of a sample needed for training
  */
 typedef struct training_sample_t {
-	std::vector<NFIQ::QualityFeatureData>
+	std::vector<NFIQ2::QualityFeatureData>
 	    featureDataVector; ///< The quality feature data vector used
 			       ///< for training
 	double utilityValue;   ///< The assigned utility value
@@ -232,9 +233,9 @@ typedef struct training_sample_t {
  * This type represents the result of a Machine Learning evaluation run
  */
 typedef struct evaluation_result_t {
-	std::string databaseID;		  ///< The ID of the database
-	NFIQ::ImageID fingerprintImageID; ///< The ID of the fingerprint image
-	double utilityValue;		  ///< The utility value
+	std::string databaseID;		   ///< The ID of the database
+	NFIQ2::ImageID fingerprintImageID; ///< The ID of the fingerprint image
+	double utilityValue;		   ///< The utility value
 	double qualityScore; ///< The quality score for the fingerprint image
 	double
 	    deviation; ///< The deviation of the quality score and utility value
@@ -244,8 +245,8 @@ typedef struct evaluation_result_t {
  * This type represents the weight assigned to a fingerprint image ID
  */
 typedef struct weight_image_id_t {
-	NFIQ::ImageID fingerprintImageID; ///< The ID of the fingerprint image
-	double weight;			  ///< The set (pattern) weight [0..1].
+	NFIQ2::ImageID fingerprintImageID; ///< The ID of the fingerprint image
+	double weight;			   ///< The set (pattern) weight [0..1].
 } WeightImageID;
 
 /**
@@ -254,7 +255,7 @@ typedef struct weight_image_id_t {
  */
 typedef struct training_id_t {
 	std::string databaseID; ///< The ID of the database
-	std::vector<NFIQ::WeightImageID>
+	std::vector<NFIQ2::WeightImageID>
 	    imageIDs; ///< A list of image IDs + their weights
 } TrainingID;
 
@@ -262,7 +263,7 @@ typedef struct training_id_t {
  * This type represents the image ID and an assigned database ID
  */
 typedef struct database_image_id {
-	NFIQ::ImageID fingerprintImageID; ///< The ID of the fingerprint image
+	NFIQ2::ImageID fingerprintImageID; ///< The ID of the fingerprint image
 	std::string
 	    databaseID; ///< The ID of the database where image is stored
 } DatabaseImageID;
@@ -274,7 +275,7 @@ typedef struct database_image_id {
 typedef struct evaluation_id {
 	std::string
 	    databaseID; ///< The ID of the database where image is stored
-	std::vector<NFIQ::ImageID> imageIDs; ///< A list of image IDs
+	std::vector<NFIQ2::ImageID> imageIDs; ///< A list of image IDs
 } EvaluationID;
 } // namespace NFIQ
 

--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2_modelinfo.hpp
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2_modelinfo.hpp
@@ -3,7 +3,7 @@
 
 #include <string>
 
-namespace NFIQ {
+namespace NFIQ2 {
 /** Model Class containing Model Information */
 class ModelInfo {
     public:

--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2_nfiq2algorithm.hpp
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2_nfiq2algorithm.hpp
@@ -11,7 +11,7 @@
 #include <string>
 #include <unordered_map>
 
-namespace NFIQ {
+namespace NFIQ2 {
 /** Wrapper to return quality scores for a fingerprint image */
 class NFIQ2Algorithm {
     public:
@@ -20,7 +20,7 @@ class NFIQ2Algorithm {
 #endif
 	NFIQ2Algorithm(
 	    const std::string &fileName, const std::string &fileHash);
-	NFIQ2Algorithm(const NFIQ::ModelInfo &modelInfoObj);
+	NFIQ2Algorithm(const NFIQ2::ModelInfo &modelInfoObj);
 	~NFIQ2Algorithm();
 
 	/**
@@ -31,7 +31,7 @@ class NFIQ2Algorithm {
 	 * @return achieved quality score
 	 */
 	unsigned int computeQualityScore(
-	    const NFIQ::FingerprintImageData &rawImage) const;
+	    const NFIQ2::FingerprintImageData &rawImage) const;
 
 	/**
 	 * @fn computeQualityScore
@@ -42,7 +42,7 @@ class NFIQ2Algorithm {
 	 * @return achieved quality score
 	 */
 	unsigned int computeQualityScore(const std::vector<
-	    std::shared_ptr<NFIQ::QualityFeatures::BaseFeature>> &features)
+	    std::shared_ptr<NFIQ2::QualityFeatures::BaseFeature>> &features)
 	    const;
 
 	/**
@@ -53,7 +53,7 @@ class NFIQ2Algorithm {
 	 * @return achieved quality score
 	 */
 	unsigned int computeQualityScore(
-	    const std::unordered_map<std::string, NFIQ::QualityFeatureData>
+	    const std::unordered_map<std::string, NFIQ2::QualityFeatureData>
 		&features) const;
 
 	/**

--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2_nfiqexception.hpp
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2_nfiqexception.hpp
@@ -4,7 +4,7 @@
 #include <exception>
 #include <string>
 
-namespace NFIQ {
+namespace NFIQ2 {
 /**
  * This type represents error codes defined within this framework.
  */

--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2_qualityfeatures.hpp
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2_qualityfeatures.hpp
@@ -9,7 +9,7 @@
 #include <string>
 #include <unordered_map>
 
-namespace NFIQ { namespace QualityFeatures {
+namespace NFIQ2 { namespace QualityFeatures {
 /**
  * @brief
  * Obtain all actionable quality feedback identifiers.
@@ -48,8 +48,8 @@ std::vector<std::string> getAllSpeedFeatureGroups();
  * @return
  * A vector if BaseFeature modules containing computed feature data
  */
-std::vector<std::shared_ptr<NFIQ::QualityFeatures::BaseFeature>>
-computeQualityFeatures(const NFIQ::FingerprintImageData &rawImage);
+std::vector<std::shared_ptr<NFIQ2::QualityFeatures::BaseFeature>>
+computeQualityFeatures(const NFIQ2::FingerprintImageData &rawImage);
 
 /**
  * @brief
@@ -61,9 +61,9 @@ computeQualityFeatures(const NFIQ::FingerprintImageData &rawImage);
  * @return
  * A map of string, actionable quality feedback pairs
  */
-std::unordered_map<std::string, NFIQ::ActionableQualityFeedback>
+std::unordered_map<std::string, NFIQ2::ActionableQualityFeedback>
 getActionableQualityFeedback(
-    const std::vector<std::shared_ptr<NFIQ::QualityFeatures::BaseFeature>>
+    const std::vector<std::shared_ptr<NFIQ2::QualityFeatures::BaseFeature>>
 	&features);
 
 /**
@@ -76,8 +76,8 @@ getActionableQualityFeedback(
  * @return
  * A map of string, actionable quality feedback pairs
  */
-std::unordered_map<std::string, NFIQ::ActionableQualityFeedback>
-getActionableQualityFeedback(const NFIQ::FingerprintImageData &rawImage);
+std::unordered_map<std::string, NFIQ2::ActionableQualityFeedback>
+getActionableQualityFeedback(const NFIQ2::FingerprintImageData &rawImage);
 
 /**
  * @brief
@@ -89,8 +89,9 @@ getActionableQualityFeedback(const NFIQ::FingerprintImageData &rawImage);
  * @return
  * A map of string, quality feature data pairs
  */
-std::unordered_map<std::string, NFIQ::QualityFeatureData> getQualityFeatureData(
-    const std::vector<std::shared_ptr<NFIQ::QualityFeatures::BaseFeature>>
+std::unordered_map<std::string, NFIQ2::QualityFeatureData>
+getQualityFeatureData(
+    const std::vector<std::shared_ptr<NFIQ2::QualityFeatures::BaseFeature>>
 	&features);
 
 /**
@@ -103,8 +104,8 @@ std::unordered_map<std::string, NFIQ::QualityFeatureData> getQualityFeatureData(
  * @return
  * A map of string, quality feature data pairs
  */
-std::unordered_map<std::string, NFIQ::QualityFeatureData> getQualityFeatureData(
-    const NFIQ::FingerprintImageData &rawImage);
+std::unordered_map<std::string, NFIQ2::QualityFeatureData>
+getQualityFeatureData(const NFIQ2::FingerprintImageData &rawImage);
 
 /**
  * @brief
@@ -116,9 +117,9 @@ std::unordered_map<std::string, NFIQ::QualityFeatureData> getQualityFeatureData(
  * @return
  * A map of string, quality feature speed pairs
  */
-std::unordered_map<std::string, NFIQ::QualityFeatureSpeed>
+std::unordered_map<std::string, NFIQ2::QualityFeatureSpeed>
 getQualityFeatureSpeeds(
-    const std::vector<std::shared_ptr<NFIQ::QualityFeatures::BaseFeature>>
+    const std::vector<std::shared_ptr<NFIQ2::QualityFeatures::BaseFeature>>
 	&features);
 
 }}

--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2_results.hpp
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2_results.hpp
@@ -7,41 +7,41 @@
 #include <string>
 #include <vector>
 
-namespace NFIQ {
+namespace NFIQ2 {
 
 class NFIQ2Results {
     public:
 	NFIQ2Results();
-	NFIQ2Results(const std::vector<NFIQ::ActionableQualityFeedback>
+	NFIQ2Results(const std::vector<NFIQ2::ActionableQualityFeedback>
 			 &actionableQuality,
-	    const std::vector<NFIQ::QualityFeatureData> &qualityFeatureData,
-	    const std::vector<NFIQ::QualityFeatureSpeed> &qualityFeatureSpeed,
+	    const std::vector<NFIQ2::QualityFeatureData> &qualityFeatureData,
+	    const std::vector<NFIQ2::QualityFeatureSpeed> &qualityFeatureSpeed,
 	    const unsigned int qualityScore);
 	~NFIQ2Results();
 
 	static unsigned int checkScore(const unsigned int qualityScore);
 
 	void setActionableQualityFeedback(
-	    const std::vector<NFIQ::ActionableQualityFeedback>
+	    const std::vector<NFIQ2::ActionableQualityFeedback>
 		&actionableQuality);
 	void setQualityFeatures(
-	    const std::vector<NFIQ::QualityFeatureData> &qualityFeatureData);
+	    const std::vector<NFIQ2::QualityFeatureData> &qualityFeatureData);
 	void setQualityFeatureSpeed(
-	    const std::vector<NFIQ::QualityFeatureSpeed> &qualityFeatureSpeed);
+	    const std::vector<NFIQ2::QualityFeatureSpeed> &qualityFeatureSpeed);
 	void setScore(const unsigned int qualityScore);
 
-	std::vector<NFIQ::ActionableQualityFeedback>
+	std::vector<NFIQ2::ActionableQualityFeedback>
 	getActionableQualityFeedback() const;
-	std::vector<NFIQ::QualityFeatureData> getQualityFeatures() const;
-	std::vector<NFIQ::QualityFeatureSpeed> getQualityFeatureSpeed() const;
+	std::vector<NFIQ2::QualityFeatureData> getQualityFeatures() const;
+	std::vector<NFIQ2::QualityFeatureSpeed> getQualityFeatureSpeed() const;
 	unsigned int getScore() const;
 
     private:
 	class Impl;
 	std::shared_ptr<NFIQ2Results::Impl> pimpl;
-	std::vector<NFIQ::ActionableQualityFeedback> actionableQuality_ {};
-	std::vector<NFIQ::QualityFeatureData> qualityFeatureData_ {};
-	std::vector<NFIQ::QualityFeatureSpeed> qualityFeatureSpeed_ {};
+	std::vector<NFIQ2::ActionableQualityFeedback> actionableQuality_ {};
+	std::vector<NFIQ2::QualityFeatureData> qualityFeatureData_ {};
+	std::vector<NFIQ2::QualityFeatureSpeed> qualityFeatureSpeed_ {};
 	unsigned int qualityScore_ {};
 };
 }

--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2_timer.hpp
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2_timer.hpp
@@ -3,7 +3,7 @@
 
 #include <chrono>
 
-namespace NFIQ {
+namespace NFIQ2 {
 /** Used to calculate speed of internal operations. */
 class Timer {
     public:

--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2_version.hpp
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2_version.hpp
@@ -3,7 +3,7 @@
 
 #include <string>
 
-namespace NFIQ { namespace Version {
+namespace NFIQ2 { namespace Version {
 extern const unsigned int Major;
 extern const unsigned int Minor;
 extern const unsigned int Patch;

--- a/NFIQ2/NFIQ2Algorithm/include/prediction/RandomForestML.h
+++ b/NFIQ2/NFIQ2Algorithm/include/prediction/RandomForestML.h
@@ -10,7 +10,7 @@
 
 #undef EMBED_RANDOMFOREST_PARAMETERS
 
-namespace NFIQ { namespace Prediction {
+namespace NFIQ2 { namespace Prediction {
 
 class RandomForestML {
     public:
@@ -27,7 +27,7 @@ class RandomForestML {
 	    const std::string &fileName, const std::string &fileHash);
 
 	void evaluate(
-	    const std::unordered_map<std::string, NFIQ::QualityFeatureData>
+	    const std::unordered_map<std::string, NFIQ2::QualityFeatureData>
 		&features,
 	    const double &utilityValue, double &qualityValue,
 	    double &deviation) const;

--- a/NFIQ2/NFIQ2Algorithm/include/tool/nfiq2_ui_log.h
+++ b/NFIQ2/NFIQ2Algorithm/include/tool/nfiq2_ui_log.h
@@ -72,12 +72,12 @@ class Log {
 	void printScore(const std::string &name, uint8_t fingerCode,
 	    unsigned int score, const std::string &errmsg, const bool quantized,
 	    const bool resampled,
-	    const std::unordered_map<std::string, NFIQ::QualityFeatureData>
+	    const std::unordered_map<std::string, NFIQ2::QualityFeatureData>
 		&features,
-	    const std::unordered_map<std::string, NFIQ::QualityFeatureSpeed>
+	    const std::unordered_map<std::string, NFIQ2::QualityFeatureSpeed>
 		&speed,
 	    const std::unordered_map<std::string,
-		NFIQ::ActionableQualityFeedback> &actionable) const;
+		NFIQ2::ActionableQualityFeedback> &actionable) const;
 
 	/**
 	 *  @brief

--- a/NFIQ2/NFIQ2Algorithm/include/tool/nfiq2_ui_refresh.h
+++ b/NFIQ2/NFIQ2Algorithm/include/tool/nfiq2_ui_refresh.h
@@ -139,7 +139,7 @@ cv::Mat resampleAndLogError(
  */
 void executeSingle(std::shared_ptr<BiometricEvaluation::Image::Image> img,
     const std::string &name, const Flags &flags,
-    const NFIQ::NFIQ2Algorithm &model, std::shared_ptr<NFIQ2UI::Log> logger,
+    const NFIQ2::NFIQ2Algorithm &model, std::shared_ptr<NFIQ2UI::Log> logger,
     const bool singleImage, const bool interactive,
     const uint8_t fingerPosition = 0, const std::string &warning = "NA");
 
@@ -166,7 +166,7 @@ void executeSingle(std::shared_ptr<BiometricEvaluation::Image::Image> img,
  *      Indicates whether yes/no prompts will be active.
  */
 void executeSingle(const NFIQ2UI::ImgCouple &couple, const Flags &flags,
-    const NFIQ::NFIQ2Algorithm &model, std::shared_ptr<NFIQ2UI::Log> logger,
+    const NFIQ2::NFIQ2Algorithm &model, std::shared_ptr<NFIQ2UI::Log> logger,
     const bool singleImage, const bool interactive);
 
 /**
@@ -188,7 +188,7 @@ void executeSingle(const NFIQ2UI::ImgCouple &couple, const Flags &flags,
  *      Prints scores, errors and debug messages to an output stream.
  */
 void parseDirectory(const std::string &dirname, const Flags &flags,
-    const NFIQ::NFIQ2Algorithm &model, std::shared_ptr<NFIQ2UI::Log> logger);
+    const NFIQ2::NFIQ2Algorithm &model, std::shared_ptr<NFIQ2UI::Log> logger);
 
 /**
  *  @brief
@@ -211,7 +211,7 @@ void parseDirectory(const std::string &dirname, const Flags &flags,
  */
 void batchConsume(SafeSplitPathsQueue &splitQueue,
     SafeQueue<std::string> &printQueue, const Flags &flags,
-    const NFIQ::NFIQ2Algorithm &model);
+    const NFIQ2::NFIQ2Algorithm &model);
 
 /**
  *  @brief
@@ -231,7 +231,7 @@ void batchConsume(SafeSplitPathsQueue &splitQueue,
  *      Prints scores, errors and debug messages to an output stream.
  */
 void executeBatch(const std::string &filename, const Flags &flags,
-    const NFIQ::NFIQ2Algorithm &model, std::shared_ptr<NFIQ2UI::Log> logger);
+    const NFIQ2::NFIQ2Algorithm &model, std::shared_ptr<NFIQ2UI::Log> logger);
 
 /**
  *  @brief
@@ -258,7 +258,7 @@ void executeBatch(const std::string &filename, const Flags &flags,
 void recordStoreConsume(const std::string &name,
     NFIQ2UI::SafeSplitPathsQueue &splitQueue,
     SafeQueue<std::string> &printQueue, const Flags &flags,
-    const NFIQ::NFIQ2Algorithm &model);
+    const NFIQ2::NFIQ2Algorithm &model);
 
 /**
  *  @brief
@@ -278,7 +278,7 @@ void recordStoreConsume(const std::string &name,
  *      Prints scores, errors and debug messages to an output stream.
  */
 void executeRecordStore(const std::string &filename, const Flags &flags,
-    const NFIQ::NFIQ2Algorithm &model, std::shared_ptr<NFIQ2UI::Log> logger);
+    const NFIQ2::NFIQ2Algorithm &model, std::shared_ptr<NFIQ2UI::Log> logger);
 
 /**
  *  @brief
@@ -337,8 +337,8 @@ NFIQ2UI::Arguments processArguments(int argc, char **argv);
  *  @param[in] logger
  *      Prints scores, errors and debug messages to an output stream.
  */
-void procSingle(NFIQ2UI::Arguments arguments, const NFIQ::NFIQ2Algorithm &model,
-    std::shared_ptr<NFIQ2UI::Log> logger);
+void procSingle(NFIQ2UI::Arguments arguments,
+    const NFIQ2::NFIQ2Algorithm &model, std::shared_ptr<NFIQ2UI::Log> logger);
 
 /**
  *  @brief
@@ -372,7 +372,7 @@ void printHeader(
  *  @return
  *      Returns a tuple containing the model path and the models hash.
  */
-NFIQ::ModelInfo parseModelInfo(const NFIQ2UI::Arguments &arguments);
+NFIQ2::ModelInfo parseModelInfo(const NFIQ2UI::Arguments &arguments);
 
 } // namespace NFIQ2UI
 

--- a/NFIQ2/NFIQ2Algorithm/src/features/BaseFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/BaseFeature.cpp
@@ -3,32 +3,32 @@
 
 #include <vector>
 
-NFIQ::QualityFeatures::BaseFeature::BaseFeature() = default;
+NFIQ2::QualityFeatures::BaseFeature::BaseFeature() = default;
 
-NFIQ::QualityFeatures::BaseFeature::~BaseFeature() = default;
+NFIQ2::QualityFeatures::BaseFeature::~BaseFeature() = default;
 
-NFIQ::QualityFeatureSpeed
-NFIQ::QualityFeatures::BaseFeature::getSpeed() const
+NFIQ2::QualityFeatureSpeed
+NFIQ2::QualityFeatures::BaseFeature::getSpeed() const
 {
 	return this->speed;
 }
 
-std::vector<NFIQ::QualityFeatureResult>
-NFIQ::QualityFeatures::BaseFeature::getFeatures() const
+std::vector<NFIQ2::QualityFeatureResult>
+NFIQ2::QualityFeatures::BaseFeature::getFeatures() const
 {
 	return this->features;
 }
 
 void
-NFIQ::QualityFeatures::BaseFeature::setSpeed(
-    const NFIQ::QualityFeatureSpeed &featureSpeed)
+NFIQ2::QualityFeatures::BaseFeature::setSpeed(
+    const NFIQ2::QualityFeatureSpeed &featureSpeed)
 {
 	this->speed = featureSpeed;
 }
 
 void
-NFIQ::QualityFeatures::BaseFeature::setFeatures(
-    const std::vector<NFIQ::QualityFeatureResult> &featureResult)
+NFIQ2::QualityFeatures::BaseFeature::setFeatures(
+    const std::vector<NFIQ2::QualityFeatureResult> &featureResult)
 {
 	this->features = featureResult;
 }

--- a/NFIQ2/NFIQ2Algorithm/src/features/FDAFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FDAFeature.cpp
@@ -16,16 +16,16 @@
 double fda(const cv::Mat &block, const double orientation, const int v1sz_x,
     const int v1sz_y, const bool padFlag);
 
-NFIQ::QualityFeatures::FDAFeature::FDAFeature(
-    const NFIQ::FingerprintImageData &fingerprintImage)
+NFIQ2::QualityFeatures::FDAFeature::FDAFeature(
+    const NFIQ2::FingerprintImageData &fingerprintImage)
 {
 	this->setFeatures(computeFeatureData(fingerprintImage));
 }
 
-NFIQ::QualityFeatures::FDAFeature::~FDAFeature() = default;
+NFIQ2::QualityFeatures::FDAFeature::~FDAFeature() = default;
 
 std::vector<std::string>
-NFIQ::QualityFeatures::FDAFeature::getAllFeatureIDs()
+NFIQ2::QualityFeatures::FDAFeature::getAllFeatureIDs()
 {
 	std::vector<std::string> featureIDs;
 	addHistogramFeatureNames(featureIDs, "FDA_Bin10_", 10);
@@ -33,25 +33,28 @@ NFIQ::QualityFeatures::FDAFeature::getAllFeatureIDs()
 	return featureIDs;
 }
 
-const std::string NFIQ::QualityFeatures::FDAFeature::speedFeatureIDGroup =
+const std::string NFIQ2::QualityFeatures::FDAFeature::speedFeatureIDGroup =
     "Frequency domain";
 
-const std::string NFIQ::QualityFeatures::FDAFeature::moduleName { "NFIQ2_FDA" };
+const std::string NFIQ2::QualityFeatures::FDAFeature::moduleName {
+	"NFIQ2_FDA"
+};
 std::string
-NFIQ::QualityFeatures::FDAFeature::getModuleName() const
+NFIQ2::QualityFeatures::FDAFeature::getModuleName() const
 {
 	return moduleName;
 }
 
-std::vector<NFIQ::QualityFeatureResult>
-NFIQ::QualityFeatures::FDAFeature::computeFeatureData(
-    const NFIQ::FingerprintImageData &fingerprintImage)
+std::vector<NFIQ2::QualityFeatureResult>
+NFIQ2::QualityFeatures::FDAFeature::computeFeatureData(
+    const NFIQ2::FingerprintImageData &fingerprintImage)
 {
-	std::vector<NFIQ::QualityFeatureResult> featureDataList;
+	std::vector<NFIQ2::QualityFeatureResult> featureDataList;
 
 	// check if input image has 500 dpi
-	if (fingerprintImage.m_ImageDPI != NFIQ::e_ImageResolution_500dpi) {
-		throw NFIQ::NFIQException(NFIQ::e_Error_FeatureCalculationError,
+	if (fingerprintImage.m_ImageDPI != NFIQ2::e_ImageResolution_500dpi) {
+		throw NFIQ2::NFIQException(
+		    NFIQ2::e_Error_FeatureCalculationError,
 		    "Only 500 dpi fingerprint images are supported!");
 	}
 
@@ -64,7 +67,7 @@ NFIQ::QualityFeatures::FDAFeature::computeFeatureData(
 	// compute Fda (taken from Rvu)
 	// ----------------------------
 
-	NFIQ::Timer timer;
+	NFIQ2::Timer timer;
 	double time = 0.0;
 	try {
 		timer.start();
@@ -169,7 +172,7 @@ NFIQ::QualityFeatures::FDAFeature::computeFeatureData(
 		time = timer.stop();
 
 		// Speed
-		NFIQ::QualityFeatureSpeed speed;
+		NFIQ2::QualityFeatureSpeed speed;
 		speed.featureIDGroup = FDAFeature::speedFeatureIDGroup;
 
 		addHistogramFeatureNames(speed.featureIDs, "FDA_Bin10_", 10);
@@ -181,12 +184,13 @@ NFIQ::QualityFeatures::FDAFeature::computeFeatureData(
 		std::stringstream ssErr;
 		ssErr << "Cannot compute Frequency Domain Analysis (FDA): "
 		      << e.what();
-		throw NFIQ::NFIQException(
-		    NFIQ::e_Error_FeatureCalculationError, ssErr.str());
-	} catch (const NFIQ::NFIQException &) {
+		throw NFIQ2::NFIQException(
+		    NFIQ2::e_Error_FeatureCalculationError, ssErr.str());
+	} catch (const NFIQ2::NFIQException &) {
 		throw;
 	} catch (...) {
-		throw NFIQ::NFIQException(NFIQ::e_Error_FeatureCalculationError,
+		throw NFIQ2::NFIQException(
+		    NFIQ2::e_Error_FeatureCalculationError,
 		    "Unknown exception occurred!");
 	}
 
@@ -227,8 +231,8 @@ fda(const cv::Mat &block, const double orientation, const int v1sz_x,
 	float cBlock = static_cast<float>(block.rows) / 2; // square block
 	int icBlock = static_cast<int>(cBlock);
 	if (icBlock != cBlock) {
-		throw NFIQ::NFIQException {
-			NFIQ::e_Error_FeatureCalculationError,
+		throw NFIQ2::NFIQException {
+			NFIQ2::e_Error_FeatureCalculationError,
 			"Wrong block size! Consider block with size of even number "
 			"(block rows = " +
 			    std::to_string(block.rows) + ')'
@@ -238,7 +242,7 @@ fda(const cv::Mat &block, const double orientation, const int v1sz_x,
 	// rotate image to get the ridges horizontal using nearest-neighbor
 	// interpolation
 	cv::Mat blockRotated;
-	NFIQ::QualityFeatures::getRotatedBlock(
+	NFIQ2::QualityFeatures::getRotatedBlock(
 	    block, orientation + (M_PI / 2), padFlag, blockRotated);
 
 	//% set x and y

--- a/NFIQ2/NFIQ2Algorithm/src/features/FJFXMinutiaeQualityFeatures.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FJFXMinutiaeQualityFeatures.cpp
@@ -5,8 +5,8 @@
 
 #include <sstream>
 
-NFIQ::QualityFeatures::FJFXMinutiaeQualityFeature::FJFXMinutiaeQualityFeature(
-    const NFIQ::FingerprintImageData &fingerprintImage,
+NFIQ2::QualityFeatures::FJFXMinutiaeQualityFeature::FJFXMinutiaeQualityFeature(
+    const NFIQ2::FingerprintImageData &fingerprintImage,
     const std::vector<FingerJetFXFeature::Minutia> &minutiaData,
     const bool templateCouldBeExtracted)
     : minutiaData_ { minutiaData }
@@ -15,19 +15,19 @@ NFIQ::QualityFeatures::FJFXMinutiaeQualityFeature::FJFXMinutiaeQualityFeature(
 	this->setFeatures(computeFeatureData(fingerprintImage));
 };
 
-NFIQ::QualityFeatures::FJFXMinutiaeQualityFeature::
+NFIQ2::QualityFeatures::FJFXMinutiaeQualityFeature::
     ~FJFXMinutiaeQualityFeature() = default;
 
 const std::string
-    NFIQ::QualityFeatures::FJFXMinutiaeQualityFeature::speedFeatureIDGroup =
+    NFIQ2::QualityFeatures::FJFXMinutiaeQualityFeature::speedFeatureIDGroup =
 	"Minutiae quality";
 
-std::vector<NFIQ::QualityFeatures::FingerJetFXFeature::Minutia>
-NFIQ::QualityFeatures::FJFXMinutiaeQualityFeature::getMinutiaData() const
+std::vector<NFIQ2::QualityFeatures::FingerJetFXFeature::Minutia>
+NFIQ2::QualityFeatures::FJFXMinutiaeQualityFeature::getMinutiaData() const
 {
 	if (!this->templateCouldBeExtracted_) {
 		// This should never be reached but is here for consistency
-		throw NFIQ::NFIQException { e_Error_NoDataAvailable,
+		throw NFIQ2::NFIQException { e_Error_NoDataAvailable,
 			"Template could not be extracted." };
 	}
 
@@ -35,31 +35,31 @@ NFIQ::QualityFeatures::FJFXMinutiaeQualityFeature::getMinutiaData() const
 }
 
 bool
-NFIQ::QualityFeatures::FJFXMinutiaeQualityFeature::getTemplateStatus() const
+NFIQ2::QualityFeatures::FJFXMinutiaeQualityFeature::getTemplateStatus() const
 {
 	return (this->templateCouldBeExtracted_);
 }
 
-std::vector<NFIQ::QualityFeatureResult>
-NFIQ::QualityFeatures::FJFXMinutiaeQualityFeature::computeFeatureData(
-    const NFIQ::FingerprintImageData &fingerprintImage)
+std::vector<NFIQ2::QualityFeatureResult>
+NFIQ2::QualityFeatures::FJFXMinutiaeQualityFeature::computeFeatureData(
+    const NFIQ2::FingerprintImageData &fingerprintImage)
 {
-	std::vector<NFIQ::QualityFeatureResult> featureDataList;
+	std::vector<NFIQ2::QualityFeatureResult> featureDataList;
 
-	std::vector<NFIQ::QualityFeatureResult> vecResultMuMinQuality;
-	NFIQ::QualityFeatureData fd_mu;
+	std::vector<NFIQ2::QualityFeatureResult> vecResultMuMinQuality;
+	NFIQ2::QualityFeatureData fd_mu;
 	fd_mu.featureID = "FJFXPos_Mu_MinutiaeQuality_2";
-	fd_mu.featureDataType = NFIQ::e_QualityFeatureDataTypeDouble;
+	fd_mu.featureDataType = NFIQ2::e_QualityFeatureDataTypeDouble;
 	fd_mu.featureDataDouble = -1;
-	NFIQ::QualityFeatureResult res_mu;
+	NFIQ2::QualityFeatureResult res_mu;
 	res_mu.featureData = fd_mu;
 	res_mu.returnCode = 0;
 
-	NFIQ::QualityFeatureData fd_ocl;
+	NFIQ2::QualityFeatureData fd_ocl;
 	fd_ocl.featureID = "FJFXPos_OCL_MinutiaeQuality_80";
-	fd_ocl.featureDataType = NFIQ::e_QualityFeatureDataTypeDouble;
+	fd_ocl.featureDataType = NFIQ2::e_QualityFeatureDataTypeDouble;
 	fd_ocl.featureDataDouble = -1;
-	NFIQ::QualityFeatureResult res_ocl;
+	NFIQ2::QualityFeatureResult res_ocl;
 	res_ocl.featureData = fd_ocl;
 	res_ocl.returnCode = 0;
 
@@ -73,7 +73,7 @@ NFIQ::QualityFeatures::FJFXMinutiaeQualityFeature::computeFeatureData(
 		featureDataList.push_back(res_ocl);
 
 		// Speed
-		NFIQ::QualityFeatureSpeed speed;
+		NFIQ2::QualityFeatureSpeed speed;
 		speed.featureIDGroup =
 		    FJFXMinutiaeQualityFeature::speedFeatureIDGroup;
 		speed.featureIDs.push_back("FJFXPos_Mu_MinutiaeQuality_2");
@@ -85,7 +85,7 @@ NFIQ::QualityFeatures::FJFXMinutiaeQualityFeature::computeFeatureData(
 	}
 
 	try {
-		NFIQ::Timer timer;
+		NFIQ2::Timer timer;
 		timer.start();
 
 		// compute minutiae quality based on Mu feature computated at
@@ -156,7 +156,7 @@ NFIQ::QualityFeatures::FJFXMinutiaeQualityFeature::computeFeatureData(
 		featureDataList.push_back(res_ocl);
 
 		// Speed
-		NFIQ::QualityFeatureSpeed speed;
+		NFIQ2::QualityFeatureSpeed speed;
 		speed.featureIDGroup =
 		    FJFXMinutiaeQualityFeature::speedFeatureIDGroup;
 		speed.featureIDs.push_back("FJFXPos_Mu_MinutiaeQuality_2");
@@ -168,12 +168,13 @@ NFIQ::QualityFeatures::FJFXMinutiaeQualityFeature::computeFeatureData(
 		std::stringstream ssErr;
 		ssErr << "Cannot compute FJFX based minutiae quality features: "
 		      << e.what();
-		throw NFIQ::NFIQException(
-		    NFIQ::e_Error_FeatureCalculationError, ssErr.str());
-	} catch (const NFIQ::NFIQException &) {
+		throw NFIQ2::NFIQException(
+		    NFIQ2::e_Error_FeatureCalculationError, ssErr.str());
+	} catch (const NFIQ2::NFIQException &) {
 		throw;
 	} catch (...) {
-		throw NFIQ::NFIQException(NFIQ::e_Error_FeatureCalculationError,
+		throw NFIQ2::NFIQException(
+		    NFIQ2::e_Error_FeatureCalculationError,
 		    "Unknown exception occurred!");
 	}
 
@@ -181,17 +182,17 @@ NFIQ::QualityFeatures::FJFXMinutiaeQualityFeature::computeFeatureData(
 }
 
 const std::string
-    NFIQ::QualityFeatures::FJFXMinutiaeQualityFeature::moduleName {
+    NFIQ2::QualityFeatures::FJFXMinutiaeQualityFeature::moduleName {
 	    "NFIQ2_FJFXPos_MinutiaeQuality"
     };
 std::string
-NFIQ::QualityFeatures::FJFXMinutiaeQualityFeature::getModuleName() const
+NFIQ2::QualityFeatures::FJFXMinutiaeQualityFeature::getModuleName() const
 {
 	return moduleName;
 }
 
 std::vector<std::string>
-NFIQ::QualityFeatures::FJFXMinutiaeQualityFeature::getAllFeatureIDs()
+NFIQ2::QualityFeatures::FJFXMinutiaeQualityFeature::getAllFeatureIDs()
 {
 	std::vector<std::string> featureIDs;
 	featureIDs.push_back("FJFXPos_Mu_MinutiaeQuality_2");
@@ -199,9 +200,9 @@ NFIQ::QualityFeatures::FJFXMinutiaeQualityFeature::getAllFeatureIDs()
 	return featureIDs;
 }
 
-std::vector<NFIQ::QualityFeatures::FJFXMinutiaeQualityFeature::MinutiaData>
-NFIQ::QualityFeatures::FJFXMinutiaeQualityFeature::computeMuMinQuality(
-    int bs, const NFIQ::FingerprintImageData &fingerprintImage)
+std::vector<NFIQ2::QualityFeatures::FJFXMinutiaeQualityFeature::MinutiaData>
+NFIQ2::QualityFeatures::FJFXMinutiaeQualityFeature::computeMuMinQuality(
+    int bs, const NFIQ2::FingerprintImageData &fingerprintImage)
 {
 	std::vector<MinutiaData> vecMinData;
 
@@ -254,9 +255,9 @@ NFIQ::QualityFeatures::FJFXMinutiaeQualityFeature::computeMuMinQuality(
 	return vecMinData;
 }
 
-std::vector<NFIQ::QualityFeatures::FJFXMinutiaeQualityFeature::MinutiaData>
-NFIQ::QualityFeatures::FJFXMinutiaeQualityFeature::computeOCLMinQuality(
-    int bs, const NFIQ::FingerprintImageData &fingerprintImage)
+std::vector<NFIQ2::QualityFeatures::FJFXMinutiaeQualityFeature::MinutiaData>
+NFIQ2::QualityFeatures::FJFXMinutiaeQualityFeature::computeOCLMinQuality(
+    int bs, const NFIQ2::FingerprintImageData &fingerprintImage)
 {
 	std::vector<MinutiaData> vecMinData;
 

--- a/NFIQ2/NFIQ2Algorithm/src/features/FeatureFunctions.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FeatureFunctions.cpp
@@ -26,7 +26,7 @@ From the matlab code:
 ***/
 
 void
-NFIQ::QualityFeatures::ridgesegment(const cv::Mat &img, int blksze,
+NFIQ2::QualityFeatures::ridgesegment(const cv::Mat &img, int blksze,
     double thresh, cv::OutputArray _normImage, cv::Mat &maskImage,
     cv::OutputArray _maskIndex)
 
@@ -125,7 +125,7 @@ gradients inside %   a block specified as a parameter
 %
 ***/
 void
-NFIQ::QualityFeatures::covcoef(const cv::Mat &imblock, double &a, double &b,
+NFIQ2::QualityFeatures::covcoef(const cv::Mat &imblock, double &a, double &b,
     double &c, ocl_type compMethod)
 {
 	/*** Compute the gradient of the input block.  In Matlab, this is done
@@ -168,8 +168,9 @@ NFIQ::QualityFeatures::covcoef(const cv::Mat &imblock, double &a, double &b,
 			ssErr << "Call to OpenCV Sobel operator function "
 				 "failed: "
 			      << e.what();
-			throw NFIQ::NFIQException(
-			    NFIQ::e_Error_FeatureCalculationError, ssErr.str());
+			throw NFIQ2::NFIQException(
+			    NFIQ2::e_Error_FeatureCalculationError,
+			    ssErr.str());
 		}
 	}
 
@@ -216,7 +217,7 @@ function orientang = ridgeorient(a, b, c)
 ***/
 
 double
-NFIQ::QualityFeatures::ridgeorient(double a, double b, double c)
+NFIQ2::QualityFeatures::ridgeorient(double a, double b, double c)
 {
 	double denom, sin2theta, cos2theta, orientang;
 	double temp;
@@ -233,7 +234,7 @@ NFIQ::QualityFeatures::ridgeorient(double a, double b, double c)
 /////////////////////////////////////////////////////////////////////////
 
 uint8_t
-NFIQ::QualityFeatures::allfun(const cv::Mat &Image)
+NFIQ2::QualityFeatures::allfun(const cv::Mat &Image)
 /*** Returns 1 if all elements are nonzero, 0 otherwise.
 % Equivalent to matlab:
 % all elements of x should be nonzero, otherwise flag a
@@ -263,7 +264,7 @@ forward differences at the edges and central differences elsewhere.
 Spacing is 1.  The input matrix is assumed to be 64-bit floating point
 */
 void
-NFIQ::QualityFeatures::diffGrad(const cv::Mat &inBlock, cv::Mat &outBlock)
+NFIQ2::QualityFeatures::diffGrad(const cv::Mat &inBlock, cv::Mat &outBlock)
 {
 	outBlock.create(inBlock.size(), CV_64F);
 
@@ -286,7 +287,7 @@ NFIQ::QualityFeatures::diffGrad(const cv::Mat &inBlock, cv::Mat &outBlock)
 
 //////////////////////////////////////////////////////////////
 void
-NFIQ::QualityFeatures::getRotatedBlock(const cv::Mat &block,
+NFIQ2::QualityFeatures::getRotatedBlock(const cv::Mat &block,
     const double orientation, bool padFlag, cv::Mat &rotatedBlock)
 {
 	const double Rad2Deg = 180.0 / M_PI;
@@ -297,8 +298,8 @@ NFIQ::QualityFeatures::getRotatedBlock(const cv::Mat &block,
 	float cBlock = static_cast<float>(block.rows) / 2; // square block
 	int icBlock = static_cast<int>(cBlock);
 	if (icBlock != cBlock) {
-		throw NFIQ::NFIQException {
-			NFIQ::e_Error_FeatureCalculationError,
+		throw NFIQ2::NFIQException {
+			NFIQ2::e_Error_FeatureCalculationError,
 			"Wrong block size! Consider block with size of even number "
 			"(block rows = " +
 			    std::to_string(block.rows) + ')'
@@ -325,15 +326,15 @@ NFIQ::QualityFeatures::getRotatedBlock(const cv::Mat &block,
 	} catch (const cv::Exception &e) {
 		std::stringstream ssErr;
 		ssErr << "Exception during block rotation: " << e.what();
-		throw NFIQ::NFIQException(
-		    NFIQ::e_Error_FeatureCalculationError, ssErr.str());
+		throw NFIQ2::NFIQException(
+		    NFIQ2::e_Error_FeatureCalculationError, ssErr.str());
 	}
 
 	return;
 }
 //////////////////////////////////////////////////////////////////////////////
 void
-NFIQ::QualityFeatures::getRidgeValleyStructure(const cv::Mat &blockCropped,
+NFIQ2::QualityFeatures::getRidgeValleyStructure(const cv::Mat &blockCropped,
     std::vector<uint8_t> &ridval, std::vector<double> &dt)
 {
 	// average profile of blockCropped: Compute average of each column to
@@ -374,8 +375,8 @@ NFIQ::QualityFeatures::getRidgeValleyStructure(const cv::Mat &blockCropped,
 		ssErr << "Exception during ridge/valley processing: "
 			 "cv::solve(cv::DECOMP_QR) "
 		      << e.what();
-		throw NFIQ::NFIQException(
-		    NFIQ::e_Error_FeatureCalculationError, ssErr.str());
+		throw NFIQ2::NFIQException(
+		    NFIQ2::e_Error_FeatureCalculationError, ssErr.str());
 	}
 
 	// Round to 10 decimal points to preserve score consistency across
@@ -417,7 +418,7 @@ NFIQ::QualityFeatures::getRidgeValleyStructure(const cv::Mat &blockCropped,
  * @return
  */
 void
-NFIQ::QualityFeatures::GaborFilterCx(const int ksize, const double theta,
+NFIQ2::QualityFeatures::GaborFilterCx(const int ksize, const double theta,
     const double freq, const int sigma, cv::Mat &FilterOut)
 {
 	int ks2 = (ksize - 1) / 2;
@@ -446,7 +447,7 @@ NFIQ::QualityFeatures::GaborFilterCx(const int ksize, const double theta,
 ///////////////////////////////////////////////////////////////////////////////
 
 void
-NFIQ::QualityFeatures::Conv2D(const cv::Mat &imDFT, const cv::Mat &filter,
+NFIQ2::QualityFeatures::Conv2D(const cv::Mat &imDFT, const cv::Mat &filter,
     cv::Mat &ConvOut, const cv::Size &imageSize, const cv::Size &dftSize,
     bool imDFTFlag)
 {
@@ -480,13 +481,13 @@ NFIQ::QualityFeatures::Conv2D(const cv::Mat &imDFT, const cv::Mat &filter,
 ////////////////////////////////////////
 // compute coherence for COH/CS
 double
-NFIQ::QualityFeatures::calccoh(double gxx, double gyy, double gxy)
+NFIQ2::QualityFeatures::calccoh(double gxx, double gyy, double gxy)
 {
 	return sqrt((gxx - gyy) * (gxx - gyy) + 4 * gxy * gxy) / (gxx + gyy);
 }
 
 double
-NFIQ::QualityFeatures::calcof(double gsxavg, double gsyavg)
+NFIQ2::QualityFeatures::calcof(double gsxavg, double gsyavg)
 {
 	double theta = 0;
 	double phi = atan2(gsyavg, gsxavg);
@@ -499,7 +500,7 @@ NFIQ::QualityFeatures::calcof(double gsxavg, double gsyavg)
 }
 
 cv::Mat
-NFIQ::QualityFeatures::computeNumericalGradientX(const cv::Mat &mat)
+NFIQ2::QualityFeatures::computeNumericalGradientX(const cv::Mat &mat)
 {
 	cv::Mat out(mat.rows, mat.cols, CV_64F);
 
@@ -517,7 +518,7 @@ NFIQ::QualityFeatures::computeNumericalGradientX(const cv::Mat &mat)
 }
 
 void
-NFIQ::QualityFeatures::computeNumericalGradients(
+NFIQ2::QualityFeatures::computeNumericalGradients(
     const cv::Mat &mat, cv::Mat &grad_x, cv::Mat &grad_y)
 {
 	// get x-gradient
@@ -528,8 +529,8 @@ NFIQ::QualityFeatures::computeNumericalGradients(
 }
 
 void
-NFIQ::QualityFeatures::addSamplingFeatures(
-    std::vector<NFIQ::QualityFeatureResult> &featureDataList,
+NFIQ2::QualityFeatures::addSamplingFeatures(
+    std::vector<NFIQ2::QualityFeatureResult> &featureDataList,
     std::string featurePrefix, std::vector<double> &dataVector)
 {
 	const int sampleSize = dataVector.size();
@@ -538,13 +539,13 @@ NFIQ::QualityFeatures::addSamplingFeatures(
 	std::random_shuffle(dataVector.begin(), dataVector.end());
 
 	for (int i = 0; i < maxSampleCount; i++) {
-		NFIQ::QualityFeatureData fd;
+		NFIQ2::QualityFeatureData fd;
 
 		std::stringstream s;
 		s << featurePrefix << i;
 
 		fd.featureID = s.str();
-		fd.featureDataType = NFIQ::e_QualityFeatureDataTypeDouble;
+		fd.featureDataType = NFIQ2::e_QualityFeatureDataTypeDouble;
 		bool canComputeValue = true;
 		if (i < sampleSize) {
 			fd.featureDataDouble = dataVector.at(i);
@@ -552,13 +553,13 @@ NFIQ::QualityFeatures::addSamplingFeatures(
 			canComputeValue = false;
 		}
 
-		NFIQ::QualityFeatureResult result;
+		NFIQ2::QualityFeatureResult result;
 		result.featureData = fd;
 		if (canComputeValue) {
 			result.returnCode = 0;
 		} else {
 			result.returnCode =
-			    NFIQ::e_Error_FeatureCalculationError;
+			    NFIQ2::e_Error_FeatureCalculationError;
 		}
 
 		featureDataList.push_back(result);
@@ -566,8 +567,8 @@ NFIQ::QualityFeatures::addSamplingFeatures(
 }
 
 void
-NFIQ::QualityFeatures::addHistogramFeatures(
-    std::vector<NFIQ::QualityFeatureResult> &featureDataList,
+NFIQ2::QualityFeatures::addHistogramFeatures(
+    std::vector<NFIQ2::QualityFeatureResult> &featureDataList,
     std::string featurePrefix, std::vector<double> &binBoundaries,
     std::vector<double> &dataVector, int binCount)
 {
@@ -579,8 +580,8 @@ NFIQ::QualityFeatures::addHistogramFeatures(
 		std::stringstream s;
 		s << "Wrong histogram bin count for " << featurePrefix
 		  << ". Should be " << binCount << " but is " << myBinCount;
-		throw NFIQ::NFIQException(
-		    NFIQ::e_Error_FeatureCalculationError, s.str());
+		throw NFIQ2::NFIQException(
+		    NFIQ2::e_Error_FeatureCalculationError, s.str());
 	}
 
 	std::sort(dataVector.begin(), dataVector.end());
@@ -602,16 +603,16 @@ NFIQ::QualityFeatures::addHistogramFeatures(
 	}
 
 	for (int i = 0; i < binCount; i++) {
-		NFIQ::QualityFeatureData fd;
+		NFIQ2::QualityFeatureData fd;
 
 		std::stringstream s;
 		s << featurePrefix << i;
 
 		fd.featureID = s.str();
-		fd.featureDataType = NFIQ::e_QualityFeatureDataTypeDouble;
+		fd.featureDataType = NFIQ2::e_QualityFeatureDataTypeDouble;
 		fd.featureDataDouble = bins[i];
 
-		NFIQ::QualityFeatureResult result;
+		NFIQ2::QualityFeatureResult result;
 		result.featureData = fd;
 		result.returnCode = 0;
 
@@ -622,21 +623,21 @@ NFIQ::QualityFeatures::addHistogramFeatures(
 	cv::Scalar mean, stdDev;
 	cv::meanStdDev(dataMat, mean, stdDev);
 
-	NFIQ::QualityFeatureData meanFD, stdDevFD;
-	NFIQ::QualityFeatureResult meanFR, stdDevFR;
+	NFIQ2::QualityFeatureData meanFD, stdDevFD;
+	NFIQ2::QualityFeatureResult meanFR, stdDevFR;
 	std::stringstream meanSs, stdDevSs;
 
 	meanSs << featurePrefix << "Mean";
 	stdDevSs << featurePrefix << "StdDev";
 
 	meanFD.featureID = meanSs.str();
-	meanFD.featureDataType = NFIQ::e_QualityFeatureDataTypeDouble;
+	meanFD.featureDataType = NFIQ2::e_QualityFeatureDataTypeDouble;
 	meanFD.featureDataDouble = mean.val[0];
 	meanFR.featureData = meanFD;
 	meanFR.returnCode = 0;
 
 	stdDevFD.featureID = stdDevSs.str();
-	stdDevFD.featureDataType = NFIQ::e_QualityFeatureDataTypeDouble;
+	stdDevFD.featureDataType = NFIQ2::e_QualityFeatureDataTypeDouble;
 	stdDevFD.featureDataDouble = stdDev.val[0];
 	stdDevFR.featureData = stdDevFD;
 	stdDevFR.returnCode = 0;
@@ -650,7 +651,7 @@ NFIQ::QualityFeatures::addHistogramFeatures(
 }
 
 void
-NFIQ::QualityFeatures::addSamplingFeatureNames(
+NFIQ2::QualityFeatures::addSamplingFeatureNames(
     std::vector<std::string> &featureNames, const char *prefix)
 {
 	for (int i = 0; i < maxSampleCount; i++) {
@@ -661,7 +662,7 @@ NFIQ::QualityFeatures::addSamplingFeatureNames(
 }
 
 void
-NFIQ::QualityFeatures::addHistogramFeatureNames(
+NFIQ2::QualityFeatures::addHistogramFeatureNames(
     std::vector<std::string> &featureNames, const char *prefix, int binCount)
 {
 	for (int i = 0; i < binCount; i++) {

--- a/NFIQ2/NFIQ2Algorithm/src/features/FingerJetFXFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FingerJetFXFeature.cpp
@@ -7,19 +7,20 @@
 #include <sstream>
 #include <tuple>
 
-NFIQ::QualityFeatures::FingerJetFXFeature::FingerJetFXFeature(
-    const NFIQ::FingerprintImageData &fingerprintImage)
+NFIQ2::QualityFeatures::FingerJetFXFeature::FingerJetFXFeature(
+    const NFIQ2::FingerprintImageData &fingerprintImage)
 {
 	this->setFeatures(computeFeatureData(fingerprintImage));
 }
 
-NFIQ::QualityFeatures::FingerJetFXFeature::~FingerJetFXFeature() = default;
+NFIQ2::QualityFeatures::FingerJetFXFeature::~FingerJetFXFeature() = default;
 
 const std::string
-    NFIQ::QualityFeatures::FingerJetFXFeature::speedFeatureIDGroup = "Minutiae";
+    NFIQ2::QualityFeatures::FingerJetFXFeature::speedFeatureIDGroup =
+	"Minutiae";
 
 std::pair<unsigned int, unsigned int>
-NFIQ::QualityFeatures::FingerJetFXFeature::centerOfMinutiaeMass(
+NFIQ2::QualityFeatures::FingerJetFXFeature::centerOfMinutiaeMass(
     const std::vector<FingerJetFXFeature::Minutia> &minutiaData)
 {
 	unsigned int lx { 0 }, ly { 0 };
@@ -32,7 +33,7 @@ NFIQ::QualityFeatures::FingerJetFXFeature::centerOfMinutiaeMass(
 }
 
 std::string
-NFIQ::QualityFeatures::FingerJetFXFeature::parseFRFXLLError(
+NFIQ2::QualityFeatures::FingerJetFXFeature::parseFRFXLLError(
     const FRFXLL_RESULT fxRes)
 {
 	switch (fxRes) {
@@ -70,33 +71,33 @@ NFIQ::QualityFeatures::FingerJetFXFeature::parseFRFXLLError(
 }
 
 bool
-NFIQ::QualityFeatures::FingerJetFXFeature::getTemplateStatus() const
+NFIQ2::QualityFeatures::FingerJetFXFeature::getTemplateStatus() const
 {
 	return (this->templateCouldBeExtracted_);
 }
 
-std::vector<NFIQ::QualityFeatures::FingerJetFXFeature::Minutia>
-NFIQ::QualityFeatures::FingerJetFXFeature::getMinutiaData() const
+std::vector<NFIQ2::QualityFeatures::FingerJetFXFeature::Minutia>
+NFIQ2::QualityFeatures::FingerJetFXFeature::getMinutiaData() const
 {
 	if (!this->templateCouldBeExtracted_) {
-		throw NFIQ::NFIQException { e_Error_NoDataAvailable,
+		throw NFIQ2::NFIQException { e_Error_NoDataAvailable,
 			"Template could not be extracted." };
 	}
 
 	return (this->minutiaData_);
 }
 
-std::vector<NFIQ::QualityFeatureResult>
-NFIQ::QualityFeatures::FingerJetFXFeature::computeFeatureData(
-    const NFIQ::FingerprintImageData &fingerprintImage)
+std::vector<NFIQ2::QualityFeatureResult>
+NFIQ2::QualityFeatures::FingerJetFXFeature::computeFeatureData(
+    const NFIQ2::FingerprintImageData &fingerprintImage)
 {
 	this->templateCouldBeExtracted_ = false;
 
-	std::vector<NFIQ::QualityFeatureResult> featureDataList;
+	std::vector<NFIQ2::QualityFeatureResult> featureDataList;
 
 	// make local copy of fingerprint image
 	// since FJFX somehow transforms the input image
-	NFIQ::FingerprintImageData localFingerprintImage(
+	NFIQ2::FingerprintImageData localFingerprintImage(
 	    fingerprintImage.m_ImageWidth, fingerprintImage.m_ImageHeight,
 	    fingerprintImage.m_FingerCode, fingerprintImage.m_ImageDPI);
 	// copy data now
@@ -104,40 +105,40 @@ NFIQ::QualityFeatures::FingerJetFXFeature::computeFeatureData(
 	memcpy((void *)localFingerprintImage.data(), fingerprintImage.data(),
 	    fingerprintImage.size());
 
-	NFIQ::QualityFeatureData fd_min_cnt;
+	NFIQ2::QualityFeatureData fd_min_cnt;
 	fd_min_cnt.featureID = "FingerJetFX_MinutiaeCount";
-	fd_min_cnt.featureDataType = NFIQ::e_QualityFeatureDataTypeDouble;
+	fd_min_cnt.featureDataType = NFIQ2::e_QualityFeatureDataTypeDouble;
 	fd_min_cnt.featureDataDouble = 0;
-	NFIQ::QualityFeatureResult res_min_cnt;
+	NFIQ2::QualityFeatureResult res_min_cnt;
 	res_min_cnt.featureData = fd_min_cnt;
 	res_min_cnt.returnCode = 0;
 
-	NFIQ::QualityFeatureData fd_min_cnt_comrect200x200;
+	NFIQ2::QualityFeatureData fd_min_cnt_comrect200x200;
 	fd_min_cnt_comrect200x200.featureID =
 	    "FingerJetFX_MinCount_COMMinRect200x200";
 	fd_min_cnt_comrect200x200.featureDataType =
-	    NFIQ::e_QualityFeatureDataTypeDouble;
+	    NFIQ2::e_QualityFeatureDataTypeDouble;
 	fd_min_cnt_comrect200x200.featureDataDouble = 0;
-	NFIQ::QualityFeatureResult res_min_cnt_comrect200x200;
+	NFIQ2::QualityFeatureResult res_min_cnt_comrect200x200;
 	res_min_cnt_comrect200x200.featureData = fd_min_cnt_comrect200x200;
 	res_min_cnt_comrect200x200.returnCode = 0;
 
-	NFIQ::Timer timer;
+	NFIQ2::Timer timer;
 	timer.start();
 
 	// create context for feature extraction
 	// the created context function is modified to override default settings
 	FRFXLL_HANDLE hCtx = NULL, hFeatureSet = NULL;
 	if (!FRFXLL_SUCCESS(createContext(&hCtx))) {
-		throw NFIQ::NFIQException(
-		    NFIQ::
+		throw NFIQ2::NFIQException(
+		    NFIQ2::
 			e_Error_FeatureCalculationError_FJFX_CannotCreateContext,
 		    "Cannot create context of feature extraction (create "
 		    "context failed).");
 	}
 	if (hCtx == NULL) {
-		throw NFIQ::NFIQException(
-		    NFIQ::
+		throw NFIQ2::NFIQException(
+		    NFIQ2::
 			e_Error_FeatureCalculationError_FJFX_CannotCreateContext,
 		    "Cannot create context of feature extraction (hCtx is "
 		    "NULL).");
@@ -152,8 +153,8 @@ NFIQ::QualityFeatures::FingerJetFXFeature::computeFeatureData(
 	    &hFeatureSet);
 	if (!FRFXLL_SUCCESS(fxRes)) {
 		FRFXLLCloseHandle(&hCtx);
-		throw NFIQ::NFIQException(
-		    NFIQ::
+		throw NFIQ2::NFIQException(
+		    NFIQ2::
 			e_Error_FeatureCalculationError_FJFX_CannotCreateFeatureSet,
 		    "Could not create feature set from raw data: " +
 			FingerJetFXFeature::parseFRFXLLError(fxRes));
@@ -162,8 +163,8 @@ NFIQ::QualityFeatures::FingerJetFXFeature::computeFeatureData(
 	// close handle
 	FRFXLLCloseHandle(&hCtx);
 	if (hFeatureSet == NULL) {
-		throw NFIQ::NFIQException(
-		    NFIQ::
+		throw NFIQ2::NFIQException(
+		    NFIQ2::
 			e_Error_FeatureCalculationError_FJFX_CannotCreateFeatureSet,
 		    "Feature set creation failed. Feature set is null.");
 	}
@@ -173,8 +174,8 @@ NFIQ::QualityFeatures::FingerJetFXFeature::computeFeatureData(
 	    hFeatureSet, &minCnt, nullptr);
 	if (!FRFXLL_SUCCESS(fxResMin)) {
 		FRFXLLCloseHandle(&hFeatureSet);
-		throw NFIQ::NFIQException(
-		    NFIQ::
+		throw NFIQ2::NFIQException(
+		    NFIQ2::
 			e_Error_FeatureCalculationError_FJFX_NoFeatureSetCreated,
 		    "Failed to obtain Minutia Info from feature set: " +
 			FingerJetFXFeature::parseFRFXLLError(fxResMin));
@@ -185,7 +186,7 @@ NFIQ::QualityFeatures::FingerJetFXFeature::computeFeatureData(
 		mdata.reset(new FRFXLL_Basic_19794_2_Minutia[minCnt]);
 	} catch (const std::bad_alloc &) {
 		FRFXLLCloseHandle(&hFeatureSet);
-		throw NFIQ::NFIQException(NFIQ::e_Error_NotEnoughMemory,
+		throw NFIQ2::NFIQException(NFIQ2::e_Error_NotEnoughMemory,
 		    "Could not allocate space for extracted minutiae records.");
 	}
 
@@ -193,8 +194,8 @@ NFIQ::QualityFeatures::FingerJetFXFeature::computeFeatureData(
 	    hFeatureSet, BASIC_19794_2_MINUTIA_STRUCT, &minCnt, mdata.get());
 	if (!FRFXLL_SUCCESS(fxResData)) {
 		FRFXLLCloseHandle(&hFeatureSet);
-		throw NFIQ::NFIQException(
-		    NFIQ::
+		throw NFIQ2::NFIQException(
+		    NFIQ2::
 			e_Error_FeatureCalculationError_FJFX_NoFeatureSetCreated,
 		    "Failed to parse Minutia Data into 19794 Minutia Struct: " +
 			FingerJetFXFeature::parseFRFXLLError(fxResData));
@@ -233,7 +234,7 @@ NFIQ::QualityFeatures::FingerJetFXFeature::computeFeatureData(
 		featureDataList.push_back(res_min_cnt);
 
 		// Speed
-		NFIQ::QualityFeatureSpeed speed;
+		NFIQ2::QualityFeatureSpeed speed;
 		speed.featureIDGroup = FingerJetFXFeature::speedFeatureIDGroup;
 		speed.featureIDs.push_back("FingerJetFX_MinutiaeCount");
 		speed.featureIDs.push_back(
@@ -282,7 +283,7 @@ NFIQ::QualityFeatures::FingerJetFXFeature::computeFeatureData(
 	res_min_cnt.featureData = fd_min_cnt;
 	featureDataList.push_back(res_min_cnt);
 
-	NFIQ::QualityFeatureSpeed speed;
+	NFIQ2::QualityFeatureSpeed speed;
 	speed.featureIDGroup = FingerJetFXFeature::speedFeatureIDGroup;
 	speed.featureIDs.push_back("FingerJetFX_MinutiaeCount");
 	speed.featureIDs.push_back("FingerJetFX_MinCount_COMMinRect200x200");
@@ -292,17 +293,17 @@ NFIQ::QualityFeatures::FingerJetFXFeature::computeFeatureData(
 	return featureDataList;
 }
 
-const std::string NFIQ::QualityFeatures::FingerJetFXFeature::moduleName {
+const std::string NFIQ2::QualityFeatures::FingerJetFXFeature::moduleName {
 	"NFIQ2_FingerJetFX"
 };
 std::string
-NFIQ::QualityFeatures::FingerJetFXFeature::getModuleName() const
+NFIQ2::QualityFeatures::FingerJetFXFeature::getModuleName() const
 {
 	return moduleName;
 }
 
 std::vector<std::string>
-NFIQ::QualityFeatures::FingerJetFXFeature::getAllFeatureIDs()
+NFIQ2::QualityFeatures::FingerJetFXFeature::getAllFeatureIDs()
 {
 	std::vector<std::string> featureIDs;
 	featureIDs.push_back("FingerJetFX_MinCount_COMMinRect200x200");
@@ -311,7 +312,7 @@ NFIQ::QualityFeatures::FingerJetFXFeature::getAllFeatureIDs()
 }
 
 FRFXLL_RESULT
-NFIQ::QualityFeatures::FingerJetFXFeature::createContext(
+NFIQ2::QualityFeatures::FingerJetFXFeature::createContext(
     FRFXLL_HANDLE_PT phContext)
 {
 	FRFXLL_RESULT rc = FRFXLL_OK;
@@ -326,9 +327,9 @@ NFIQ::QualityFeatures::FingerJetFXFeature::createContext(
 	return rc;
 }
 
-NFIQ::QualityFeatures::FingerJetFXFeature::FJFXROIResults
-NFIQ::QualityFeatures::FingerJetFXFeature::computeROI(int bs,
-    const NFIQ::FingerprintImageData &fingerprintImage,
+NFIQ2::QualityFeatures::FingerJetFXFeature::FJFXROIResults
+NFIQ2::QualityFeatures::FingerJetFXFeature::computeROI(int bs,
+    const NFIQ2::FingerprintImageData &fingerprintImage,
     std::vector<FingerJetFXFeature::Object> vecRectDimensions)
 {
 	unsigned int fpHeight = fingerprintImage.m_ImageHeight;

--- a/NFIQ2/NFIQ2Algorithm/src/features/ImgProcROIFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/ImgProcROIFeature.cpp
@@ -5,38 +5,39 @@
 
 #include <sstream>
 
-NFIQ::QualityFeatures::ImgProcROIFeature::ImgProcROIFeature(
-    const NFIQ::FingerprintImageData &fingerprintImage)
+NFIQ2::QualityFeatures::ImgProcROIFeature::ImgProcROIFeature(
+    const NFIQ2::FingerprintImageData &fingerprintImage)
 {
 	this->setFeatures(computeFeatureData(fingerprintImage));
 }
 
-NFIQ::QualityFeatures::ImgProcROIFeature::~ImgProcROIFeature() = default;
+NFIQ2::QualityFeatures::ImgProcROIFeature::~ImgProcROIFeature() = default;
 
 const std::string
-    NFIQ::QualityFeatures::ImgProcROIFeature::speedFeatureIDGroup =
+    NFIQ2::QualityFeatures::ImgProcROIFeature::speedFeatureIDGroup =
 	"Region of interest";
 
-NFIQ::QualityFeatures::ImgProcROIFeature::ImgProcROIResults
-NFIQ::QualityFeatures::ImgProcROIFeature::getImgProcResults()
+NFIQ2::QualityFeatures::ImgProcROIFeature::ImgProcROIResults
+NFIQ2::QualityFeatures::ImgProcROIFeature::getImgProcResults()
 {
 	if (!this->imgProcComputed_) {
-		throw NFIQ::NFIQException { e_Error_NoDataAvailable,
+		throw NFIQ2::NFIQException { e_Error_NoDataAvailable,
 			"Img Proc Results could not be computed." };
 	}
 
 	return (this->imgProcResults_);
 }
 
-std::vector<NFIQ::QualityFeatureResult>
-NFIQ::QualityFeatures::ImgProcROIFeature::computeFeatureData(
-    const NFIQ::FingerprintImageData &fingerprintImage)
+std::vector<NFIQ2::QualityFeatureResult>
+NFIQ2::QualityFeatures::ImgProcROIFeature::computeFeatureData(
+    const NFIQ2::FingerprintImageData &fingerprintImage)
 {
-	std::vector<NFIQ::QualityFeatureResult> featureDataList;
+	std::vector<NFIQ2::QualityFeatureResult> featureDataList;
 
 	// check if input image has 500 dpi
-	if (fingerprintImage.m_ImageDPI != NFIQ::e_ImageResolution_500dpi) {
-		throw NFIQ::NFIQException(NFIQ::e_Error_FeatureCalculationError,
+	if (fingerprintImage.m_ImageDPI != NFIQ2::e_ImageResolution_500dpi) {
+		throw NFIQ2::NFIQException(
+		    NFIQ2::e_Error_FeatureCalculationError,
 		    "Only 500 dpi fingerprint images are supported!");
 	}
 
@@ -50,11 +51,11 @@ NFIQ::QualityFeatures::ImgProcROIFeature::computeFeatureData(
 		std::stringstream ssErr;
 		ssErr << "Cannot get matrix from fingerprint image: "
 		      << e.what();
-		throw NFIQ::NFIQException(
-		    NFIQ::e_Error_FeatureCalculationError, ssErr.str());
+		throw NFIQ2::NFIQException(
+		    NFIQ2::e_Error_FeatureCalculationError, ssErr.str());
 	}
 
-	NFIQ::Timer timer;
+	NFIQ2::Timer timer;
 	timer.start();
 
 	// ---------------------------------------------
@@ -64,20 +65,20 @@ NFIQ::QualityFeatures::ImgProcROIFeature::computeFeatureData(
 		this->imgProcResults_ = computeROI(
 		    img, 16); // block size = 16x16 pixels
 
-		NFIQ::QualityFeatureData fd_roi_pixel_area_mean;
+		NFIQ2::QualityFeatureData fd_roi_pixel_area_mean;
 		fd_roi_pixel_area_mean.featureID = "ImgProcROIArea_Mean";
 		fd_roi_pixel_area_mean.featureDataType =
-		    NFIQ::e_QualityFeatureDataTypeDouble;
+		    NFIQ2::e_QualityFeatureDataTypeDouble;
 		fd_roi_pixel_area_mean.featureDataDouble =
 		    this->imgProcResults_.meanOfROIPixels;
-		NFIQ::QualityFeatureResult res_roi_pixel_area_mean;
+		NFIQ2::QualityFeatureResult res_roi_pixel_area_mean;
 		res_roi_pixel_area_mean.featureData = fd_roi_pixel_area_mean;
 		res_roi_pixel_area_mean.returnCode = 0;
 
 		featureDataList.push_back(res_roi_pixel_area_mean);
 
 		// Speed
-		NFIQ::QualityFeatureSpeed speed;
+		NFIQ2::QualityFeatureSpeed speed;
 		speed.featureIDGroup = ImgProcROIFeature::speedFeatureIDGroup;
 		speed.featureIDs.push_back("ImgProcROIArea_Mean");
 		speed.featureSpeed = timer.stop();
@@ -87,12 +88,13 @@ NFIQ::QualityFeatures::ImgProcROIFeature::computeFeatureData(
 		std::stringstream ssErr;
 		ssErr << "Cannot compute feature (ImgProc)ROI area: "
 		      << e.what();
-		throw NFIQ::NFIQException(
-		    NFIQ::e_Error_FeatureCalculationError, ssErr.str());
-	} catch (const NFIQ::NFIQException &) {
+		throw NFIQ2::NFIQException(
+		    NFIQ2::e_Error_FeatureCalculationError, ssErr.str());
+	} catch (const NFIQ2::NFIQException &) {
 		throw;
 	} catch (...) {
-		throw NFIQ::NFIQException(NFIQ::e_Error_FeatureCalculationError,
+		throw NFIQ2::NFIQException(
+		    NFIQ2::e_Error_FeatureCalculationError,
 		    "Unknown exception occurred!");
 	}
 
@@ -101,26 +103,26 @@ NFIQ::QualityFeatures::ImgProcROIFeature::computeFeatureData(
 	return featureDataList;
 }
 
-const std::string NFIQ::QualityFeatures::ImgProcROIFeature::moduleName {
+const std::string NFIQ2::QualityFeatures::ImgProcROIFeature::moduleName {
 	"NFIQ2_ImgProcROI"
 };
 
 std::string
-NFIQ::QualityFeatures::ImgProcROIFeature::getModuleName() const
+NFIQ2::QualityFeatures::ImgProcROIFeature::getModuleName() const
 {
 	return moduleName;
 }
 
 std::vector<std::string>
-NFIQ::QualityFeatures::ImgProcROIFeature::getAllFeatureIDs()
+NFIQ2::QualityFeatures::ImgProcROIFeature::getAllFeatureIDs()
 {
 	std::vector<std::string> featureIDs;
 	featureIDs.push_back("ImgProcROIArea_Mean");
 	return featureIDs;
 }
 
-NFIQ::QualityFeatures::ImgProcROIFeature::ImgProcROIResults
-NFIQ::QualityFeatures::ImgProcROIFeature::computeROI(
+NFIQ2::QualityFeatures::ImgProcROIFeature::ImgProcROIResults
+NFIQ2::QualityFeatures::ImgProcROIFeature::computeROI(
     cv::Mat &img, unsigned int bs)
 {
 	ImgProcROIResults roiResults;
@@ -298,7 +300,7 @@ NFIQ::QualityFeatures::ImgProcROIFeature::computeROI(
 }
 
 bool
-NFIQ::QualityFeatures::ImgProcROIFeature::isBlackPixelAvailable(
+NFIQ2::QualityFeatures::ImgProcROIFeature::isBlackPixelAvailable(
     cv::Mat &img, cv::Point &point)
 {
 	bool found = false;

--- a/NFIQ2/NFIQ2Algorithm/src/features/LCSFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/LCSFeature.cpp
@@ -15,24 +15,26 @@
 double loclar(cv::Mat &block, const double orientation, const int v1sz_x,
     const int v1sz_y, const int scres, const bool padFlag);
 
-NFIQ::QualityFeatures::LCSFeature::LCSFeature(
-    const NFIQ::FingerprintImageData &fingerprintImage)
+NFIQ2::QualityFeatures::LCSFeature::LCSFeature(
+    const NFIQ2::FingerprintImageData &fingerprintImage)
 {
 	this->setFeatures(computeFeatureData(fingerprintImage));
 }
 
-NFIQ::QualityFeatures::LCSFeature::~LCSFeature() = default;
+NFIQ2::QualityFeatures::LCSFeature::~LCSFeature() = default;
 
-const std::string NFIQ::QualityFeatures::LCSFeature::moduleName { "NFIQ2_LCS" };
+const std::string NFIQ2::QualityFeatures::LCSFeature::moduleName {
+	"NFIQ2_LCS"
+};
 
 std::string
-NFIQ::QualityFeatures::LCSFeature::getModuleName() const
+NFIQ2::QualityFeatures::LCSFeature::getModuleName() const
 {
 	return moduleName;
 }
 
 std::vector<std::string>
-NFIQ::QualityFeatures::LCSFeature::getAllFeatureIDs()
+NFIQ2::QualityFeatures::LCSFeature::getAllFeatureIDs()
 {
 	std::vector<std::string> featureIDs;
 	addHistogramFeatureNames(featureIDs, "LCS_Bin10_", 10);
@@ -40,18 +42,19 @@ NFIQ::QualityFeatures::LCSFeature::getAllFeatureIDs()
 	return featureIDs;
 }
 
-const std::string NFIQ::QualityFeatures::LCSFeature::speedFeatureIDGroup =
+const std::string NFIQ2::QualityFeatures::LCSFeature::speedFeatureIDGroup =
     "Local clarity";
 
-std::vector<NFIQ::QualityFeatureResult>
-NFIQ::QualityFeatures::LCSFeature::computeFeatureData(
-    const NFIQ::FingerprintImageData &fingerprintImage)
+std::vector<NFIQ2::QualityFeatureResult>
+NFIQ2::QualityFeatures::LCSFeature::computeFeatureData(
+    const NFIQ2::FingerprintImageData &fingerprintImage)
 {
-	std::vector<NFIQ::QualityFeatureResult> featureDataList;
+	std::vector<NFIQ2::QualityFeatureResult> featureDataList;
 
 	// check if input image has 500 dpi
-	if (fingerprintImage.m_ImageDPI != NFIQ::e_ImageResolution_500dpi) {
-		throw NFIQ::NFIQException(NFIQ::e_Error_FeatureCalculationError,
+	if (fingerprintImage.m_ImageDPI != NFIQ2::e_ImageResolution_500dpi) {
+		throw NFIQ2::NFIQException(
+		    NFIQ2::e_Error_FeatureCalculationError,
 		    "Only 500 dpi fingerprint images are supported!");
 	}
 
@@ -65,11 +68,11 @@ NFIQ::QualityFeatures::LCSFeature::computeFeatureData(
 		std::stringstream ssErr;
 		ssErr << "Cannot get matrix from fingerprint image: "
 		      << e.what();
-		throw NFIQ::NFIQException(
-		    NFIQ::e_Error_FeatureCalculationError, ssErr.str());
+		throw NFIQ2::NFIQException(
+		    NFIQ2::e_Error_FeatureCalculationError, ssErr.str());
 	}
 
-	NFIQ::Timer timerLCS;
+	NFIQ2::Timer timerLCS;
 	double timeLCS = 0.0;
 	try {
 		timerLCS.start();
@@ -180,7 +183,7 @@ NFIQ::QualityFeatures::LCSFeature::computeFeatureData(
 		    histogramBins10, dataVector, 10);
 
 		// Speed
-		NFIQ::QualityFeatureSpeed speed;
+		NFIQ2::QualityFeatureSpeed speed;
 		speed.featureIDGroup = LCSFeature::speedFeatureIDGroup;
 
 		addHistogramFeatureNames(speed.featureIDs, "LCS_Bin10_", 10);
@@ -191,12 +194,13 @@ NFIQ::QualityFeatures::LCSFeature::computeFeatureData(
 	} catch (const cv::Exception &e) {
 		std::stringstream ssErr;
 		ssErr << "Cannot compute LCS: " << e.what();
-		throw NFIQ::NFIQException(
-		    NFIQ::e_Error_FeatureCalculationError, ssErr.str());
-	} catch (const NFIQ::NFIQException &) {
+		throw NFIQ2::NFIQException(
+		    NFIQ2::e_Error_FeatureCalculationError, ssErr.str());
+	} catch (const NFIQ2::NFIQException &) {
 		throw;
 	} catch (...) {
-		throw NFIQ::NFIQException(NFIQ::e_Error_FeatureCalculationError,
+		throw NFIQ2::NFIQException(
+		    NFIQ2::e_Error_FeatureCalculationError,
 		    "Unknown exception occurred!");
 	}
 	return featureDataList;
@@ -236,8 +240,8 @@ loclar(cv::Mat &block, const double orientation, const int v1sz_x,
 	float cBlock = static_cast<float>(block.rows) / 2; // square block
 	int icBlock = static_cast<int>(cBlock);
 	if (icBlock != cBlock) {
-		throw NFIQ::NFIQException {
-			NFIQ::e_Error_FeatureCalculationError,
+		throw NFIQ2::NFIQException {
+			NFIQ2::e_Error_FeatureCalculationError,
 			"Wrong block size! Consider block with size of even number "
 			"(block rows = " +
 			    std::to_string(block.rows) + ')'
@@ -245,7 +249,7 @@ loclar(cv::Mat &block, const double orientation, const int v1sz_x,
 	}
 
 	cv::Mat blockRotated;
-	NFIQ::QualityFeatures::getRotatedBlock(
+	NFIQ2::QualityFeatures::getRotatedBlock(
 	    block, orientation, padFlag, blockRotated);
 
 	//% set x and y
@@ -269,7 +273,7 @@ loclar(cv::Mat &block, const double orientation, const int v1sz_x,
 
 	std::vector<uint8_t> ridval;
 	std::vector<double> dt;
-	NFIQ::QualityFeatures::getRidgeValleyStructure(v2, ridval, dt);
+	NFIQ2::QualityFeatures::getRidgeValleyStructure(v2, ridval, dt);
 
 	// Ridge-valley thickness
 	//  begrid = ridval(1); % begining with ridge?

--- a/NFIQ2/NFIQ2Algorithm/src/features/MuFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/MuFeature.cpp
@@ -5,26 +5,27 @@
 
 #include <sstream>
 
-NFIQ::QualityFeatures::MuFeature::MuFeature(
-    const NFIQ::FingerprintImageData &fingerprintImage)
+NFIQ2::QualityFeatures::MuFeature::MuFeature(
+    const NFIQ2::FingerprintImageData &fingerprintImage)
 {
 	this->setFeatures(computeFeatureData(fingerprintImage));
 }
 
-NFIQ::QualityFeatures::MuFeature::~MuFeature() = default;
+NFIQ2::QualityFeatures::MuFeature::~MuFeature() = default;
 
-const std::string NFIQ::QualityFeatures::MuFeature::speedFeatureIDGroup =
+const std::string NFIQ2::QualityFeatures::MuFeature::speedFeatureIDGroup =
     "Contrast";
 
-std::vector<NFIQ::QualityFeatureResult>
-NFIQ::QualityFeatures::MuFeature::computeFeatureData(
-    const NFIQ::FingerprintImageData &fingerprintImage)
+std::vector<NFIQ2::QualityFeatureResult>
+NFIQ2::QualityFeatures::MuFeature::computeFeatureData(
+    const NFIQ2::FingerprintImageData &fingerprintImage)
 {
-	std::vector<NFIQ::QualityFeatureResult> featureDataList;
+	std::vector<NFIQ2::QualityFeatureResult> featureDataList;
 
 	// check if input image has 500 dpi
-	if (fingerprintImage.m_ImageDPI != NFIQ::e_ImageResolution_500dpi) {
-		throw NFIQ::NFIQException(NFIQ::e_Error_FeatureCalculationError,
+	if (fingerprintImage.m_ImageDPI != NFIQ2::e_ImageResolution_500dpi) {
+		throw NFIQ2::NFIQException(
+		    NFIQ2::e_Error_FeatureCalculationError,
 		    "Only 500 dpi fingerprint images are supported!");
 	}
 
@@ -38,11 +39,11 @@ NFIQ::QualityFeatures::MuFeature::computeFeatureData(
 		std::stringstream ssErr;
 		ssErr << "Cannot get matrix from fingerprint image: "
 		      << e.what();
-		throw NFIQ::NFIQException(
-		    NFIQ::e_Error_FeatureCalculationError, ssErr.str());
+		throw NFIQ2::NFIQException(
+		    NFIQ2::e_Error_FeatureCalculationError, ssErr.str());
 	}
 
-	NFIQ::Timer timer;
+	NFIQ2::Timer timer;
 	timer.start();
 
 	// -------------------------
@@ -84,11 +85,11 @@ NFIQ::QualityFeatures::MuFeature::computeFeatureData(
 		}
 
 		// return MMB value
-		NFIQ::QualityFeatureData fd_mmb;
+		NFIQ2::QualityFeatureData fd_mmb;
 		fd_mmb.featureID = "MMB";
-		fd_mmb.featureDataType = NFIQ::e_QualityFeatureDataTypeDouble;
+		fd_mmb.featureDataType = NFIQ2::e_QualityFeatureDataTypeDouble;
 		fd_mmb.featureDataDouble = avg;
-		NFIQ::QualityFeatureResult res_mmb;
+		NFIQ2::QualityFeatureResult res_mmb;
 		res_mmb.featureData = fd_mmb;
 		res_mmb.returnCode = 0;
 
@@ -97,12 +98,13 @@ NFIQ::QualityFeatures::MuFeature::computeFeatureData(
 		std::stringstream ssErr;
 		ssErr << "Cannot compute feature Mu Mu Block (MMB): "
 		      << e.what();
-		throw NFIQ::NFIQException(
-		    NFIQ::e_Error_FeatureCalculationError, ssErr.str());
-	} catch (const NFIQ::NFIQException &) {
+		throw NFIQ2::NFIQException(
+		    NFIQ2::e_Error_FeatureCalculationError, ssErr.str());
+	} catch (const NFIQ2::NFIQException &) {
 		throw;
 	} catch (...) {
-		throw NFIQ::NFIQException(NFIQ::e_Error_FeatureCalculationError,
+		throw NFIQ2::NFIQException(
+		    NFIQ2::e_Error_FeatureCalculationError,
 		    "Unknown exception occurred!");
 	}
 
@@ -120,11 +122,11 @@ NFIQ::QualityFeatures::MuFeature::computeFeatureData(
 		this->sigmaComputed = true;
 
 		// return mu value
-		NFIQ::QualityFeatureData fd_mu;
+		NFIQ2::QualityFeatureData fd_mu;
 		fd_mu.featureID = "Mu";
-		fd_mu.featureDataType = NFIQ::e_QualityFeatureDataTypeDouble;
+		fd_mu.featureDataType = NFIQ2::e_QualityFeatureDataTypeDouble;
 		fd_mu.featureDataDouble = mu.val[0];
-		NFIQ::QualityFeatureResult res_mu;
+		NFIQ2::QualityFeatureResult res_mu;
 		res_mu.featureData = fd_mu;
 		res_mu.returnCode = 0;
 
@@ -133,17 +135,18 @@ NFIQ::QualityFeatures::MuFeature::computeFeatureData(
 		std::stringstream ssErr;
 		ssErr << "Cannot compute feature Sigma (stddev) and Mu (mean): "
 		      << e.what();
-		throw NFIQ::NFIQException(
-		    NFIQ::e_Error_FeatureCalculationError, ssErr.str());
-	} catch (const NFIQ::NFIQException &) {
+		throw NFIQ2::NFIQException(
+		    NFIQ2::e_Error_FeatureCalculationError, ssErr.str());
+	} catch (const NFIQ2::NFIQException &) {
 		throw;
 	} catch (...) {
-		throw NFIQ::NFIQException(NFIQ::e_Error_FeatureCalculationError,
+		throw NFIQ2::NFIQException(
+		    NFIQ2::e_Error_FeatureCalculationError,
 		    "Unknown exception occurred!");
 	}
 
 	// Speed
-	NFIQ::QualityFeatureSpeed speed;
+	NFIQ2::QualityFeatureSpeed speed;
 	speed.featureIDGroup = MuFeature::speedFeatureIDGroup;
 	speed.featureIDs.push_back("MMB");
 	speed.featureIDs.push_back("Mu");
@@ -154,25 +157,25 @@ NFIQ::QualityFeatures::MuFeature::computeFeatureData(
 }
 
 double
-NFIQ::QualityFeatures::MuFeature::getSigma() const
+NFIQ2::QualityFeatures::MuFeature::getSigma() const
 {
 	if (!this->sigmaComputed)
-		throw NFIQ::NFIQException { e_Error_NoDataAvailable,
+		throw NFIQ2::NFIQException { e_Error_NoDataAvailable,
 			"Sigma has not been computed." };
 
 	return (this->sigma);
 }
 
-const std::string NFIQ::QualityFeatures::MuFeature::moduleName { "NFIQ2_Mu" };
+const std::string NFIQ2::QualityFeatures::MuFeature::moduleName { "NFIQ2_Mu" };
 
 std::string
-NFIQ::QualityFeatures::MuFeature::getModuleName() const
+NFIQ2::QualityFeatures::MuFeature::getModuleName() const
 {
 	return moduleName;
 }
 
 std::vector<std::string>
-NFIQ::QualityFeatures::MuFeature::getAllFeatureIDs()
+NFIQ2::QualityFeatures::MuFeature::getAllFeatureIDs()
 {
 	std::vector<std::string> featureIDs;
 	featureIDs.push_back("MMB");

--- a/NFIQ2/NFIQ2Algorithm/src/features/OCLHistogramFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/OCLHistogramFeature.cpp
@@ -11,29 +11,30 @@
 #include <cfloat>
 #endif
 
-NFIQ::QualityFeatures::OCLHistogramFeature::OCLHistogramFeature(
-    const NFIQ::FingerprintImageData &fingerprintImage)
+NFIQ2::QualityFeatures::OCLHistogramFeature::OCLHistogramFeature(
+    const NFIQ2::FingerprintImageData &fingerprintImage)
 {
 	this->setFeatures(computeFeatureData(fingerprintImage));
 }
 
-NFIQ::QualityFeatures::OCLHistogramFeature::~OCLHistogramFeature() = default;
+NFIQ2::QualityFeatures::OCLHistogramFeature::~OCLHistogramFeature() = default;
 
 const std::string
-    NFIQ::QualityFeatures::OCLHistogramFeature::speedFeatureIDGroup =
+    NFIQ2::QualityFeatures::OCLHistogramFeature::speedFeatureIDGroup =
 	"Orientation certainty";
 
-std::vector<NFIQ::QualityFeatureResult>
-NFIQ::QualityFeatures::OCLHistogramFeature::computeFeatureData(
-    const NFIQ::FingerprintImageData &fingerprintImage)
+std::vector<NFIQ2::QualityFeatureResult>
+NFIQ2::QualityFeatures::OCLHistogramFeature::computeFeatureData(
+    const NFIQ2::FingerprintImageData &fingerprintImage)
 {
-	std::vector<NFIQ::QualityFeatureResult> featureDataList;
+	std::vector<NFIQ2::QualityFeatureResult> featureDataList;
 
 	cv::Mat img;
 
 	// check if input image has 500 dpi
-	if (fingerprintImage.m_ImageDPI != NFIQ::e_ImageResolution_500dpi) {
-		throw NFIQ::NFIQException(NFIQ::e_Error_FeatureCalculationError,
+	if (fingerprintImage.m_ImageDPI != NFIQ2::e_ImageResolution_500dpi) {
+		throw NFIQ2::NFIQException(
+		    NFIQ2::e_Error_FeatureCalculationError,
 		    "Only 500 dpi fingerprint images are supported!");
 	}
 
@@ -46,12 +47,12 @@ NFIQ::QualityFeatures::OCLHistogramFeature::computeFeatureData(
 		std::stringstream ssErr;
 		ssErr << "Cannot get matrix from fingerprint image: "
 		      << e.what();
-		throw NFIQ::NFIQException(
-		    NFIQ::e_Error_FeatureCalculationError, ssErr.str());
+		throw NFIQ2::NFIQException(
+		    NFIQ2::e_Error_FeatureCalculationError, ssErr.str());
 	}
 
 	// compute OCL
-	NFIQ::Timer timerOCL;
+	NFIQ2::Timer timerOCL;
 	double timeOCL = 0.0;
 	std::vector<double> oclres;
 	try {
@@ -106,7 +107,7 @@ NFIQ::QualityFeatures::OCLHistogramFeature::computeFeatureData(
 		timeOCL = timerOCL.stop();
 
 		// Speed
-		NFIQ::QualityFeatureSpeed speed;
+		NFIQ2::QualityFeatureSpeed speed;
 		speed.featureIDGroup = OCLHistogramFeature::speedFeatureIDGroup;
 
 		addHistogramFeatureNames(speed.featureIDs, "OCL_Bin10_", 10);
@@ -117,12 +118,13 @@ NFIQ::QualityFeatures::OCLHistogramFeature::computeFeatureData(
 	} catch (const cv::Exception &e) {
 		std::stringstream ssErr;
 		ssErr << "Cannot compute feature OCL histogram: " << e.what();
-		throw NFIQ::NFIQException(
-		    NFIQ::e_Error_FeatureCalculationError, ssErr.str());
-	} catch (const NFIQ::NFIQException &) {
+		throw NFIQ2::NFIQException(
+		    NFIQ2::e_Error_FeatureCalculationError, ssErr.str());
+	} catch (const NFIQ2::NFIQException &) {
 		throw;
 	} catch (...) {
-		throw NFIQ::NFIQException(NFIQ::e_Error_FeatureCalculationError,
+		throw NFIQ2::NFIQException(
+		    NFIQ2::e_Error_FeatureCalculationError,
 		    "Unknown exception occurred!");
 	}
 
@@ -130,7 +132,7 @@ NFIQ::QualityFeatures::OCLHistogramFeature::computeFeatureData(
 }
 
 bool
-NFIQ::QualityFeatures::OCLHistogramFeature::getOCLValueOfBlock(
+NFIQ2::QualityFeatures::OCLHistogramFeature::getOCLValueOfBlock(
     const cv::Mat &block, double &ocl)
 {
 	double eigv_max = 0.0, eigv_min = 0.0;
@@ -172,18 +174,18 @@ NFIQ::QualityFeatures::OCLHistogramFeature::getOCLValueOfBlock(
 	return true;
 }
 
-const std::string NFIQ::QualityFeatures::OCLHistogramFeature::moduleName {
+const std::string NFIQ2::QualityFeatures::OCLHistogramFeature::moduleName {
 	"NFIQ2_OCLHistogram"
 };
 
 std::string
-NFIQ::QualityFeatures::OCLHistogramFeature::getModuleName() const
+NFIQ2::QualityFeatures::OCLHistogramFeature::getModuleName() const
 {
 	return "NFIQ2_OCLHistogram";
 }
 
 std::vector<std::string>
-NFIQ::QualityFeatures::OCLHistogramFeature::getAllFeatureIDs()
+NFIQ2::QualityFeatures::OCLHistogramFeature::getAllFeatureIDs()
 {
 	std::vector<std::string> featureIDs;
 	addHistogramFeatureNames(featureIDs, "OCL_Bin10_", 10);

--- a/NFIQ2/NFIQ2Algorithm/src/features/OFFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/OFFeature.cpp
@@ -14,23 +14,23 @@
 #include <cfloat>
 #endif
 
-NFIQ::QualityFeatures::OFFeature::OFFeature(
-    const NFIQ::FingerprintImageData &fingerprintImage)
+NFIQ2::QualityFeatures::OFFeature::OFFeature(
+    const NFIQ2::FingerprintImageData &fingerprintImage)
 {
 	this->setFeatures(computeFeatureData(fingerprintImage));
 }
 
-NFIQ::QualityFeatures::OFFeature::~OFFeature() = default;
+NFIQ2::QualityFeatures::OFFeature::~OFFeature() = default;
 
-const std::string NFIQ::QualityFeatures::OFFeature::moduleName { "NFIQ2_OF" };
+const std::string NFIQ2::QualityFeatures::OFFeature::moduleName { "NFIQ2_OF" };
 std::string
-NFIQ::QualityFeatures::OFFeature::getModuleName() const
+NFIQ2::QualityFeatures::OFFeature::getModuleName() const
 {
 	return moduleName;
 }
 
 std::vector<std::string>
-NFIQ::QualityFeatures::OFFeature::getAllFeatureIDs()
+NFIQ2::QualityFeatures::OFFeature::getAllFeatureIDs()
 {
 	std::vector<std::string> featureIDs;
 	addHistogramFeatureNames(featureIDs, "OF_Bin10_", 10);
@@ -38,18 +38,19 @@ NFIQ::QualityFeatures::OFFeature::getAllFeatureIDs()
 	return featureIDs;
 }
 
-const std::string NFIQ::QualityFeatures::OFFeature::speedFeatureIDGroup =
+const std::string NFIQ2::QualityFeatures::OFFeature::speedFeatureIDGroup =
     "Orientation flow";
 
-std::vector<NFIQ::QualityFeatureResult>
-NFIQ::QualityFeatures::OFFeature::computeFeatureData(
-    const NFIQ::FingerprintImageData &fingerprintImage)
+std::vector<NFIQ2::QualityFeatureResult>
+NFIQ2::QualityFeatures::OFFeature::computeFeatureData(
+    const NFIQ2::FingerprintImageData &fingerprintImage)
 {
-	std::vector<NFIQ::QualityFeatureResult> featureDataList;
+	std::vector<NFIQ2::QualityFeatureResult> featureDataList;
 
 	// check if input image has 500 dpi
-	if (fingerprintImage.m_ImageDPI != NFIQ::e_ImageResolution_500dpi) {
-		throw NFIQ::NFIQException(NFIQ::e_Error_FeatureCalculationError,
+	if (fingerprintImage.m_ImageDPI != NFIQ2::e_ImageResolution_500dpi) {
+		throw NFIQ2::NFIQException(
+		    NFIQ2::e_Error_FeatureCalculationError,
 		    "Only 500 dpi fingerprint images are supported!");
 	}
 
@@ -63,11 +64,11 @@ NFIQ::QualityFeatures::OFFeature::computeFeatureData(
 		std::stringstream ssErr;
 		ssErr << "Cannot get matrix from fingerprint image: "
 		      << e.what();
-		throw NFIQ::NFIQException(
-		    NFIQ::e_Error_FeatureCalculationError, ssErr.str());
+		throw NFIQ2::NFIQException(
+		    NFIQ2::e_Error_FeatureCalculationError, ssErr.str());
 	}
 
-	NFIQ::Timer timerOF;
+	NFIQ2::Timer timerOF;
 	double timeOF = 0.0;
 	try {
 		timerOF.start();
@@ -253,7 +254,7 @@ NFIQ::QualityFeatures::OFFeature::computeFeatureData(
 		timeOF = timerOF.stop();
 
 		// Speed
-		NFIQ::QualityFeatureSpeed speed;
+		NFIQ2::QualityFeatureSpeed speed;
 		speed.featureIDGroup = OFFeature::speedFeatureIDGroup;
 
 		addHistogramFeatureNames(speed.featureIDs, "OF_Bin10_", 10);
@@ -264,12 +265,13 @@ NFIQ::QualityFeatures::OFFeature::computeFeatureData(
 	} catch (const cv::Exception &e) {
 		std::stringstream ssErr;
 		ssErr << "Cannot compute Orientation Flow (OF): " << e.what();
-		throw NFIQ::NFIQException(
-		    NFIQ::e_Error_FeatureCalculationError, ssErr.str());
-	} catch (const NFIQ::NFIQException &) {
+		throw NFIQ2::NFIQException(
+		    NFIQ2::e_Error_FeatureCalculationError, ssErr.str());
+	} catch (const NFIQ2::NFIQException &) {
 		throw;
 	} catch (...) {
-		throw NFIQ::NFIQException(NFIQ::e_Error_FeatureCalculationError,
+		throw NFIQ2::NFIQException(
+		    NFIQ2::e_Error_FeatureCalculationError,
 		    "Unknown exception occurred!");
 	}
 	return featureDataList;

--- a/NFIQ2/NFIQ2Algorithm/src/features/QualityMapFeatures.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/QualityMapFeatures.cpp
@@ -12,33 +12,34 @@
 #include <cfloat>
 #endif
 
-NFIQ::QualityFeatures::QualityMapFeatures::QualityMapFeatures(
-    const NFIQ::FingerprintImageData &fingerprintImage,
+NFIQ2::QualityFeatures::QualityMapFeatures::QualityMapFeatures(
+    const NFIQ2::FingerprintImageData &fingerprintImage,
     const ImgProcROIFeature::ImgProcROIResults &imgProcResults)
     : imgProcResults_ { imgProcResults }
 {
 	this->setFeatures(computeFeatureData(fingerprintImage));
 }
 
-NFIQ::QualityFeatures::QualityMapFeatures::~QualityMapFeatures() = default;
+NFIQ2::QualityFeatures::QualityMapFeatures::~QualityMapFeatures() = default;
 
 const std::string
-    NFIQ::QualityFeatures::QualityMapFeatures::speedFeatureIDGroup =
+    NFIQ2::QualityFeatures::QualityMapFeatures::speedFeatureIDGroup =
 	"Quality map";
 
-std::vector<NFIQ::QualityFeatureResult>
-NFIQ::QualityFeatures::QualityMapFeatures::computeFeatureData(
-    const NFIQ::FingerprintImageData &fingerprintImage)
+std::vector<NFIQ2::QualityFeatureResult>
+NFIQ2::QualityFeatures::QualityMapFeatures::computeFeatureData(
+    const NFIQ2::FingerprintImageData &fingerprintImage)
 {
-	std::vector<NFIQ::QualityFeatureResult> featureDataList;
+	std::vector<NFIQ2::QualityFeatureResult> featureDataList;
 
 	// check if input image has 500 dpi
-	if (fingerprintImage.m_ImageDPI != NFIQ::e_ImageResolution_500dpi) {
-		throw NFIQ::NFIQException(NFIQ::e_Error_FeatureCalculationError,
+	if (fingerprintImage.m_ImageDPI != NFIQ2::e_ImageResolution_500dpi) {
+		throw NFIQ2::NFIQException(
+		    NFIQ2::e_Error_FeatureCalculationError,
 		    "Only 500 dpi fingerprint images are supported!");
 	}
 
-	NFIQ::Timer timer;
+	NFIQ2::Timer timer;
 	timer.start();
 
 	cv::Mat img;
@@ -51,8 +52,8 @@ NFIQ::QualityFeatures::QualityMapFeatures::computeFeatureData(
 		std::stringstream ssErr;
 		ssErr << "Cannot get matrix from fingerprint image: "
 		      << e.what();
-		throw NFIQ::NFIQException(
-		    NFIQ::e_Error_FeatureCalculationError, ssErr.str());
+		throw NFIQ2::NFIQException(
+		    NFIQ2::e_Error_FeatureCalculationError, ssErr.str());
 	}
 
 	try {
@@ -69,27 +70,27 @@ NFIQ::QualityFeatures::QualityMapFeatures::computeFeatureData(
 		    this->imgProcResults_);
 
 		// return features based on coherence values of orientation map
-		NFIQ::QualityFeatureData fd_om_2;
+		NFIQ2::QualityFeatureData fd_om_2;
 		fd_om_2.featureID = "OrientationMap_ROIFilter_CoherenceRel";
-		fd_om_2.featureDataType = NFIQ::e_QualityFeatureDataTypeDouble;
+		fd_om_2.featureDataType = NFIQ2::e_QualityFeatureDataTypeDouble;
 		fd_om_2.featureDataDouble = coherenceRelFilter;
-		NFIQ::QualityFeatureResult res_om_2;
+		NFIQ2::QualityFeatureResult res_om_2;
 		res_om_2.featureData = fd_om_2;
 		res_om_2.returnCode = 0;
 
 		featureDataList.push_back(res_om_2);
 
-		NFIQ::QualityFeatureData fd_om_1;
+		NFIQ2::QualityFeatureData fd_om_1;
 		fd_om_1.featureID = "OrientationMap_ROIFilter_CoherenceSum";
-		fd_om_1.featureDataType = NFIQ::e_QualityFeatureDataTypeDouble;
+		fd_om_1.featureDataType = NFIQ2::e_QualityFeatureDataTypeDouble;
 		fd_om_1.featureDataDouble = coherenceSumFilter;
-		NFIQ::QualityFeatureResult res_om_1;
+		NFIQ2::QualityFeatureResult res_om_1;
 		res_om_1.featureData = fd_om_1;
 		res_om_1.returnCode = 0;
 
 		featureDataList.push_back(res_om_1);
 
-		NFIQ::QualityFeatureSpeed speed;
+		NFIQ2::QualityFeatureSpeed speed;
 		speed.featureIDGroup = QualityMapFeatures::speedFeatureIDGroup;
 		speed.featureIDs.push_back(
 		    "OrientationMap_ROIFilter_CoherenceSum");
@@ -101,9 +102,9 @@ NFIQ::QualityFeatures::QualityMapFeatures::computeFeatureData(
 	} catch (const cv::Exception &e) {
 		std::stringstream ssErr;
 		ssErr << "Cannot compute orientation map: " << e.what();
-		throw NFIQ::NFIQException(
-		    NFIQ::e_Error_FeatureCalculationError, ssErr.str());
-	} catch (const NFIQ::NFIQException &) {
+		throw NFIQ2::NFIQException(
+		    NFIQ2::e_Error_FeatureCalculationError, ssErr.str());
+	} catch (const NFIQ2::NFIQException &) {
 		throw;
 	}
 
@@ -111,7 +112,7 @@ NFIQ::QualityFeatures::QualityMapFeatures::computeFeatureData(
 }
 
 cv::Mat
-NFIQ::QualityFeatures::QualityMapFeatures::computeOrientationMap(cv::Mat &img,
+NFIQ2::QualityFeatures::QualityMapFeatures::computeOrientationMap(cv::Mat &img,
     bool bFilterByROI, double &coherenceSum, double &coherenceRel,
     unsigned int bs, ImgProcROIFeature::ImgProcROIResults roiResults)
 {
@@ -225,7 +226,7 @@ NFIQ::QualityFeatures::QualityMapFeatures::computeOrientationMap(cv::Mat &img,
 }
 
 bool
-NFIQ::QualityFeatures::QualityMapFeatures::getAngleOfBlock(
+NFIQ2::QualityFeatures::QualityMapFeatures::getAngleOfBlock(
     const cv::Mat &block, double &angle, double &coherence)
 {
 	// compute the numerical gradients of the block
@@ -286,7 +287,7 @@ NFIQ::QualityFeatures::QualityMapFeatures::getAngleOfBlock(
 }
 
 cv::Mat
-NFIQ::QualityFeatures::QualityMapFeatures::computeNumericalGradientX(
+NFIQ2::QualityFeatures::QualityMapFeatures::computeNumericalGradientX(
     const cv::Mat &mat)
 {
 	cv::Mat out(mat.rows, mat.cols, CV_64F, cv::Scalar(0));
@@ -308,7 +309,7 @@ NFIQ::QualityFeatures::QualityMapFeatures::computeNumericalGradientX(
 }
 
 void
-NFIQ::QualityFeatures::QualityMapFeatures::computeNumericalGradients(
+NFIQ2::QualityFeatures::QualityMapFeatures::computeNumericalGradients(
     const cv::Mat &mat, cv::Mat &grad_x, cv::Mat &grad_y)
 {
 	// get x-gradient
@@ -318,17 +319,17 @@ NFIQ::QualityFeatures::QualityMapFeatures::computeNumericalGradients(
 	grad_y = computeNumericalGradientX(mat.t()).t();
 }
 
-const std::string NFIQ::QualityFeatures::QualityMapFeatures::moduleName {
+const std::string NFIQ2::QualityFeatures::QualityMapFeatures::moduleName {
 	"NFIQ2_QualityMap"
 };
 std::string
-NFIQ::QualityFeatures::QualityMapFeatures::getModuleName() const
+NFIQ2::QualityFeatures::QualityMapFeatures::getModuleName() const
 {
 	return moduleName;
 }
 
 std::vector<std::string>
-NFIQ::QualityFeatures::QualityMapFeatures::getAllFeatureIDs()
+NFIQ2::QualityFeatures::QualityMapFeatures::getAllFeatureIDs()
 {
 	std::vector<std::string> featureIDs;
 	featureIDs.push_back("OrientationMap_ROIFilter_CoherenceRel");

--- a/NFIQ2/NFIQ2Algorithm/src/features/RVUPHistogramFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/RVUPHistogramFeature.cpp
@@ -17,27 +17,28 @@ void rvuhist(cv::Mat block, const double orientation, const int v1sz_x,
     const int v1sz_y, bool padFlag, std::vector<double> &ratios,
     std::vector<uint8_t> &Nans);
 
-NFIQ::QualityFeatures::RVUPHistogramFeature::RVUPHistogramFeature(
-    const NFIQ::FingerprintImageData &fingerprintImage)
+NFIQ2::QualityFeatures::RVUPHistogramFeature::RVUPHistogramFeature(
+    const NFIQ2::FingerprintImageData &fingerprintImage)
 {
 	this->setFeatures(computeFeatureData(fingerprintImage));
 }
 
-NFIQ::QualityFeatures::RVUPHistogramFeature::~RVUPHistogramFeature() = default;
+NFIQ2::QualityFeatures::RVUPHistogramFeature::~RVUPHistogramFeature() = default;
 
 const std::string
-    NFIQ::QualityFeatures::RVUPHistogramFeature::speedFeatureIDGroup =
+    NFIQ2::QualityFeatures::RVUPHistogramFeature::speedFeatureIDGroup =
 	"Ridge valley uniformity";
 
-std::vector<NFIQ::QualityFeatureResult>
-NFIQ::QualityFeatures::RVUPHistogramFeature::computeFeatureData(
-    const NFIQ::FingerprintImageData &fingerprintImage)
+std::vector<NFIQ2::QualityFeatureResult>
+NFIQ2::QualityFeatures::RVUPHistogramFeature::computeFeatureData(
+    const NFIQ2::FingerprintImageData &fingerprintImage)
 {
-	std::vector<NFIQ::QualityFeatureResult> featureDataList;
+	std::vector<NFIQ2::QualityFeatureResult> featureDataList;
 
 	// check if input image has 500 dpi
-	if (fingerprintImage.m_ImageDPI != NFIQ::e_ImageResolution_500dpi) {
-		throw NFIQ::NFIQException(NFIQ::e_Error_FeatureCalculationError,
+	if (fingerprintImage.m_ImageDPI != NFIQ2::e_ImageResolution_500dpi) {
+		throw NFIQ2::NFIQException(
+		    NFIQ2::e_Error_FeatureCalculationError,
 		    "Only 500 dpi fingerprint images are supported!");
 	}
 
@@ -51,15 +52,15 @@ NFIQ::QualityFeatures::RVUPHistogramFeature::computeFeatureData(
 		std::stringstream ssErr;
 		ssErr << "Cannot get matrix from fingerprint image: "
 		      << e.what();
-		throw NFIQ::NFIQException(
-		    NFIQ::e_Error_FeatureCalculationError, ssErr.str());
+		throw NFIQ2::NFIQException(
+		    NFIQ2::e_Error_FeatureCalculationError, ssErr.str());
 	}
 
 	// ----------
 	// compute RVU
 	// ----------
 
-	NFIQ::Timer timerRVU;
+	NFIQ2::Timer timerRVU;
 	double timeRVU = 0.0;
 	try {
 		timerRVU.start();
@@ -162,7 +163,7 @@ NFIQ::QualityFeatures::RVUPHistogramFeature::computeFeatureData(
 
 		timeRVU = timerRVU.stop();
 
-		NFIQ::QualityFeatureSpeed speed;
+		NFIQ2::QualityFeatureSpeed speed;
 		speed.featureIDGroup =
 		    RVUPHistogramFeature::speedFeatureIDGroup;
 
@@ -174,29 +175,30 @@ NFIQ::QualityFeatures::RVUPHistogramFeature::computeFeatureData(
 	} catch (const cv::Exception &e) {
 		std::stringstream ssErr;
 		ssErr << "Cannot compute RVU: " << e.what();
-		throw NFIQ::NFIQException(
-		    NFIQ::e_Error_FeatureCalculationError, ssErr.str());
-	} catch (const NFIQ::NFIQException &) {
+		throw NFIQ2::NFIQException(
+		    NFIQ2::e_Error_FeatureCalculationError, ssErr.str());
+	} catch (const NFIQ2::NFIQException &) {
 		throw;
 	} catch (...) {
-		throw NFIQ::NFIQException(NFIQ::e_Error_FeatureCalculationError,
+		throw NFIQ2::NFIQException(
+		    NFIQ2::e_Error_FeatureCalculationError,
 		    "Unknown exception occurred!");
 	}
 	return featureDataList;
 }
 
-const std::string NFIQ::QualityFeatures::RVUPHistogramFeature::moduleName {
+const std::string NFIQ2::QualityFeatures::RVUPHistogramFeature::moduleName {
 	"NFIQ2_RVUPHistogram"
 };
 
 std::string
-NFIQ::QualityFeatures::RVUPHistogramFeature::getModuleName() const
+NFIQ2::QualityFeatures::RVUPHistogramFeature::getModuleName() const
 {
 	return "NFIQ2_RVUPHistogram";
 }
 
 std::vector<std::string>
-NFIQ::QualityFeatures::RVUPHistogramFeature::getAllFeatureIDs()
+NFIQ2::QualityFeatures::RVUPHistogramFeature::getAllFeatureIDs()
 {
 	std::vector<std::string> featureIDs;
 	addHistogramFeatureNames(featureIDs, "RVUP_Bin10_", 10);
@@ -241,8 +243,8 @@ rvuhist(cv::Mat block, const double orientation, const int v1sz_x,
 	float cBlock = static_cast<float>(block.rows) / 2; // square block
 	int icBlock = static_cast<int>(cBlock);
 	if (icBlock != cBlock) {
-		throw NFIQ::NFIQException {
-			NFIQ::e_Error_FeatureCalculationError,
+		throw NFIQ2::NFIQException {
+			NFIQ2::e_Error_FeatureCalculationError,
 			"Wrong block size! Consider block with size of even number "
 			"(block rows = " +
 			    std::to_string(block.rows) + ')'
@@ -250,7 +252,7 @@ rvuhist(cv::Mat block, const double orientation, const int v1sz_x,
 	}
 
 	cv::Mat blockRotated;
-	NFIQ::QualityFeatures::getRotatedBlock(
+	NFIQ2::QualityFeatures::getRotatedBlock(
 	    block, orientation, padFlag, blockRotated);
 
 	//% set x and y
@@ -271,7 +273,7 @@ rvuhist(cv::Mat block, const double orientation, const int v1sz_x,
 
 	std::vector<uint8_t> ridval;
 	std::vector<double> dt;
-	NFIQ::QualityFeatures::getRidgeValleyStructure(
+	NFIQ2::QualityFeatures::getRidgeValleyStructure(
 	    blockCropped, ridval, dt);
 
 	// Ridge-valley thickness

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/data.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/data.cpp
@@ -3,31 +3,31 @@
 #include <iomanip>
 #include <sstream>
 
-NFIQ::Data::Data()
+NFIQ2::Data::Data()
 {
 }
 
-NFIQ::Data::Data(const uint8_t *pData, uint32_t dataSize)
+NFIQ2::Data::Data(const uint8_t *pData, uint32_t dataSize)
     : std::basic_string<uint8_t>(pData, dataSize)
 {
 }
 
-NFIQ::Data::Data(const Data &otherData)
+NFIQ2::Data::Data(const Data &otherData)
     : std::basic_string<uint8_t>(otherData)
 {
 }
 
-NFIQ::Data::Data(const std::basic_string<uint8_t> &otherData)
+NFIQ2::Data::Data(const std::basic_string<uint8_t> &otherData)
     : std::basic_string<uint8_t>(otherData)
 {
 }
 
-NFIQ::Data::~Data()
+NFIQ2::Data::~Data()
 {
 }
 
 void
-NFIQ::Data::writeToFile(const std::string &filename) const
+NFIQ2::Data::writeToFile(const std::string &filename) const
 {
 	bool success = false;
 	if (!filename.empty()) {
@@ -40,17 +40,17 @@ NFIQ::Data::writeToFile(const std::string &filename) const
 					    // incomplete or failed
 			f.close();
 		} else {
-			throw NFIQ::NFIQException(
-			    NFIQ::e_Error_CannotWriteToFile);
+			throw NFIQ2::NFIQException(
+			    NFIQ2::e_Error_CannotWriteToFile);
 		}
 	}
 	if (!success) {
-		throw NFIQ::NFIQException(NFIQ::e_Error_CannotWriteToFile);
+		throw NFIQ2::NFIQException(NFIQ2::e_Error_CannotWriteToFile);
 	}
 }
 
 void
-NFIQ::Data::readFromFile(const std::string &filename)
+NFIQ2::Data::readFromFile(const std::string &filename)
 {
 	bool success = false;
 	if (!filename.empty()) {
@@ -78,20 +78,20 @@ NFIQ::Data::readFromFile(const std::string &filename)
 				success = true;
 			}
 		} else {
-			throw NFIQ::NFIQException(
-			    NFIQ::e_Error_CannotReadFromFile);
+			throw NFIQ2::NFIQException(
+			    NFIQ2::e_Error_CannotReadFromFile);
 		}
 	}
 	if (!success) {
-		throw NFIQ::NFIQException(NFIQ::e_Error_CannotReadFromFile);
+		throw NFIQ2::NFIQException(NFIQ2::e_Error_CannotReadFromFile);
 	}
 }
 
 std::string
-NFIQ::Data::toHexString() const
+NFIQ2::Data::toHexString() const
 {
 	if (this->size() <= 0) {
-		throw NFIQ::NFIQException(NFIQ::e_Error_NoDataAvailable);
+		throw NFIQ2::NFIQException(NFIQ2::e_Error_NoDataAvailable);
 	}
 
 	std::stringstream ss;
@@ -109,7 +109,7 @@ NFIQ::Data::toHexString() const
 }
 
 void
-NFIQ::Data::fromBase64String(const std::string &base64String)
+NFIQ2::Data::fromBase64String(const std::string &base64String)
 {
 	const char *ptr = base64String.data();
 	size_t len = base64String.size();
@@ -160,12 +160,12 @@ NFIQ::Data::fromBase64String(const std::string &base64String)
 	}
 
 	if (!ok) {
-		throw NFIQ::NFIQException(NFIQ::e_Error_CannotDecodeBase64);
+		throw NFIQ2::NFIQException(NFIQ2::e_Error_CannotDecodeBase64);
 	}
 }
 
 std::string
-NFIQ::Data::toBase64String() const
+NFIQ2::Data::toBase64String() const
 {
 	const char base64Lookup[65] = { 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H',
 		'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U',

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/fingerprintimagedata.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/fingerprintimagedata.cpp
@@ -9,16 +9,16 @@ int debug = 0;
 static double computeMuFromRow(unsigned int rowIndex, cv::Mat &img);
 static double computeMuFromColumn(unsigned int columnIndex, cv::Mat &img);
 
-NFIQ::FingerprintImageData::FingerprintImageData()
+NFIQ2::FingerprintImageData::FingerprintImageData()
     : Data()
     , m_ImageWidth(0)
     , m_ImageHeight(0)
     , m_FingerCode(0)
-    , m_ImageDPI(NFIQ::e_ImageResolution_500dpi)
+    , m_ImageDPI(NFIQ2::e_ImageResolution_500dpi)
 {
 }
 
-NFIQ::FingerprintImageData::FingerprintImageData(uint32_t imageWidth,
+NFIQ2::FingerprintImageData::FingerprintImageData(uint32_t imageWidth,
     uint32_t imageHeight, uint8_t fingerCode, uint16_t imageDPI)
     : Data()
     , m_ImageWidth(imageWidth)
@@ -28,7 +28,7 @@ NFIQ::FingerprintImageData::FingerprintImageData(uint32_t imageWidth,
 {
 }
 
-NFIQ::FingerprintImageData::FingerprintImageData(const uint8_t *pData,
+NFIQ2::FingerprintImageData::FingerprintImageData(const uint8_t *pData,
     uint32_t dataSize, uint32_t imageWidth, uint32_t imageHeight,
     uint8_t fingerCode, uint16_t imageDPI)
     : Data(pData, dataSize)
@@ -39,7 +39,7 @@ NFIQ::FingerprintImageData::FingerprintImageData(const uint8_t *pData,
 {
 }
 
-NFIQ::FingerprintImageData::FingerprintImageData(
+NFIQ2::FingerprintImageData::FingerprintImageData(
     const FingerprintImageData &otherData)
     : Data(otherData)
 {
@@ -49,15 +49,15 @@ NFIQ::FingerprintImageData::FingerprintImageData(
 	m_ImageDPI = otherData.m_ImageDPI;
 }
 
-NFIQ::FingerprintImageData::~FingerprintImageData()
+NFIQ2::FingerprintImageData::~FingerprintImageData()
 {
 }
 
-NFIQ::FingerprintImageData
-NFIQ::FingerprintImageData::removeWhiteFrameAroundFingerprint() const
+NFIQ2::FingerprintImageData
+NFIQ2::FingerprintImageData::removeWhiteFrameAroundFingerprint() const
 {
 	// make local copy of internal fingerprint image
-	NFIQ::FingerprintImageData localFingerprintImage(this->m_ImageWidth,
+	NFIQ2::FingerprintImageData localFingerprintImage(this->m_ImageWidth,
 	    this->m_ImageHeight, this->m_FingerCode, this->m_ImageDPI);
 	// copy data now
 	localFingerprintImage.resize(this->size());
@@ -74,8 +74,8 @@ NFIQ::FingerprintImageData::removeWhiteFrameAroundFingerprint() const
 		std::stringstream ssErr;
 		ssErr << "Cannot get matrix from fingerprint image: "
 		      << e.what();
-		throw NFIQ::NFIQException(
-		    NFIQ::e_Error_FeatureCalculationError, ssErr.str());
+		throw NFIQ2::NFIQException(
+		    NFIQ2::e_Error_FeatureCalculationError, ssErr.str());
 	}
 
 	// start from top of image and find top row index that is already part
@@ -164,28 +164,28 @@ NFIQ::FingerprintImageData::removeWhiteFrameAroundFingerprint() const
 
 	// Values are from FJFX image size thresholds
 	if (roiImg.cols <= fingerJetMinWidth) {
-		throw NFIQ::NFIQException(NFIQ::e_Error_InvalidImageSize,
+		throw NFIQ2::NFIQException(NFIQ2::e_Error_InvalidImageSize,
 		    "Width is too small after trimming whitespace. WxH: " +
 			std::to_string(roiImg.cols) + "x" +
 			std::to_string(roiImg.rows) +
 			", but minimum width is " +
 			std::to_string(fingerJetMinWidth + 1));
 	} else if (roiImg.cols >= fingerJetMaxWidth) {
-		throw NFIQ::NFIQException(NFIQ::e_Error_InvalidImageSize,
+		throw NFIQ2::NFIQException(NFIQ2::e_Error_InvalidImageSize,
 		    "Width is too large after trimming whitespace. WxH: " +
 			std::to_string(roiImg.cols) + "x" +
 			std::to_string(roiImg.rows) +
 			", but maximum width is " +
 			std::to_string(fingerJetMaxWidth - 1));
 	} else if (roiImg.rows <= fingerJetMinHeight) {
-		throw NFIQ::NFIQException(NFIQ::e_Error_InvalidImageSize,
+		throw NFIQ2::NFIQException(NFIQ2::e_Error_InvalidImageSize,
 		    "Height is too small after trimming whitespace. WxH: " +
 			std::to_string(roiImg.cols) + "x" +
 			std::to_string(roiImg.rows) +
 			", but minimum height is " +
 			std::to_string(fingerJetMinHeight + 1));
 	} else if (roiImg.rows >= fingerJetMaxHeight) {
-		throw NFIQ::NFIQException(NFIQ::e_Error_InvalidImageSize,
+		throw NFIQ2::NFIQException(NFIQ2::e_Error_InvalidImageSize,
 		    "Height is too large after trimming whitespace. WxH: " +
 			std::to_string(roiImg.cols) + "x" +
 			std::to_string(roiImg.rows) +
@@ -193,7 +193,7 @@ NFIQ::FingerprintImageData::removeWhiteFrameAroundFingerprint() const
 			std::to_string(fingerJetMaxHeight - 1));
 	}
 
-	NFIQ::FingerprintImageData croppedImage;
+	NFIQ2::FingerprintImageData croppedImage;
 	croppedImage.m_ImageHeight = roiImg.rows;
 	croppedImage.m_ImageWidth = roiImg.cols;
 	croppedImage.m_FingerCode = this->m_FingerCode;

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/modelinfo.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/modelinfo.cpp
@@ -8,24 +8,24 @@
 
 static std::string trimWhitespace(const std::string &s);
 
-const std::string NFIQ::ModelInfo::ModelInfoKeyName = "Name";
-const std::string NFIQ::ModelInfo::ModelInfoKeyTrainer = "Trainer";
-const std::string NFIQ::ModelInfo::ModelInfoKeyDescription = "Description";
-const std::string NFIQ::ModelInfo::ModelInfoKeyVersion = "Version";
-const std::string NFIQ::ModelInfo::ModelInfoKeyPath = "Path";
-const std::string NFIQ::ModelInfo::ModelInfoKeyHash = "Hash";
+const std::string NFIQ2::ModelInfo::ModelInfoKeyName = "Name";
+const std::string NFIQ2::ModelInfo::ModelInfoKeyTrainer = "Trainer";
+const std::string NFIQ2::ModelInfo::ModelInfoKeyDescription = "Description";
+const std::string NFIQ2::ModelInfo::ModelInfoKeyVersion = "Version";
+const std::string NFIQ2::ModelInfo::ModelInfoKeyPath = "Path";
+const std::string NFIQ2::ModelInfo::ModelInfoKeyHash = "Hash";
 
-NFIQ::ModelInfo::ModelInfo()
+NFIQ2::ModelInfo::ModelInfo()
 {
 }
 
-NFIQ::ModelInfo::ModelInfo(const std::string &modelInfoFilePath)
+NFIQ2::ModelInfo::ModelInfo(const std::string &modelInfoFilePath)
 {
 	std::ifstream fp(modelInfoFilePath);
 	std::string line;
 
 	if (!fp) {
-		throw NFIQ::NFIQException(e_Error_CannotReadFromFile,
+		throw NFIQ2::NFIQException(e_Error_CannotReadFromFile,
 		    "Failed to Read File: " + modelInfoFilePath);
 	}
 
@@ -101,49 +101,49 @@ NFIQ::ModelInfo::ModelInfo(const std::string &modelInfoFilePath)
 	fp.close();
 
 	if (this->modelPath.empty()) {
-		throw NFIQ::NFIQException(e_Error_NoDataAvailable,
+		throw NFIQ2::NFIQException(e_Error_NoDataAvailable,
 		    "The required model information: " +
 			ModelInfo::ModelInfoKeyPath + " was not found.");
 	}
 	if (this->modelHash.empty()) {
-		throw NFIQ::NFIQException(e_Error_NoDataAvailable,
+		throw NFIQ2::NFIQException(e_Error_NoDataAvailable,
 		    "The required model information: " +
 			ModelInfo::ModelInfoKeyHash + " was not found.");
 	}
 }
 
 std::string
-NFIQ::ModelInfo::getModelName() const
+NFIQ2::ModelInfo::getModelName() const
 {
 	return this->modelName;
 }
 
 std::string
-NFIQ::ModelInfo::getModelTrainer() const
+NFIQ2::ModelInfo::getModelTrainer() const
 {
 	return this->modelTrainer;
 }
 
 std::string
-NFIQ::ModelInfo::getModelDescription() const
+NFIQ2::ModelInfo::getModelDescription() const
 {
 	return this->modelDescription;
 }
 
 std::string
-NFIQ::ModelInfo::getModelVersion() const
+NFIQ2::ModelInfo::getModelVersion() const
 {
 	return this->modelVersion;
 }
 
 std::string
-NFIQ::ModelInfo::getModelPath() const
+NFIQ2::ModelInfo::getModelPath() const
 {
 	return this->modelPath;
 }
 
 std::string
-NFIQ::ModelInfo::getModelHash() const
+NFIQ2::ModelInfo::getModelHash() const
 {
 	return this->modelHash;
 }

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_nfiq2algorithm.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_nfiq2algorithm.cpp
@@ -4,51 +4,51 @@
 #include "nfiq2_nfiq2algorithm_impl.hpp"
 
 #ifdef EMBED_RANDOMFOREST_PARAMETERS
-NFIQ::NFIQ2Algorithm::NFIQ2Algorithm()
-    : pimpl { new NFIQ::NFIQ2Algorithm::Impl() }
+NFIQ2::NFIQ2Algorithm::NFIQ2Algorithm()
+    : pimpl { new NFIQ2::NFIQ2Algorithm::Impl() }
 {
 }
 #endif
 
-NFIQ::NFIQ2Algorithm::NFIQ2Algorithm(
+NFIQ2::NFIQ2Algorithm::NFIQ2Algorithm(
     const std::string &fileName, const std::string &fileHash)
-    : pimpl { new NFIQ::NFIQ2Algorithm::Impl(fileName, fileHash) }
+    : pimpl { new NFIQ2::NFIQ2Algorithm::Impl(fileName, fileHash) }
 {
 }
 
-NFIQ::NFIQ2Algorithm::NFIQ2Algorithm(const NFIQ::ModelInfo &modelInfoObj)
-    : NFIQ::NFIQ2Algorithm { modelInfoObj.getModelPath(),
+NFIQ2::NFIQ2Algorithm::NFIQ2Algorithm(const NFIQ2::ModelInfo &modelInfoObj)
+    : NFIQ2::NFIQ2Algorithm { modelInfoObj.getModelPath(),
 	    modelInfoObj.getModelHash() }
 {
 }
 
 unsigned int
-NFIQ::NFIQ2Algorithm::computeQualityScore(
-    const NFIQ::FingerprintImageData &rawImage) const
+NFIQ2::NFIQ2Algorithm::computeQualityScore(
+    const NFIQ2::FingerprintImageData &rawImage) const
 {
 	return (this->pimpl->computeQualityScore(rawImage));
 }
 
 unsigned int
-NFIQ::NFIQ2Algorithm::computeQualityScore(
-    const std::vector<std::shared_ptr<NFIQ::QualityFeatures::BaseFeature>>
+NFIQ2::NFIQ2Algorithm::computeQualityScore(
+    const std::vector<std::shared_ptr<NFIQ2::QualityFeatures::BaseFeature>>
 	&features) const
 {
 	return (this->pimpl->computeQualityScore(features));
 }
 
 unsigned int
-NFIQ::NFIQ2Algorithm::computeQualityScore(
-    const std::unordered_map<std::string, NFIQ::QualityFeatureData> &features)
+NFIQ2::NFIQ2Algorithm::computeQualityScore(
+    const std::unordered_map<std::string, NFIQ2::QualityFeatureData> &features)
     const
 {
 	return (this->pimpl->computeQualityScore(features));
 }
 
 std::string
-NFIQ::NFIQ2Algorithm::getParameterHash() const
+NFIQ2::NFIQ2Algorithm::getParameterHash() const
 {
 	return (this->pimpl->getParameterHash());
 }
 
-NFIQ::NFIQ2Algorithm::~NFIQ2Algorithm() = default;
+NFIQ2::NFIQ2Algorithm::~NFIQ2Algorithm() = default;

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_nfiq2algorithm_impl.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_nfiq2algorithm_impl.cpp
@@ -29,7 +29,7 @@ set_fpu(unsigned int mode)
 #endif
 
 #ifdef EMBED_RANDOMFOREST_PARAMETERS
-NFIQ::NFIQ2Algorithm::Impl::Impl()
+NFIQ2::NFIQ2Algorithm::Impl::Impl()
 {
 #if defined(__linux) && defined(__i386__)
 	set_fpu(0x27F); /* use double-precision rounding */
@@ -39,7 +39,7 @@ NFIQ::NFIQ2Algorithm::Impl::Impl()
 }
 #endif
 
-NFIQ::NFIQ2Algorithm::Impl::Impl(
+NFIQ2::NFIQ2Algorithm::Impl::Impl(
     const std::string &fileName, const std::string &fileHash)
 {
 #if defined(__linux) && defined(__i386__)
@@ -56,7 +56,7 @@ NFIQ::NFIQ2Algorithm::Impl::Impl(
 		    "Check the path (" +
 			fileName + ") and hash (" + fileHash +
 			") (initial error: " + e.msg + ").");
-	} catch (const NFIQ::NFIQException &e) {
+	} catch (const NFIQ2::NFIQException &e) {
 		throw NFIQException(e_Error_BadArguments,
 		    "Could not initialize random forest parameters with "
 		    "external file. Most likely, the hash is not correct. "
@@ -66,13 +66,13 @@ NFIQ::NFIQ2Algorithm::Impl::Impl(
 	}
 }
 
-NFIQ::NFIQ2Algorithm::Impl::~Impl()
+NFIQ2::NFIQ2Algorithm::Impl::~Impl()
 {
 }
 
 double
-NFIQ::NFIQ2Algorithm::Impl::getQualityPrediction(
-    const std::unordered_map<std::string, NFIQ::QualityFeatureData> &features)
+NFIQ2::NFIQ2Algorithm::Impl::getQualityPrediction(
+    const std::unordered_map<std::string, NFIQ2::QualityFeatureData> &features)
     const
 {
 	const double utility {};
@@ -84,17 +84,17 @@ NFIQ::NFIQ2Algorithm::Impl::getQualityPrediction(
 }
 
 unsigned int
-NFIQ::NFIQ2Algorithm::Impl::computeQualityScore(
-    const std::vector<std::shared_ptr<NFIQ::QualityFeatures::BaseFeature>>
+NFIQ2::NFIQ2Algorithm::Impl::computeQualityScore(
+    const std::vector<std::shared_ptr<NFIQ2::QualityFeatures::BaseFeature>>
 	&features) const
 {
 
-	const std::unordered_map<std::string, NFIQ::QualityFeatureData>
-	    quality = NFIQ::QualityFeatures::getQualityFeatureData(features);
+	const std::unordered_map<std::string, NFIQ2::QualityFeatureData>
+	    quality = NFIQ2::QualityFeatures::getQualityFeatureData(features);
 
 	if (quality.size() == 0) {
 		// no features have been computed
-		throw NFIQ::NFIQException(e_Error_FeatureCalculationError,
+		throw NFIQ2::NFIQException(e_Error_FeatureCalculationError,
 		    "No features have been computed");
 	}
 
@@ -105,7 +105,7 @@ NFIQ::NFIQ2Algorithm::Impl::computeQualityScore(
 	double qualityScore {};
 	try {
 		qualityScore = getQualityPrediction(quality);
-	} catch (const NFIQ::NFIQException &) {
+	} catch (const NFIQ2::NFIQException &) {
 		throw;
 	}
 
@@ -113,35 +113,35 @@ NFIQ::NFIQ2Algorithm::Impl::computeQualityScore(
 }
 
 unsigned int
-NFIQ::NFIQ2Algorithm::Impl::computeQualityScore(
-    const NFIQ::FingerprintImageData &rawImage) const
+NFIQ2::NFIQ2Algorithm::Impl::computeQualityScore(
+    const NFIQ2::FingerprintImageData &rawImage) const
 {
 
 	// --------------------------------------------------------
 	// compute quality features (including actionable feedback)
 	// --------------------------------------------------------
 
-	std::vector<std::shared_ptr<NFIQ::QualityFeatures::BaseFeature>>
+	std::vector<std::shared_ptr<NFIQ2::QualityFeatures::BaseFeature>>
 	    features {};
 	try {
-		features = NFIQ::QualityFeatures::computeQualityFeatures(
+		features = NFIQ2::QualityFeatures::computeQualityFeatures(
 		    rawImage);
-	} catch (const NFIQ::NFIQException &) {
+	} catch (const NFIQ2::NFIQException &) {
 		throw;
 	} catch (const std::exception &e) {
 		/*
 		 * Nothing should get here, but computeQualityFeatures() calls
 		 * a lot of code...
 		 */
-		throw NFIQ::NFIQException(e_Error_UnknownError, e.what());
+		throw NFIQ2::NFIQException(e_Error_UnknownError, e.what());
 	}
 
-	const std::unordered_map<std::string, NFIQ::QualityFeatureData>
-	    quality = NFIQ::QualityFeatures::getQualityFeatureData(features);
+	const std::unordered_map<std::string, NFIQ2::QualityFeatureData>
+	    quality = NFIQ2::QualityFeatures::getQualityFeatureData(features);
 
 	if (quality.size() == 0) {
 		// no features have been computed
-		throw NFIQ::NFIQException(e_Error_FeatureCalculationError,
+		throw NFIQ2::NFIQException(e_Error_FeatureCalculationError,
 		    "No features have been computed");
 	}
 
@@ -152,7 +152,7 @@ NFIQ::NFIQ2Algorithm::Impl::computeQualityScore(
 	double qualityScore {};
 	try {
 		qualityScore = getQualityPrediction(quality);
-	} catch (const NFIQ::NFIQException &) {
+	} catch (const NFIQ2::NFIQException &) {
 		throw;
 	}
 
@@ -160,15 +160,15 @@ NFIQ::NFIQ2Algorithm::Impl::computeQualityScore(
 }
 
 unsigned int
-NFIQ::NFIQ2Algorithm::Impl::computeQualityScore(
-    const std::unordered_map<std::string, NFIQ::QualityFeatureData> &features)
+NFIQ2::NFIQ2Algorithm::Impl::computeQualityScore(
+    const std::unordered_map<std::string, NFIQ2::QualityFeatureData> &features)
     const
 {
 	return (unsigned int)getQualityPrediction(features);
 }
 
 std::string
-NFIQ::NFIQ2Algorithm::Impl::getParameterHash() const
+NFIQ2::NFIQ2Algorithm::Impl::getParameterHash() const
 {
 	return (this->m_parameterHash);
 }

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_nfiq2algorithm_impl.hpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_nfiq2algorithm_impl.hpp
@@ -12,7 +12,7 @@
 #include <string>
 #include <vector>
 
-namespace NFIQ {
+namespace NFIQ2 {
 /**
 ******************************************************************************
 * @class Impl
@@ -50,7 +50,7 @@ class NFIQ2Algorithm::Impl {
 	 * @return achieved quality score
 	 */
 	unsigned int computeQualityScore(
-	    const NFIQ::FingerprintImageData &rawImage) const;
+	    const NFIQ2::FingerprintImageData &rawImage) const;
 
 	/**
 	 * @fn computeQualityScore
@@ -61,7 +61,7 @@ class NFIQ2Algorithm::Impl {
 	 * @return achieved quality score
 	 */
 	unsigned int computeQualityScore(const std::vector<
-	    std::shared_ptr<NFIQ::QualityFeatures::BaseFeature>> &features)
+	    std::shared_ptr<NFIQ2::QualityFeatures::BaseFeature>> &features)
 	    const;
 
 	/**
@@ -72,7 +72,7 @@ class NFIQ2Algorithm::Impl {
 	 * @return achieved quality score
 	 */
 	unsigned int computeQualityScore(
-	    const std::unordered_map<std::string, NFIQ::QualityFeatureData>
+	    const std::unordered_map<std::string, NFIQ2::QualityFeatureData>
 		&features) const;
 
 	/**
@@ -90,13 +90,13 @@ class NFIQ2Algorithm::Impl {
 	 * Failure to compute (OpenCV reason contained within message string).
 	 */
 	double getQualityPrediction(
-	    const std::unordered_map<std::string, NFIQ::QualityFeatureData>
+	    const std::unordered_map<std::string, NFIQ2::QualityFeatureData>
 		&features) const;
 
-	NFIQ::Prediction::RandomForestML m_RandomForestML;
+	NFIQ2::Prediction::RandomForestML m_RandomForestML;
 	std::string m_parameterHash {};
 };
-} // namespace NFIQ
+} // namespace NFIQ2
 
 #endif
 

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures.cpp
@@ -5,65 +5,65 @@
 #include <vector>
 
 std::vector<std::string>
-NFIQ::QualityFeatures::getAllActionableIdentifiers()
+NFIQ2::QualityFeatures::getAllActionableIdentifiers()
 {
-	return NFIQ::QualityFeatures::Impl::getAllActionableIdentifiers();
+	return NFIQ2::QualityFeatures::Impl::getAllActionableIdentifiers();
 }
 
 std::vector<std::string>
-NFIQ::QualityFeatures::getAllQualityFeatureIDs()
+NFIQ2::QualityFeatures::getAllQualityFeatureIDs()
 {
-	return NFIQ::QualityFeatures::Impl::getAllQualityFeatureIDs();
+	return NFIQ2::QualityFeatures::Impl::getAllQualityFeatureIDs();
 }
 
 std::vector<std::string>
-NFIQ::QualityFeatures::getAllSpeedFeatureGroups()
+NFIQ2::QualityFeatures::getAllSpeedFeatureGroups()
 {
-	return NFIQ::QualityFeatures::Impl::getAllSpeedFeatureGroups();
+	return NFIQ2::QualityFeatures::Impl::getAllSpeedFeatureGroups();
 }
 
-std::vector<std::shared_ptr<NFIQ::QualityFeatures::BaseFeature>>
-NFIQ::QualityFeatures::computeQualityFeatures(
-    const NFIQ::FingerprintImageData &rawImage)
+std::vector<std::shared_ptr<NFIQ2::QualityFeatures::BaseFeature>>
+NFIQ2::QualityFeatures::computeQualityFeatures(
+    const NFIQ2::FingerprintImageData &rawImage)
 {
-	return NFIQ::QualityFeatures::Impl::computeQualityFeatures(rawImage);
+	return NFIQ2::QualityFeatures::Impl::computeQualityFeatures(rawImage);
 }
 
-std::unordered_map<std::string, NFIQ::ActionableQualityFeedback>
-NFIQ::QualityFeatures::getActionableQualityFeedback(
-    const std::vector<std::shared_ptr<NFIQ::QualityFeatures::BaseFeature>>
+std::unordered_map<std::string, NFIQ2::ActionableQualityFeedback>
+NFIQ2::QualityFeatures::getActionableQualityFeedback(
+    const std::vector<std::shared_ptr<NFIQ2::QualityFeatures::BaseFeature>>
 	&features)
 {
-	return NFIQ::QualityFeatures::Impl::getActionableQualityFeedback(
+	return NFIQ2::QualityFeatures::Impl::getActionableQualityFeedback(
 	    features);
 }
-std::unordered_map<std::string, NFIQ::ActionableQualityFeedback>
-NFIQ::QualityFeatures::getActionableQualityFeedback(
-    const NFIQ::FingerprintImageData &rawImage)
+std::unordered_map<std::string, NFIQ2::ActionableQualityFeedback>
+NFIQ2::QualityFeatures::getActionableQualityFeedback(
+    const NFIQ2::FingerprintImageData &rawImage)
 {
-	return NFIQ::QualityFeatures::Impl::getActionableQualityFeedback(
+	return NFIQ2::QualityFeatures::Impl::getActionableQualityFeedback(
 	    rawImage);
 }
 
-std::unordered_map<std::string, NFIQ::QualityFeatureData>
-NFIQ::QualityFeatures::getQualityFeatureData(
-    const std::vector<std::shared_ptr<NFIQ::QualityFeatures::BaseFeature>>
+std::unordered_map<std::string, NFIQ2::QualityFeatureData>
+NFIQ2::QualityFeatures::getQualityFeatureData(
+    const std::vector<std::shared_ptr<NFIQ2::QualityFeatures::BaseFeature>>
 	&features)
 {
-	return NFIQ::QualityFeatures::Impl::getQualityFeatureData(features);
+	return NFIQ2::QualityFeatures::Impl::getQualityFeatureData(features);
 }
 
-std::unordered_map<std::string, NFIQ::QualityFeatureData>
-NFIQ::QualityFeatures::getQualityFeatureData(
-    const NFIQ::FingerprintImageData &rawImage)
+std::unordered_map<std::string, NFIQ2::QualityFeatureData>
+NFIQ2::QualityFeatures::getQualityFeatureData(
+    const NFIQ2::FingerprintImageData &rawImage)
 {
-	return NFIQ::QualityFeatures::Impl::getQualityFeatureData(rawImage);
+	return NFIQ2::QualityFeatures::Impl::getQualityFeatureData(rawImage);
 }
 
-std::unordered_map<std::string, NFIQ::QualityFeatureSpeed>
-NFIQ::QualityFeatures::getQualityFeatureSpeeds(
-    const std::vector<std::shared_ptr<NFIQ::QualityFeatures::BaseFeature>>
+std::unordered_map<std::string, NFIQ2::QualityFeatureSpeed>
+NFIQ2::QualityFeatures::getQualityFeatureSpeeds(
+    const std::vector<std::shared_ptr<NFIQ2::QualityFeatures::BaseFeature>>
 	&features)
 {
-	return NFIQ::QualityFeatures::Impl::getQualityFeatureSpeeds(features);
+	return NFIQ2::QualityFeatures::Impl::getQualityFeatureSpeeds(features);
 }

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures_impl.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures_impl.cpp
@@ -21,15 +21,15 @@
 #include <unordered_map>
 #include <vector>
 
-std::unordered_map<std::string, NFIQ::QualityFeatureSpeed>
-NFIQ::QualityFeatures::Impl::getQualityFeatureSpeeds(
-    const std::vector<std::shared_ptr<NFIQ::QualityFeatures::BaseFeature>>
+std::unordered_map<std::string, NFIQ2::QualityFeatureSpeed>
+NFIQ2::QualityFeatures::Impl::getQualityFeatureSpeeds(
+    const std::vector<std::shared_ptr<NFIQ2::QualityFeatures::BaseFeature>>
 	&features)
 {
 	std::vector<std::string> speedIdentifiers =
-	    NFIQ::QualityFeatures::getAllSpeedFeatureGroups();
+	    NFIQ2::QualityFeatures::getAllSpeedFeatureGroups();
 
-	std::unordered_map<std::string, NFIQ::QualityFeatureSpeed> speedMap {};
+	std::unordered_map<std::string, NFIQ2::QualityFeatureSpeed> speedMap {};
 
 	for (auto i = 0; i < speedIdentifiers.size(); i++) {
 		speedMap[speedIdentifiers.at(i)] = features.at(i)->getSpeed();
@@ -38,23 +38,23 @@ NFIQ::QualityFeatures::Impl::getQualityFeatureSpeeds(
 	return speedMap;
 }
 
-std::unordered_map<std::string, NFIQ::QualityFeatureData>
-NFIQ::QualityFeatures::Impl::getQualityFeatureData(
-    const NFIQ::FingerprintImageData &rawImage)
+std::unordered_map<std::string, NFIQ2::QualityFeatureData>
+NFIQ2::QualityFeatures::Impl::getQualityFeatureData(
+    const NFIQ2::FingerprintImageData &rawImage)
 {
-	return NFIQ::QualityFeatures::getQualityFeatureData(
-	    NFIQ::QualityFeatures::computeQualityFeatures(rawImage));
+	return NFIQ2::QualityFeatures::getQualityFeatureData(
+	    NFIQ2::QualityFeatures::computeQualityFeatures(rawImage));
 }
 
-std::unordered_map<std::string, NFIQ::QualityFeatureData>
-NFIQ::QualityFeatures::Impl::getQualityFeatureData(
-    const std::vector<std::shared_ptr<NFIQ::QualityFeatures::BaseFeature>>
+std::unordered_map<std::string, NFIQ2::QualityFeatureData>
+NFIQ2::QualityFeatures::Impl::getQualityFeatureData(
+    const std::vector<std::shared_ptr<NFIQ2::QualityFeatures::BaseFeature>>
 	&features)
 {
 	std::vector<std::string> qualityIdentifiers =
-	    NFIQ::QualityFeatures::Impl::getAllQualityFeatureIDs();
+	    NFIQ2::QualityFeatures::Impl::getAllQualityFeatureIDs();
 
-	std::unordered_map<std::string, NFIQ::QualityFeatureData> quality {};
+	std::unordered_map<std::string, NFIQ2::QualityFeatureData> quality {};
 
 	auto counter = 0;
 	for (const auto &feature : features) {
@@ -74,20 +74,20 @@ NFIQ::QualityFeatures::Impl::getQualityFeatureData(
 	return quality;
 }
 
-std::unordered_map<std::string, NFIQ::ActionableQualityFeedback>
-NFIQ::QualityFeatures::Impl::getActionableQualityFeedback(
-    const NFIQ::FingerprintImageData &rawImage)
+std::unordered_map<std::string, NFIQ2::ActionableQualityFeedback>
+NFIQ2::QualityFeatures::Impl::getActionableQualityFeedback(
+    const NFIQ2::FingerprintImageData &rawImage)
 {
-	return NFIQ::QualityFeatures::getActionableQualityFeedback(
-	    NFIQ::QualityFeatures::computeQualityFeatures(rawImage));
+	return NFIQ2::QualityFeatures::getActionableQualityFeedback(
+	    NFIQ2::QualityFeatures::computeQualityFeatures(rawImage));
 }
 
-std::unordered_map<std::string, NFIQ::ActionableQualityFeedback>
-NFIQ::QualityFeatures::Impl::getActionableQualityFeedback(
-    const std::vector<std::shared_ptr<NFIQ::QualityFeatures::BaseFeature>>
+std::unordered_map<std::string, NFIQ2::ActionableQualityFeedback>
+NFIQ2::QualityFeatures::Impl::getActionableQualityFeedback(
+    const std::vector<std::shared_ptr<NFIQ2::QualityFeatures::BaseFeature>>
 	&features)
 {
-	std::unordered_map<std::string, NFIQ::ActionableQualityFeedback>
+	std::unordered_map<std::string, NFIQ2::ActionableQualityFeedback>
 	    actionableMap {};
 
 	for (const auto feature : features) {
@@ -96,17 +96,17 @@ NFIQ::QualityFeatures::Impl::getActionableQualityFeedback(
 			const std::shared_ptr<MuFeature> muFeatureModule =
 			    std::dynamic_pointer_cast<MuFeature>(feature);
 
-			std::vector<NFIQ::QualityFeatureResult> muFeatures =
+			std::vector<NFIQ2::QualityFeatureResult> muFeatures =
 			    muFeatureModule->getFeatures();
 
-			std::vector<NFIQ::QualityFeatureResult>::iterator
+			std::vector<NFIQ2::QualityFeatureResult>::iterator
 			    it_muFeatures;
 			// check for uniform image by using the Sigma value
 			bool isUniformImage = false;
-			NFIQ::ActionableQualityFeedback fbUniform;
+			NFIQ2::ActionableQualityFeedback fbUniform;
 			fbUniform.actionableQualityValue =
 			    muFeatureModule->getSigma();
-			fbUniform.identifier = NFIQ::
+			fbUniform.identifier = NFIQ2::
 			    ActionableQualityFeedbackIdentifier::UniformImage;
 			isUniformImage = (fbUniform.actionableQualityValue <
 				    ActionableQualityFeedbackThreshold::
@@ -124,11 +124,11 @@ NFIQ::QualityFeatures::Impl::getActionableQualityFeedback(
 			     ++it_muFeatures) {
 				if (it_muFeatures->featureData.featureID
 					.compare("Mu") == 0) {
-					NFIQ::ActionableQualityFeedback fb;
+					NFIQ2::ActionableQualityFeedback fb;
 					fb.actionableQualityValue =
 					    it_muFeatures->featureData
 						.featureDataDouble;
-					fb.identifier = NFIQ::
+					fb.identifier = NFIQ2::
 					    ActionableQualityFeedbackIdentifier::
 						EmptyImageOrContrastTooLow;
 					isEmptyImage = (fb.actionableQualityValue >
@@ -158,10 +158,10 @@ NFIQ::QualityFeatures::Impl::getActionableQualityFeedback(
 				std::dynamic_pointer_cast<FingerJetFXFeature>(
 				    feature);
 
-			std::vector<NFIQ::QualityFeatureResult> fjfxFeatures =
+			std::vector<NFIQ2::QualityFeatureResult> fjfxFeatures =
 			    fjfxFeatureModule->getFeatures();
 
-			std::vector<NFIQ::QualityFeatureResult>::iterator
+			std::vector<NFIQ2::QualityFeatureResult>::iterator
 			    it_fjfxFeatures;
 
 			for (it_fjfxFeatures = fjfxFeatures.begin();
@@ -172,11 +172,11 @@ NFIQ::QualityFeatures::Impl::getActionableQualityFeedback(
 				    0) {
 					// return informative feature about
 					// number of minutiae
-					NFIQ::ActionableQualityFeedback fb;
+					NFIQ2::ActionableQualityFeedback fb;
 					fb.actionableQualityValue =
 					    it_fjfxFeatures->featureData
 						.featureDataDouble;
-					fb.identifier = NFIQ::
+					fb.identifier = NFIQ2::
 					    ActionableQualityFeedbackIdentifier::
 						FingerprintImageWithMinutiae;
 					actionableMap
@@ -195,13 +195,13 @@ NFIQ::QualityFeatures::Impl::getActionableQualityFeedback(
 				    feature);
 
 			// add ROI information to actionable quality feedback
-			NFIQ::ActionableQualityFeedback fb_roi;
+			NFIQ2::ActionableQualityFeedback fb_roi;
 			fb_roi.actionableQualityValue =
 			    roiFeatureModule->getImgProcResults()
 				.noOfROIPixels; // absolute number of ROI pixels
 						// (foreground)
 			fb_roi.identifier =
-			    NFIQ::ActionableQualityFeedbackIdentifier::
+			    NFIQ2::ActionableQualityFeedbackIdentifier::
 				SufficientFingerprintForeground;
 			actionableMap[ActionableQualityFeedbackIdentifier::
 				SufficientFingerprintForeground] = fb_roi;
@@ -211,14 +211,14 @@ NFIQ::QualityFeatures::Impl::getActionableQualityFeedback(
 	return actionableMap;
 }
 
-std::vector<std::shared_ptr<NFIQ::QualityFeatures::BaseFeature>>
-NFIQ::QualityFeatures::Impl::computeQualityFeatures(
-    const NFIQ::FingerprintImageData &rawImage)
+std::vector<std::shared_ptr<NFIQ2::QualityFeatures::BaseFeature>>
+NFIQ2::QualityFeatures::Impl::computeQualityFeatures(
+    const NFIQ2::FingerprintImageData &rawImage)
 {
-	const NFIQ::FingerprintImageData croppedImage =
+	const NFIQ2::FingerprintImageData croppedImage =
 	    rawImage.removeWhiteFrameAroundFingerprint();
 
-	std::vector<std::shared_ptr<NFIQ::QualityFeatures::BaseFeature>>
+	std::vector<std::shared_ptr<NFIQ2::QualityFeatures::BaseFeature>>
 	    features {};
 
 	features.push_back(std::make_shared<FDAFeature>(croppedImage));
@@ -253,13 +253,13 @@ NFIQ::QualityFeatures::Impl::computeQualityFeatures(
 }
 
 std::vector<std::string>
-NFIQ::QualityFeatures::Impl::getAllActionableIdentifiers()
+NFIQ2::QualityFeatures::Impl::getAllActionableIdentifiers()
 {
 	static const std::vector<std::string> actionableIdentifiers {
-		NFIQ::ActionableQualityFeedbackIdentifier::UniformImage,
-		NFIQ::ActionableQualityFeedbackIdentifier::
+		NFIQ2::ActionableQualityFeedbackIdentifier::UniformImage,
+		NFIQ2::ActionableQualityFeedbackIdentifier::
 		    EmptyImageOrContrastTooLow,
-		NFIQ::ActionableQualityFeedbackIdentifier::
+		NFIQ2::ActionableQualityFeedbackIdentifier::
 		    FingerprintImageWithMinutiae,
 		ActionableQualityFeedbackIdentifier::
 		    SufficientFingerprintForeground
@@ -269,7 +269,7 @@ NFIQ::QualityFeatures::Impl::getAllActionableIdentifiers()
 }
 
 std::vector<std::string>
-NFIQ::QualityFeatures::Impl::getAllQualityFeatureIDs()
+NFIQ2::QualityFeatures::Impl::getAllQualityFeatureIDs()
 {
 	const std::vector<std::vector<std::string>> vov {
 		FDAFeature::getAllFeatureIDs(),
@@ -294,7 +294,7 @@ NFIQ::QualityFeatures::Impl::getAllQualityFeatureIDs()
 }
 
 std::vector<std::string>
-NFIQ::QualityFeatures::Impl::getAllSpeedFeatureGroups()
+NFIQ2::QualityFeatures::Impl::getAllSpeedFeatureGroups()
 {
 	static const std::vector<std::string> speedFeatureGroups {
 		FDAFeature::speedFeatureIDGroup,

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures_impl.hpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures_impl.hpp
@@ -10,7 +10,7 @@
 #include <string>
 #include <vector>
 
-namespace NFIQ { namespace QualityFeatures { namespace Impl {
+namespace NFIQ2 { namespace QualityFeatures { namespace Impl {
 /**
  * @brief
  * Obtain all actionable quality feedback identifiers.
@@ -49,8 +49,8 @@ std::vector<std::string> getAllSpeedFeatureGroups();
  * @return
  * A vector if BaseFeature modules containing computed feature data
  */
-std::vector<std::shared_ptr<NFIQ::QualityFeatures::BaseFeature>>
-computeQualityFeatures(const NFIQ::FingerprintImageData &rawImage);
+std::vector<std::shared_ptr<NFIQ2::QualityFeatures::BaseFeature>>
+computeQualityFeatures(const NFIQ2::FingerprintImageData &rawImage);
 
 /**
  * @brief
@@ -62,9 +62,9 @@ computeQualityFeatures(const NFIQ::FingerprintImageData &rawImage);
  * @return
  * A map of string, actionable quality feedback pairs
  */
-std::unordered_map<std::string, NFIQ::ActionableQualityFeedback>
+std::unordered_map<std::string, NFIQ2::ActionableQualityFeedback>
 getActionableQualityFeedback(
-    const std::vector<std::shared_ptr<NFIQ::QualityFeatures::BaseFeature>>
+    const std::vector<std::shared_ptr<NFIQ2::QualityFeatures::BaseFeature>>
 	&features);
 
 /**
@@ -77,8 +77,8 @@ getActionableQualityFeedback(
  * @return
  * A map of string, actionable quality feedback pairs
  */
-std::unordered_map<std::string, NFIQ::ActionableQualityFeedback>
-getActionableQualityFeedback(const NFIQ::FingerprintImageData &rawImage);
+std::unordered_map<std::string, NFIQ2::ActionableQualityFeedback>
+getActionableQualityFeedback(const NFIQ2::FingerprintImageData &rawImage);
 
 /**
  * @brief
@@ -90,8 +90,9 @@ getActionableQualityFeedback(const NFIQ::FingerprintImageData &rawImage);
  * @return
  * A map of string, quality feature data pairs
  */
-std::unordered_map<std::string, NFIQ::QualityFeatureData> getQualityFeatureData(
-    const std::vector<std::shared_ptr<NFIQ::QualityFeatures::BaseFeature>>
+std::unordered_map<std::string, NFIQ2::QualityFeatureData>
+getQualityFeatureData(
+    const std::vector<std::shared_ptr<NFIQ2::QualityFeatures::BaseFeature>>
 	&features);
 
 /**
@@ -104,8 +105,8 @@ std::unordered_map<std::string, NFIQ::QualityFeatureData> getQualityFeatureData(
  * @return
  * A map of string, quality feature data pairs
  */
-std::unordered_map<std::string, NFIQ::QualityFeatureData> getQualityFeatureData(
-    const NFIQ::FingerprintImageData &rawImage);
+std::unordered_map<std::string, NFIQ2::QualityFeatureData>
+getQualityFeatureData(const NFIQ2::FingerprintImageData &rawImage);
 
 /**
  * @brief
@@ -117,9 +118,9 @@ std::unordered_map<std::string, NFIQ::QualityFeatureData> getQualityFeatureData(
  * @return
  * A map of string, quality feature speed pairs
  */
-std::unordered_map<std::string, NFIQ::QualityFeatureSpeed>
+std::unordered_map<std::string, NFIQ2::QualityFeatureSpeed>
 getQualityFeatureSpeeds(
-    const std::vector<std::shared_ptr<NFIQ::QualityFeatures::BaseFeature>>
+    const std::vector<std::shared_ptr<NFIQ2::QualityFeatures::BaseFeature>>
 	&features);
 
 }}}

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_results.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_results.cpp
@@ -2,72 +2,72 @@
 
 #include "nfiq2_results_impl.hpp"
 
-NFIQ::NFIQ2Results::NFIQ2Results()
-    : pimpl { new NFIQ::NFIQ2Results::Impl() }
+NFIQ2::NFIQ2Results::NFIQ2Results()
+    : pimpl { new NFIQ2::NFIQ2Results::Impl() }
 {
 }
 
-NFIQ::NFIQ2Results::NFIQ2Results(
-    const std::vector<NFIQ::ActionableQualityFeedback>
+NFIQ2::NFIQ2Results::NFIQ2Results(
+    const std::vector<NFIQ2::ActionableQualityFeedback>
 	&actionableQualityFeedback,
-    const std::vector<NFIQ::QualityFeatureData> &qualityFeatureData,
-    const std::vector<NFIQ::QualityFeatureSpeed> &qualityFeatureSpeed,
+    const std::vector<NFIQ2::QualityFeatureData> &qualityFeatureData,
+    const std::vector<NFIQ2::QualityFeatureSpeed> &qualityFeatureSpeed,
     const unsigned int qualityScore)
-    : pimpl { new NFIQ::NFIQ2Results::Impl(actionableQualityFeedback,
+    : pimpl { new NFIQ2::NFIQ2Results::Impl(actionableQualityFeedback,
 	  qualityFeatureData, qualityFeatureSpeed, qualityScore) }
 {
 }
 
-NFIQ::NFIQ2Results::~NFIQ2Results() = default;
+NFIQ2::NFIQ2Results::~NFIQ2Results() = default;
 
 unsigned int
-NFIQ::NFIQ2Results::checkScore(const unsigned int qualityScore)
+NFIQ2::NFIQ2Results::checkScore(const unsigned int qualityScore)
 {
-	return NFIQ::NFIQ2Results::Impl::checkScore(qualityScore);
+	return NFIQ2::NFIQ2Results::Impl::checkScore(qualityScore);
 }
 
 void
-NFIQ::NFIQ2Results::setActionableQualityFeedback(
-    const std::vector<NFIQ::ActionableQualityFeedback> &actionableQuality)
+NFIQ2::NFIQ2Results::setActionableQualityFeedback(
+    const std::vector<NFIQ2::ActionableQualityFeedback> &actionableQuality)
 {
 	this->pimpl->setActionableQualityFeedback(actionableQuality);
 }
 void
-NFIQ::NFIQ2Results::setQualityFeatures(
-    const std::vector<NFIQ::QualityFeatureData> &qualityFeatureData)
+NFIQ2::NFIQ2Results::setQualityFeatures(
+    const std::vector<NFIQ2::QualityFeatureData> &qualityFeatureData)
 {
 	this->pimpl->setQualityFeatures(qualityFeatureData);
 }
 void
-NFIQ::NFIQ2Results::setQualityFeatureSpeed(
-    const std::vector<NFIQ::QualityFeatureSpeed> &qualityFeatureSpeed)
+NFIQ2::NFIQ2Results::setQualityFeatureSpeed(
+    const std::vector<NFIQ2::QualityFeatureSpeed> &qualityFeatureSpeed)
 {
 	this->pimpl->setQualityFeatureSpeed(qualityFeatureSpeed);
 }
 
 void
-NFIQ::NFIQ2Results::setScore(const unsigned int qualityScore)
+NFIQ2::NFIQ2Results::setScore(const unsigned int qualityScore)
 {
 	this->pimpl->setScore(qualityScore);
 }
 
-std::vector<NFIQ::ActionableQualityFeedback>
-NFIQ::NFIQ2Results::getActionableQualityFeedback() const
+std::vector<NFIQ2::ActionableQualityFeedback>
+NFIQ2::NFIQ2Results::getActionableQualityFeedback() const
 {
 	return (this->pimpl->getActionableQualityFeedback());
 }
-std::vector<NFIQ::QualityFeatureData>
-NFIQ::NFIQ2Results::getQualityFeatures() const
+std::vector<NFIQ2::QualityFeatureData>
+NFIQ2::NFIQ2Results::getQualityFeatures() const
 {
 	return (this->pimpl->getQualityFeatures());
 }
-std::vector<NFIQ::QualityFeatureSpeed>
-NFIQ::NFIQ2Results::getQualityFeatureSpeed() const
+std::vector<NFIQ2::QualityFeatureSpeed>
+NFIQ2::NFIQ2Results::getQualityFeatureSpeed() const
 {
 	return (this->pimpl->getQualityFeatureSpeed());
 }
 unsigned int
-NFIQ::NFIQ2Results::getScore() const
+NFIQ2::NFIQ2Results::getScore() const
 {
 	return (this->pimpl->getScore());
 }

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_results_impl.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_results_impl.cpp
@@ -2,78 +2,78 @@
 #include <string>
 #include <vector>
 
-NFIQ::NFIQ2Results::Impl::Impl() = default;
+NFIQ2::NFIQ2Results::Impl::Impl() = default;
 
-NFIQ::NFIQ2Results::Impl::Impl(
-    const std::vector<NFIQ::ActionableQualityFeedback> &actionableQuality,
-    const std::vector<NFIQ::QualityFeatureData> &qualityFeatureData,
-    const std::vector<NFIQ::QualityFeatureSpeed> &qualityFeatureSpeed,
+NFIQ2::NFIQ2Results::Impl::Impl(
+    const std::vector<NFIQ2::ActionableQualityFeedback> &actionableQuality,
+    const std::vector<NFIQ2::QualityFeatureData> &qualityFeatureData,
+    const std::vector<NFIQ2::QualityFeatureSpeed> &qualityFeatureSpeed,
     const unsigned int qualityScore)
     : actionableQuality_ { actionableQuality }
     , qualityFeatureData_ { qualityFeatureData }
     , qualityFeatureSpeed_ { qualityFeatureSpeed }
-    , qualityScore_ { NFIQ::NFIQ2Results::checkScore(qualityScore) }
+    , qualityScore_ { NFIQ2::NFIQ2Results::checkScore(qualityScore) }
 {
 }
 
-NFIQ::NFIQ2Results::Impl::~Impl() = default;
+NFIQ2::NFIQ2Results::Impl::~Impl() = default;
 
 unsigned int
-NFIQ::NFIQ2Results::Impl::checkScore(const unsigned int qualityScore)
+NFIQ2::NFIQ2Results::Impl::checkScore(const unsigned int qualityScore)
 {
 	if (qualityScore > 100) {
 		const std::string errStr { "Invalid quality score: " +
 			std::to_string(qualityScore) +
 			". Valid scores are between 0 and 100" };
-		throw NFIQ::NFIQException(
-		    NFIQ::e_Error_InvalidNFIQ2Score, errStr);
+		throw NFIQ2::NFIQException(
+		    NFIQ2::e_Error_InvalidNFIQ2Score, errStr);
 	}
 	return qualityScore;
 }
 
 void
-NFIQ::NFIQ2Results::Impl::setActionableQualityFeedback(
-    const std::vector<NFIQ::ActionableQualityFeedback> &actionableQuality)
+NFIQ2::NFIQ2Results::Impl::setActionableQualityFeedback(
+    const std::vector<NFIQ2::ActionableQualityFeedback> &actionableQuality)
 {
 	this->actionableQuality_ = actionableQuality;
 }
 void
-NFIQ::NFIQ2Results::Impl::setQualityFeatures(
-    const std::vector<NFIQ::QualityFeatureData> &qualityFeatureData)
+NFIQ2::NFIQ2Results::Impl::setQualityFeatures(
+    const std::vector<NFIQ2::QualityFeatureData> &qualityFeatureData)
 {
 	this->qualityFeatureData_ = qualityFeatureData;
 }
 void
-NFIQ::NFIQ2Results::Impl::setQualityFeatureSpeed(
-    const std::vector<NFIQ::QualityFeatureSpeed> &qualityFeatureSpeed)
+NFIQ2::NFIQ2Results::Impl::setQualityFeatureSpeed(
+    const std::vector<NFIQ2::QualityFeatureSpeed> &qualityFeatureSpeed)
 {
 	this->qualityFeatureSpeed_ = qualityFeatureSpeed;
 }
 
 void
-NFIQ::NFIQ2Results::Impl::setScore(const unsigned int qualityScore)
+NFIQ2::NFIQ2Results::Impl::setScore(const unsigned int qualityScore)
 {
-	this->qualityScore_ = NFIQ::NFIQ2Results::checkScore(qualityScore);
+	this->qualityScore_ = NFIQ2::NFIQ2Results::checkScore(qualityScore);
 }
 
-std::vector<NFIQ::ActionableQualityFeedback>
-NFIQ::NFIQ2Results::Impl::getActionableQualityFeedback() const
+std::vector<NFIQ2::ActionableQualityFeedback>
+NFIQ2::NFIQ2Results::Impl::getActionableQualityFeedback() const
 {
 	return this->actionableQuality_;
 }
-std::vector<NFIQ::QualityFeatureData>
-NFIQ::NFIQ2Results::Impl::getQualityFeatures() const
+std::vector<NFIQ2::QualityFeatureData>
+NFIQ2::NFIQ2Results::Impl::getQualityFeatures() const
 {
 	return this->qualityFeatureData_;
 }
-std::vector<NFIQ::QualityFeatureSpeed>
-NFIQ::NFIQ2Results::Impl::getQualityFeatureSpeed() const
+std::vector<NFIQ2::QualityFeatureSpeed>
+NFIQ2::NFIQ2Results::Impl::getQualityFeatureSpeed() const
 {
 	return this->qualityFeatureSpeed_;
 }
 
 unsigned int
-NFIQ::NFIQ2Results::Impl::getScore() const
+NFIQ2::NFIQ2Results::Impl::getScore() const
 {
 	return this->qualityScore_;
 }

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_results_impl.hpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_results_impl.hpp
@@ -6,38 +6,38 @@
 #include "nfiq2_results_impl.hpp"
 #include <vector>
 
-namespace NFIQ {
+namespace NFIQ2 {
 class NFIQ2Results::Impl {
     public:
 	Impl();
-	Impl(const std::vector<NFIQ::ActionableQualityFeedback>
+	Impl(const std::vector<NFIQ2::ActionableQualityFeedback>
 		 &actionableQuality,
-	    const std::vector<NFIQ::QualityFeatureData> &qualityFeatureData,
-	    const std::vector<NFIQ::QualityFeatureSpeed> &qualityFeatureSpeed,
+	    const std::vector<NFIQ2::QualityFeatureData> &qualityFeatureData,
+	    const std::vector<NFIQ2::QualityFeatureSpeed> &qualityFeatureSpeed,
 	    const unsigned int qualityScore);
 	~Impl();
 
 	static unsigned int checkScore(const unsigned int qualityScore);
 
 	void setActionableQualityFeedback(
-	    const std::vector<NFIQ::ActionableQualityFeedback>
+	    const std::vector<NFIQ2::ActionableQualityFeedback>
 		&actionableQuality);
 	void setQualityFeatures(
-	    const std::vector<NFIQ::QualityFeatureData> &qualityFeatureData);
+	    const std::vector<NFIQ2::QualityFeatureData> &qualityFeatureData);
 	void setQualityFeatureSpeed(
-	    const std::vector<NFIQ::QualityFeatureSpeed> &qualityFeatureSpeed);
+	    const std::vector<NFIQ2::QualityFeatureSpeed> &qualityFeatureSpeed);
 	void setScore(const unsigned int qualityScore);
 
-	std::vector<NFIQ::ActionableQualityFeedback>
+	std::vector<NFIQ2::ActionableQualityFeedback>
 	getActionableQualityFeedback() const;
-	std::vector<NFIQ::QualityFeatureData> getQualityFeatures() const;
-	std::vector<NFIQ::QualityFeatureSpeed> getQualityFeatureSpeed() const;
+	std::vector<NFIQ2::QualityFeatureData> getQualityFeatures() const;
+	std::vector<NFIQ2::QualityFeatureSpeed> getQualityFeatureSpeed() const;
 	unsigned int getScore() const;
 
     private:
-	std::vector<NFIQ::ActionableQualityFeedback> actionableQuality_ {};
-	std::vector<NFIQ::QualityFeatureData> qualityFeatureData_ {};
-	std::vector<NFIQ::QualityFeatureSpeed> qualityFeatureSpeed_ {};
+	std::vector<NFIQ2::ActionableQualityFeedback> actionableQuality_ {};
+	std::vector<NFIQ2::QualityFeatureData> qualityFeatureData_ {};
+	std::vector<NFIQ2::QualityFeatureSpeed> qualityFeatureSpeed_ {};
 	unsigned int qualityScore_ {};
 };
 }

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_timer.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_timer.cpp
@@ -3,14 +3,14 @@
 #include <chrono>
 
 void
-NFIQ::Timer::start()
+NFIQ2::Timer::start()
 {
 	this->endTime = std::chrono::steady_clock::time_point {};
 	this->startTime = std::chrono::steady_clock::now();
 }
 
 double
-NFIQ::Timer::getElapsedTime()
+NFIQ2::Timer::getElapsedTime()
 {
 	if (this->endTime < this->startTime)
 		return std::numeric_limits<double>::signaling_NaN();
@@ -21,7 +21,7 @@ NFIQ::Timer::getElapsedTime()
 }
 
 double
-NFIQ::Timer::stop()
+NFIQ2::Timer::stop()
 {
 	this->endTime = std::chrono::steady_clock::now();
 	return this->getElapsedTime();

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiqexception.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiqexception.cpp
@@ -65,7 +65,7 @@ const std::string c_ErrorMessages[] = {
 	/* 55 */ "Invalid Image Size"
 };
 
-NFIQ::NFIQException::NFIQException(uint32_t returnCode)
+NFIQ2::NFIQException::NFIQException(uint32_t returnCode)
     : m_ReturnCode(returnCode)
 {
 	m_ErrorMessage = c_ErrorMessages[returnCode];
@@ -74,19 +74,19 @@ NFIQ::NFIQException::NFIQException(uint32_t returnCode)
 	}
 }
 
-NFIQ::NFIQException::NFIQException(
+NFIQ2::NFIQException::NFIQException(
     uint32_t returnCode, std::string errorMessage)
     : m_ReturnCode(returnCode)
     , m_ErrorMessage(errorMessage)
 {
 }
 
-NFIQ::NFIQException::~NFIQException() noexcept
+NFIQ2::NFIQException::~NFIQException() noexcept
 {
 }
 
 const char *
-NFIQ::NFIQException::what() const noexcept
+NFIQ2::NFIQException::what() const noexcept
 {
 	return m_ErrorMessage.c_str();
 }

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/version.cpp.in
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/version.cpp.in
@@ -5,20 +5,20 @@
 #include "opencv2/core/version.hpp"
 #include <string>
 
-const unsigned int NFIQ::Version::Major = @NFIQ2_VERSION_MAJOR@;
-const unsigned int NFIQ::Version::Minor = @NFIQ2_VERSION_MINOR@;
-const unsigned int NFIQ::Version::Patch = @NFIQ2_VERSION_PATCH@;
+const unsigned int NFIQ2::Version::Major = @NFIQ2_VERSION_MAJOR@;
+const unsigned int NFIQ2::Version::Minor = @NFIQ2_VERSION_MINOR@;
+const unsigned int NFIQ2::Version::Patch = @NFIQ2_VERSION_PATCH@;
 
-const std::string NFIQ::Version::Full = "@NFIQ2_VERSION_FULL@";
-const std::string NFIQ::Version::Pretty = "@NFIQ2_VERSION@";
-const std::string NFIQ::Version::Status = "@NFIQ2_VERSION_STATUS@";
-const std::string NFIQ::Version::BuildDate = "@NFIQ2_BUILD_DATE@";
-const std::string NFIQ::Version::Commit = "@NFIQ2_VERSION_COMMIT@";
+const std::string NFIQ2::Version::Full = "@NFIQ2_VERSION_FULL@";
+const std::string NFIQ2::Version::Pretty = "@NFIQ2_VERSION@";
+const std::string NFIQ2::Version::Status = "@NFIQ2_VERSION_STATUS@";
+const std::string NFIQ2::Version::BuildDate = "@NFIQ2_BUILD_DATE@";
+const std::string NFIQ2::Version::Commit = "@NFIQ2_VERSION_COMMIT@";
 
-const std::string NFIQ::Version::OpenCV = CV_VERSION;
+const std::string NFIQ2::Version::OpenCV = CV_VERSION;
 
 std::string
-NFIQ::Version::FingerJet()
+NFIQ2::Version::FingerJet()
 {
 	FRFXLL_VERSION v {};
 	FRFXLLGetLibraryVersion(&v);

--- a/NFIQ2/NFIQ2Algorithm/src/prediction/RandomForestML.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/prediction/RandomForestML.cpp
@@ -30,7 +30,7 @@
 #include <numeric> // std::accumulate
 
 std::string
-NFIQ::Prediction::RandomForestML::calculateHashString(const std::string &s)
+NFIQ2::Prediction::RandomForestML::calculateHashString(const std::string &s)
 {
 	// calculate and compare the hash
 	digestpp::md5 hasher;
@@ -41,7 +41,7 @@ NFIQ::Prediction::RandomForestML::calculateHashString(const std::string &s)
 }
 
 void
-NFIQ::Prediction::RandomForestML::initModule(const std::string &params)
+NFIQ2::Prediction::RandomForestML::initModule(const std::string &params)
 {
 	// create file storage with parameters in memory
 	cv::FileStorage fs(params.c_str(),
@@ -54,7 +54,7 @@ NFIQ::Prediction::RandomForestML::initModule(const std::string &params)
 
 #ifdef EMBED_RANDOMFOREST_PARAMETERS
 std::string
-NFIQ::Prediction::RandomForestML::joinRFTrainedParamsString()
+NFIQ2::Prediction::RandomForestML::joinRFTrainedParamsString()
 {
 	unsigned int size = sizeof(g_strRandomForestTrainedParams) /
 	    sizeof(g_strRandomForestTrainedParams[0]);
@@ -66,11 +66,11 @@ NFIQ::Prediction::RandomForestML::joinRFTrainedParamsString()
 }
 #endif
 
-NFIQ::Prediction::RandomForestML::RandomForestML()
+NFIQ2::Prediction::RandomForestML::RandomForestML()
 {
 }
 
-NFIQ::Prediction::RandomForestML::~RandomForestML()
+NFIQ2::Prediction::RandomForestML::~RandomForestML()
 {
 	if (!m_pTrainedRF.empty()) {
 		m_pTrainedRF->clear();
@@ -79,13 +79,13 @@ NFIQ::Prediction::RandomForestML::~RandomForestML()
 
 #ifdef EMBED_RANDOMFOREST_PARAMETERS
 std::string
-NFIQ::Prediction::RandomForestML::initModule()
+NFIQ2::Prediction::RandomForestML::initModule()
 {
 	try {
 		// get parameters from string
 		// accumulate it to a single string
 		// and decode base64
-		NFIQ::Data data;
+		NFIQ2::Data data;
 		std::string params = joinRFTrainedParamsString();
 		unsigned int size = params.size();
 		data.fromBase64String(params);
@@ -102,7 +102,7 @@ NFIQ::Prediction::RandomForestML::initModule()
 #endif
 
 std::string
-NFIQ::Prediction::RandomForestML::initModule(
+NFIQ2::Prediction::RandomForestML::initModule(
     const std::string &fileName, const std::string &fileHash)
 {
 	std::ifstream input(fileName);
@@ -113,7 +113,7 @@ NFIQ::Prediction::RandomForestML::initModule(
 	std::string hash = calculateHashString(params);
 	if (fileHash.compare(hash) != 0) {
 		m_pTrainedRF->clear();
-		throw NFIQ::NFIQException(NFIQ::e_Error_InvalidConfiguration,
+		throw NFIQ2::NFIQException(NFIQ2::e_Error_InvalidConfiguration,
 		    "The trained network could not be initialized! "
 		    "Error: " +
 			hash);
@@ -122,8 +122,8 @@ NFIQ::Prediction::RandomForestML::initModule(
 }
 
 void
-NFIQ::Prediction::RandomForestML::evaluate(
-    const std::unordered_map<std::string, NFIQ::QualityFeatureData> &features,
+NFIQ2::Prediction::RandomForestML::evaluate(
+    const std::unordered_map<std::string, NFIQ2::QualityFeatureData> &features,
     const double &utilityValue, double &qualityValue, double &deviation) const
 {
 	/**
@@ -156,7 +156,7 @@ NFIQ::Prediction::RandomForestML::evaluate(
 		"RVUP_Bin10_5", "RVUP_Bin10_6", "RVUP_Bin10_7", "RVUP_Bin10_8",
 		"RVUP_Bin10_9", "RVUP_Bin10_Mean", "RVUP_Bin10_StdDev" };
 
-	std::vector<NFIQ::QualityFeatureData> featureVector {};
+	std::vector<NFIQ2::QualityFeatureData> featureVector {};
 	for (const auto &i : rfFeatureOrder) {
 		featureVector.push_back(features.at(i));
 	}
@@ -164,8 +164,8 @@ NFIQ::Prediction::RandomForestML::evaluate(
 	try {
 		if (m_pTrainedRF.empty() || !m_pTrainedRF->isTrained() ||
 		    !m_pTrainedRF->isClassifier()) {
-			throw NFIQ::NFIQException(
-			    NFIQ::e_Error_InvalidConfiguration,
+			throw NFIQ2::NFIQException(
+			    NFIQ2::e_Error_InvalidConfiguration,
 			    "The trained network could not be loaded for "
 			    "prediction!");
 		}
@@ -175,7 +175,7 @@ NFIQ::Prediction::RandomForestML::evaluate(
 		// copy data to structure
 		cv::Mat sample_data = cv::Mat(
 		    1, featureVector.size(), CV_32FC1);
-		std::vector<NFIQ::QualityFeatureData>::const_iterator it_feat;
+		std::vector<NFIQ2::QualityFeatureData>::const_iterator it_feat;
 		unsigned int counterFeatures = 0;
 		for (it_feat = featureVector.begin();
 		     it_feat != featureVector.end(); it_feat++) {
@@ -202,12 +202,12 @@ NFIQ::Prediction::RandomForestML::evaluate(
 	}
 }
 
-const std::string NFIQ::Prediction::RandomForestML::moduleName {
+const std::string NFIQ2::Prediction::RandomForestML::moduleName {
 	"NFIQ2_RandomForest"
 };
 
 std::string
-NFIQ::Prediction::RandomForestML::getModuleName() const
+NFIQ2::Prediction::RandomForestML::getModuleName() const
 {
 	return moduleName;
 }

--- a/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_log.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_log.cpp
@@ -44,9 +44,9 @@ void
 NFIQ2UI::Log::printScore(const std::string &name, uint8_t fingerCode,
     unsigned int score, const std::string &errmsg, const bool quantized,
     const bool resampled,
-    const std::unordered_map<std::string, NFIQ::QualityFeatureData> &features,
-    const std::unordered_map<std::string, NFIQ::QualityFeatureSpeed> &speed,
-    const std::unordered_map<std::string, NFIQ::ActionableQualityFeedback>
+    const std::unordered_map<std::string, NFIQ2::QualityFeatureData> &features,
+    const std::unordered_map<std::string, NFIQ2::QualityFeatureSpeed> &speed,
+    const std::unordered_map<std::string, NFIQ2::ActionableQualityFeedback>
 	&actionable) const
 {
 	*(this->out) << "\"" << name << "\""
@@ -59,7 +59,7 @@ NFIQ2UI::Log::printScore(const std::string &name, uint8_t fingerCode,
 	// Print out actionable first
 	if (this->actionable) {
 		const auto actionableIDs =
-		    NFIQ::QualityFeatures::getAllActionableIdentifiers();
+		    NFIQ2::QualityFeatures::getAllActionableIdentifiers();
 		for (const auto &i : actionableIDs) {
 			if (i != actionableIDs.front()) {
 				*(this->out) << ",";
@@ -75,7 +75,7 @@ NFIQ2UI::Log::printScore(const std::string &name, uint8_t fingerCode,
 
 	if (this->verbose) {
 		const auto featureIDs =
-		    NFIQ::QualityFeatures::getAllQualityFeatureIDs();
+		    NFIQ2::QualityFeatures::getAllQualityFeatureIDs();
 		for (const auto &i : featureIDs) {
 			if (i != featureIDs.front()) {
 				*(this->out) << ",";
@@ -91,7 +91,7 @@ NFIQ2UI::Log::printScore(const std::string &name, uint8_t fingerCode,
 
 	if (this->speed) {
 		const auto speedIDs =
-		    NFIQ::QualityFeatures::getAllSpeedFeatureGroups();
+		    NFIQ2::QualityFeatures::getAllSpeedFeatureGroups();
 		for (const auto &i : speedIDs) {
 			if (i != speedIDs.front()) {
 				*(this->out) << ",";
@@ -209,7 +209,7 @@ NFIQ2UI::Log::printCSVHeader() const
 
 	if (this->actionable) {
 		std::vector<std::string> vHeaders =
-		    NFIQ::QualityFeatures::getAllActionableIdentifiers();
+		    NFIQ2::QualityFeatures::getAllActionableIdentifiers();
 
 		for (auto it = vHeaders.begin(); it != vHeaders.end(); ++it) {
 			if (it != vHeaders.begin()) {
@@ -225,7 +225,7 @@ NFIQ2UI::Log::printCSVHeader() const
 
 	if (this->verbose) {
 		std::vector<std::string> vHeaders =
-		    NFIQ::QualityFeatures::getAllQualityFeatureIDs();
+		    NFIQ2::QualityFeatures::getAllQualityFeatureIDs();
 
 		for (auto it = vHeaders.begin(); it != vHeaders.end(); ++it) {
 			if (it != vHeaders.begin()) {
@@ -241,7 +241,7 @@ NFIQ2UI::Log::printCSVHeader() const
 
 	if (this->speed) {
 		std::vector<std::string> sHeaders =
-		    NFIQ::QualityFeatures::getAllSpeedFeatureGroups();
+		    NFIQ2::QualityFeatures::getAllSpeedFeatureGroups();
 
 		for (auto it = sHeaders.begin(); it != sHeaders.end(); ++it) {
 			if (it != sHeaders.begin()) {

--- a/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_refresh.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_refresh.cpp
@@ -146,7 +146,7 @@ NFIQ2UI::resampleAndLogError(BE::Memory::uint8Array &grayscaleRawData,
 void
 NFIQ2UI::executeSingle(std::shared_ptr<BE::Image::Image> img,
     const std::string &name, const Flags &flags,
-    const NFIQ::NFIQ2Algorithm &model, std::shared_ptr<NFIQ2UI::Log> logger,
+    const NFIQ2::NFIQ2Algorithm &model, std::shared_ptr<NFIQ2UI::Log> logger,
     const bool singleImage, const bool interactive,
     const uint8_t fingerPosition, const std::string &warning)
 {
@@ -354,22 +354,22 @@ NFIQ2UI::executeSingle(std::shared_ptr<BE::Image::Image> img,
 	// At this point - all images are 500PPI, have been converted to that
 	// resolution, or are assumed to be that resolution.
 
-	const NFIQ::FingerprintImageData wrappedImage = imageProps.resampled ?
-		  NFIQ::FingerprintImageData(postResample.data, postResample.total(),
+	const NFIQ2::FingerprintImageData wrappedImage = imageProps.resampled ?
+		  NFIQ2::FingerprintImageData(postResample.data, postResample.total(),
 		postResample.cols, postResample.rows, fingerPosition,
 		requiredDPI) :
-		  NFIQ::FingerprintImageData(grayscaleRawData,
+		  NFIQ2::FingerprintImageData(grayscaleRawData,
 		grayscaleRawData.size(), imageWidth, imageHeight,
 		fingerPosition, requiredDPI);
 
-	std::vector<std::shared_ptr<NFIQ::QualityFeatures::BaseFeature>>
+	std::vector<std::shared_ptr<NFIQ2::QualityFeatures::BaseFeature>>
 	    features {};
 	unsigned int score {};
 	try {
-		features = NFIQ::QualityFeatures::computeQualityFeatures(
+		features = NFIQ2::QualityFeatures::computeQualityFeatures(
 		    wrappedImage);
 		score = model.computeQualityScore(features);
-	} catch (const NFIQ::NFIQException &e) {
+	} catch (const NFIQ2::NFIQException &e) {
 		std::string errStr {
 			"Error: NFIQ2 computeQualityScore returned an error code: "
 		};
@@ -392,16 +392,16 @@ NFIQ2UI::executeSingle(std::shared_ptr<BE::Image::Image> img,
 		// Print full score with optional headers
 		logger->printScore(name, fingerPosition, score, warning,
 		    imageProps.quantized, imageProps.resampled,
-		    NFIQ::QualityFeatures::getQualityFeatureData(features),
-		    NFIQ::QualityFeatures::getQualityFeatureSpeeds(features),
-		    NFIQ::QualityFeatures::getActionableQualityFeedback(
+		    NFIQ2::QualityFeatures::getQualityFeatureData(features),
+		    NFIQ2::QualityFeatures::getQualityFeatureSpeeds(features),
+		    NFIQ2::QualityFeatures::getActionableQualityFeedback(
 			features));
 	}
 }
 
 void
 NFIQ2UI::executeSingle(const NFIQ2UI::ImgCouple &couple, const Flags &flags,
-    const NFIQ::NFIQ2Algorithm &model, std::shared_ptr<NFIQ2UI::Log> logger,
+    const NFIQ2::NFIQ2Algorithm &model, std::shared_ptr<NFIQ2UI::Log> logger,
     const bool singleImage, const bool interactive)
 {
 	NFIQ2UI::executeSingle(couple.img, couple.imgName, flags, model, logger,
@@ -411,7 +411,7 @@ NFIQ2UI::executeSingle(const NFIQ2UI::ImgCouple &couple, const Flags &flags,
 // Parsing a directory recursively finding all fingerprint images
 void
 NFIQ2UI::parseDirectory(const std::string &dirname, const Flags &flags,
-    const NFIQ::NFIQ2Algorithm &model, std::shared_ptr<NFIQ2UI::Log> logger)
+    const NFIQ2::NFIQ2Algorithm &model, std::shared_ptr<NFIQ2UI::Log> logger)
 {
 	// Uses dirent to iterate through a directory
 	DIR *dr;
@@ -486,7 +486,7 @@ NFIQ2UI::parseDirectory(const std::string &dirname, const Flags &flags,
 void
 NFIQ2UI::batchConsume(NFIQ2UI::SafeSplitPathsQueue &splitQueue,
     SafeQueue<std::string> &printQueue, const Flags &flags,
-    const NFIQ::NFIQ2Algorithm &model)
+    const NFIQ2::NFIQ2Algorithm &model)
 {
 	std::shared_ptr<NFIQ2UI::ThreadedLog> threadedlogger =
 	    std::make_shared<NFIQ2UI::ThreadedLog>(flags);
@@ -514,7 +514,7 @@ NFIQ2UI::batchConsume(NFIQ2UI::SafeSplitPathsQueue &splitQueue,
 
 void
 NFIQ2UI::executeBatch(const std::string &filename, const Flags &flags,
-    const NFIQ::NFIQ2Algorithm &model, std::shared_ptr<NFIQ2UI::Log> logger)
+    const NFIQ2::NFIQ2Algorithm &model, std::shared_ptr<NFIQ2UI::Log> logger)
 {
 	std::vector<std::string> content;
 	unsigned int count;
@@ -594,7 +594,7 @@ void
 NFIQ2UI::recordStoreConsume(const std::string &name,
     NFIQ2UI::SafeSplitPathsQueue &splitQueue,
     SafeQueue<std::string> &printQueue, const Flags &flags,
-    const NFIQ::NFIQ2Algorithm &model)
+    const NFIQ2::NFIQ2Algorithm &model)
 {
 	std::shared_ptr<BE::IO::RecordStore> rs {};
 
@@ -635,7 +635,7 @@ NFIQ2UI::recordStoreConsume(const std::string &name,
 
 void
 NFIQ2UI::executeRecordStore(const std::string &filename, const Flags &flags,
-    const NFIQ::NFIQ2Algorithm &model, std::shared_ptr<NFIQ2UI::Log> logger)
+    const NFIQ2::NFIQ2Algorithm &model, std::shared_ptr<NFIQ2UI::Log> logger)
 {
 	std::shared_ptr<BE::IO::RecordStore> rs {};
 
@@ -827,7 +827,7 @@ NFIQ2UI::processArguments(int argc, char **argv)
 
 void
 NFIQ2UI::procSingle(NFIQ2UI::Arguments arguments,
-    const NFIQ::NFIQ2Algorithm &model, std::shared_ptr<NFIQ2UI::Log> logger)
+    const NFIQ2::NFIQ2Algorithm &model, std::shared_ptr<NFIQ2UI::Log> logger)
 {
 	logger->debugMsg("Processing Singles: ");
 	// If there is only one image being processed
@@ -870,7 +870,7 @@ NFIQ2UI::printHeader(
 	}
 }
 
-NFIQ::ModelInfo
+NFIQ2::ModelInfo
 NFIQ2UI::parseModelInfo(const NFIQ2UI::Arguments &arguments)
 {
 	static const std::string DefaultModelInfoFilename {
@@ -909,10 +909,10 @@ NFIQ2UI::parseModelInfo(const NFIQ2UI::Arguments &arguments)
 		modelInfoFilePath = arguments.flags.model;
 	}
 
-	NFIQ::ModelInfo modelInfoObj {};
+	NFIQ2::ModelInfo modelInfoObj {};
 	try {
-		modelInfoObj = NFIQ::ModelInfo(modelInfoFilePath);
-	} catch (const NFIQ::NFIQException &e) {
+		modelInfoObj = NFIQ2::ModelInfo(modelInfoFilePath);
+	} catch (const NFIQ2::NFIQException &e) {
 		throw NFIQ2UI::ModelConstructionError(
 		    "Could not construct ModelInfo Object from: " +
 		    modelInfoFilePath + ". Error: " + e.what());
@@ -920,7 +920,7 @@ NFIQ2UI::parseModelInfo(const NFIQ2UI::Arguments &arguments)
 
 	if (!BE::IO::Utility::fileExists(modelInfoObj.getModelPath())) {
 		throw NFIQ2UI::PropertyParseError("Unable to parse '" +
-		    NFIQ::ModelInfo::ModelInfoKeyPath + "' from '" +
+		    NFIQ2::ModelInfo::ModelInfoKeyPath + "' from '" +
 		    modelInfoFilePath + "' (No file exists at '" +
 		    modelInfoObj.getModelPath() + "')");
 	}
@@ -959,14 +959,14 @@ main(int argc, char **argv)
 	}
 
 	// Initialize Model
-	NFIQ::Timer timerInit;
+	NFIQ2::Timer timerInit;
 	double timeInit = 0.0;
 	timerInit.start();
 
-	NFIQ::ModelInfo modelInfoObj {};
+	NFIQ2::ModelInfo modelInfoObj {};
 
 	try {
-		modelInfoObj = NFIQ::ModelInfo(
+		modelInfoObj = NFIQ2::ModelInfo(
 		    NFIQ2UI::parseModelInfo(arguments));
 
 	} catch (const NFIQ2UI::Exception &e) {
@@ -994,10 +994,10 @@ main(int argc, char **argv)
 	logger->debugMsg("Model Path: " + modelInfoObj.getModelPath());
 	logger->debugMsg("Model Hash: " + modelInfoObj.getModelHash());
 
-	std::shared_ptr<NFIQ::NFIQ2Algorithm> model {};
+	std::shared_ptr<NFIQ2::NFIQ2Algorithm> model {};
 	try {
-		model = std::make_shared<NFIQ::NFIQ2Algorithm>(modelInfoObj);
-	} catch (const NFIQ::NFIQException &e) {
+		model = std::make_shared<NFIQ2::NFIQ2Algorithm>(modelInfoObj);
+	} catch (const NFIQ2::NFIQException &e) {
 		std::cerr << "Model could not be constructed. " << e.what()
 			  << "\n";
 		return EXIT_FAILURE;

--- a/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_utils.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_utils.cpp
@@ -317,15 +317,15 @@ NFIQ2UI::printUsage()
 	std::cout << "\nVersion Info\n------------\n"
 		  << "Biometric Evaluation: " << NFIQ2UI::getBiomevalVersion()
 		  << "\n"
-		  << "FingerJet: " << NFIQ::Version::FingerJet()
+		  << "FingerJet: " << NFIQ2::Version::FingerJet()
 		  << "\n"
 		     "OpenCV: "
-		  << NFIQ::Version::OpenCV
+		  << NFIQ2::Version::OpenCV
 		  << "\n"
 		     "NFIQ 2: "
-		  << NFIQ::Version::Pretty
-		  << " (Date: " << NFIQ::Version::BuildDate
-		  << ", Commit: " << NFIQ::Version::Commit << ")\n";
+		  << NFIQ2::Version::Pretty
+		  << " (Date: " << NFIQ2::Version::BuildDate
+		  << ", Commit: " << NFIQ2::Version::Commit << ")\n";
 }
 
 // Print to stdout if undefined flag is used

--- a/NFIQ2/NFIQ2Api/nfiq2api.cpp
+++ b/NFIQ2/NFIQ2Api/nfiq2api.cpp
@@ -22,7 +22,7 @@ extern int version_minor;
 extern int version_patch;
 
 // static object to load the algorithm only once (random forest init!)
-std::unique_ptr<NFIQ::NFIQ2Algorithm> g_nfiq2;
+std::unique_ptr<NFIQ2::NFIQ2Algorithm> g_nfiq2;
 
 std::string
 GetYamlFilePath()
@@ -86,11 +86,11 @@ InitNfiq2(char **hash)
 	try {
 		if (g_nfiq2.get() == nullptr) {
 #ifdef EMBED_RANDOMFOREST_PARAMETERS
-			g_nfiq2 = std::unique_ptr<NFIQ::NFIQ2Algorithm>(
-			    new NFIQ::NFIQ2Algorithm());
+			g_nfiq2 = std::unique_ptr<NFIQ2::NFIQ2Algorithm>(
+			    new NFIQ2::NFIQ2Algorithm());
 #else
-			g_nfiq2 = std::unique_ptr<NFIQ::NFIQ2Algorithm>(
-			    new NFIQ::NFIQ2Algorithm(GetYamlFilePath(),
+			g_nfiq2 = std::unique_ptr<NFIQ2::NFIQ2Algorithm>(
+			    new NFIQ2::NFIQ2Algorithm(GetYamlFilePath(),
 				"ccd75820b48c19f1645ef5e9c481c592"));
 #endif
 			*hash = (char *)malloc(
@@ -110,17 +110,17 @@ ComputeNfiq2Score(int fpos, const unsigned char *pixels, int size, int width,
 {
 	try {
 		if (g_nfiq2.get() != nullptr) {
-			NFIQ::FingerprintImageData rawImage(
+			NFIQ2::FingerprintImageData rawImage(
 			    pixels, size, width, height, fpos, ppi);
-			std::vector<NFIQ::ActionableQualityFeedback>
+			std::vector<NFIQ2::ActionableQualityFeedback>
 			    actionableQuality;
-			std::vector<NFIQ::QualityFeatureData> featureVector;
-			std::vector<NFIQ::QualityFeatureSpeed> featureTimings;
+			std::vector<NFIQ2::QualityFeatureData> featureVector;
+			std::vector<NFIQ2::QualityFeatureSpeed> featureTimings;
 			int qualityScore = (int)g_nfiq2->computeQualityScore(
 			    rawImage);
 			return qualityScore;
 		}
-	} catch (const NFIQ::NFIQException &exc) {
+	} catch (const NFIQ2::NFIQException &exc) {
 		std::cerr << "NFIQ2 ERROR => Return code ["
 			  << exc.getReturnCode()
 			  << "]: " << exc.getErrorMessage() << std::endl;


### PR DESCRIPTION
Closes #233 

Changing 'NFIQ' namespace to 'NFIQ2' for clarity and to avoid future confusion. 