### PR TITLE
Add default constructor for Algorithm

### DIFF
--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2_algorithm.hpp
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2_algorithm.hpp
@@ -17,6 +17,12 @@ class Algorithm {
 	Algorithm();
 	Algorithm(const std::string &fileName, const std::string &fileHash);
 	Algorithm(const NFIQ2::ModelInfo &modelInfoObj);
+
+	Algorithm(const Algorithm &);
+	Algorithm &operator=(const Algorithm &);
+
+	Algorithm(Algorithm &&) noexcept;
+	Algorithm &operator=(Algorithm &&) noexcept;
 	~Algorithm();
 
 	/**
@@ -81,10 +87,7 @@ class Algorithm {
 
     private:
 	class Impl;
-	const std::unique_ptr<const Algorithm::Impl> pimpl;
-
-	Algorithm(const Algorithm &) = delete;
-	Algorithm &operator=(const Algorithm &) = delete;
+	std::unique_ptr<Algorithm::Impl> pimpl;
 };
 } // namespace NFIQ
 

--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2_algorithm.hpp
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2_algorithm.hpp
@@ -25,6 +25,8 @@ class Algorithm {
 	 * data
 	 * @param rawImage fingerprint image in raw format
 	 * @return achieved quality score
+	 * @throw Exception
+	 * Called before random forest parameters were loaded
 	 */
 	unsigned int computeQualityScore(
 	    const NFIQ2::FingerprintImageData &rawImage) const;
@@ -36,6 +38,8 @@ class Algorithm {
 	 * @param features list of computed feature metrics that contain quality
 	 * information for a fingerprint image
 	 * @return achieved quality score
+	 * @throw Exception
+	 * Called before random forest parameters were loaded
 	 */
 	unsigned int computeQualityScore(const std::vector<
 	    std::shared_ptr<NFIQ2::QualityFeatures::BaseFeature>> &features)
@@ -47,6 +51,8 @@ class Algorithm {
 	 * quality feature data
 	 * @param features map of string, quality feature data pairs
 	 * @return achieved quality score
+	 * @throw Exception
+	 * Called before random forest parameters were loaded
 	 */
 	unsigned int computeQualityScore(
 	    const std::unordered_map<std::string, NFIQ2::QualityFeatureData>
@@ -58,6 +64,8 @@ class Algorithm {
 	 *
 	 * @return
 	 * MD5 checksum of the Random Forest parameter file loaded.
+	 * @throw Exception
+	 * Called before random forest parameters were loaded.
 	 */
 	std::string getParameterHash() const;
 

--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2_algorithm.hpp
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2_algorithm.hpp
@@ -16,6 +16,8 @@ class NFIQ2Algorithm {
     public:
 #ifdef EMBED_RANDOMFOREST_PARAMETERS
 	NFIQ2Algorithm();
+#else
+	NFIQ2Algorithm();
 #endif
 	NFIQ2Algorithm(
 	    const std::string &fileName, const std::string &fileHash);

--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2_algorithm.hpp
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2_algorithm.hpp
@@ -69,6 +69,16 @@ class Algorithm {
 	 */
 	std::string getParameterHash() const;
 
+	/**
+	 * @brief
+	 * Determine if random forest parameters have been loaded.
+	 *
+	 * @return
+	 * true if some set of random forest parameters have been loaded, false
+	 * otherwise.
+	 */
+	bool isInitialized() const;
+
     private:
 	class Impl;
 	const std::unique_ptr<const Algorithm::Impl> pimpl;

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_algorithm.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_algorithm.cpp
@@ -8,6 +8,11 @@ NFIQ2::NFIQ2Algorithm::NFIQ2Algorithm()
     : pimpl { new NFIQ2::NFIQ2Algorithm::Impl() }
 {
 }
+#else
+NFIQ2::NFIQ2Algorithm::NFIQ2Algorithm()
+    : pimpl { new NFIQ2::NFIQ2Algorithm::Impl() }
+{
+}
 #endif
 
 NFIQ2::NFIQ2Algorithm::NFIQ2Algorithm(

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_algorithm.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_algorithm.cpp
@@ -9,8 +9,8 @@ NFIQ2::Algorithm::Algorithm()
 {
 }
 #else
-NFIQ2::NFIQ2Algorithm::NFIQ2Algorithm()
-    : pimpl { new NFIQ2::NFIQ2Algorithm::Impl() }
+NFIQ2::Algorithm::Algorithm()
+    : pimpl { new NFIQ2::Algorithm::Impl() }
 {
 }
 #endif

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_algorithm.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_algorithm.cpp
@@ -56,4 +56,10 @@ NFIQ2::Algorithm::getParameterHash() const
 	return (this->pimpl->getParameterHash());
 }
 
+bool
+NFIQ2::Algorithm::isInitialized() const
+{
+	return (this->pimpl->isInitialized());
+}
+
 NFIQ2::Algorithm::~Algorithm() = default;

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_algorithm.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_algorithm.cpp
@@ -20,6 +20,18 @@ NFIQ2::Algorithm::Algorithm(const NFIQ2::ModelInfo &modelInfoObj)
 {
 }
 
+NFIQ2::Algorithm::Algorithm(const Algorithm &rhs)
+    : pimpl(new Impl(*rhs.pimpl))
+{
+}
+
+NFIQ2::Algorithm &
+NFIQ2::Algorithm::operator=(const Algorithm &rhs)
+{
+	*pimpl = *rhs.pimpl;
+	return *this;
+}
+
 unsigned int
 NFIQ2::Algorithm::computeQualityScore(
     const NFIQ2::FingerprintImageData &rawImage) const
@@ -56,3 +68,5 @@ NFIQ2::Algorithm::isInitialized() const
 }
 
 NFIQ2::Algorithm::~Algorithm() = default;
+NFIQ2::Algorithm::Algorithm(NFIQ2::Algorithm &&) noexcept = default;
+NFIQ2::Algorithm &NFIQ2::Algorithm::operator=(Algorithm &&) noexcept = default;

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_algorithm.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_algorithm.cpp
@@ -3,17 +3,10 @@
 
 #include "nfiq2_algorithm_impl.hpp"
 
-#ifdef EMBED_RANDOMFOREST_PARAMETERS
 NFIQ2::Algorithm::Algorithm()
     : pimpl { new NFIQ2::Algorithm::Impl() }
 {
 }
-#else
-NFIQ2::Algorithm::Algorithm()
-    : pimpl { new NFIQ2::Algorithm::Impl() }
-{
-}
-#endif
 
 NFIQ2::Algorithm::Algorithm(
     const std::string &fileName, const std::string &fileHash)

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_algorithm_impl.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_algorithm_impl.cpp
@@ -39,7 +39,7 @@ NFIQ2::Algorithm::Impl::Impl()
 	this->m_parameterHash = m_RandomForestML.initModule();
 }
 #else
-NFIQ2::NFIQ2Algorithm::Impl::Impl()
+NFIQ2::Algorithm::Impl::Impl()
     : initialized { false }
 {
 }

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_algorithm_impl.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_algorithm_impl.cpp
@@ -15,7 +15,6 @@
 
 #include "nfiq2_algorithm_impl.hpp"
 #include <iomanip>
-#include <list>
 #include <string>
 #include <vector>
 

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_algorithm_impl.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_algorithm_impl.cpp
@@ -73,9 +73,7 @@ NFIQ2::Algorithm::Impl::Impl(
 	}
 }
 
-NFIQ2::Algorithm::Impl::~Impl()
-{
-}
+NFIQ2::Algorithm::Impl::~Impl() = default;
 
 double
 NFIQ2::Algorithm::Impl::getQualityPrediction(

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_algorithm_impl.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_algorithm_impl.cpp
@@ -12,7 +12,6 @@
 #include <nfiq2_fingerprintimagedata.hpp>
 #include <nfiq2_qualityfeatures.hpp>
 #include <nfiq2_timer.hpp>
-#include <string.h>
 
 #include "nfiq2_algorithm_impl.hpp"
 #include <iomanip>

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_algorithm_impl.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_algorithm_impl.cpp
@@ -28,29 +28,24 @@ set_fpu(unsigned int mode)
 }
 #endif
 
-#ifdef EMBED_RANDOMFOREST_PARAMETERS
-NFIQ2::Algorithm::Impl::Impl()
-{
-#if defined(__linux) && defined(__i386__)
-	set_fpu(0x27F); /* use double-precision rounding */
-#endif
-	// init RF module that takes some time to load the parameters
-	this->m_parameterHash = m_RandomForestML.initModule();
-	this->initialized = true;
-}
-#else
 NFIQ2::Algorithm::Impl::Impl()
     : initialized { false }
 {
-}
-#endif
-
-NFIQ2::Algorithm::Impl::Impl(
-    const std::string &fileName, const std::string &fileHash)
-{
 #if defined(__linux) && defined(__i386__)
 	set_fpu(0x27F); /* use double-precision rounding */
 #endif
+
+#ifdef EMBED_RANDOMFOREST_PARAMETERS
+	// init RF module that takes some time to load the parameters
+	this->m_parameterHash = m_RandomForestML.initModule();
+	this->initialized = true;
+#endif
+}
+
+NFIQ2::Algorithm::Impl::Impl(
+    const std::string &fileName, const std::string &fileHash)
+    : Impl()
+{
 	// init RF module that takes some time to load the parameters
 	try {
 		this->m_parameterHash = m_RandomForestML.initModule(

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_algorithm_impl.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_algorithm_impl.cpp
@@ -30,13 +30,13 @@ set_fpu(unsigned int mode)
 
 #ifdef EMBED_RANDOMFOREST_PARAMETERS
 NFIQ2::Algorithm::Impl::Impl()
-    : initialized { true }
 {
 #if defined(__linux) && defined(__i386__)
 	set_fpu(0x27F); /* use double-precision rounding */
 #endif
 	// init RF module that takes some time to load the parameters
 	this->m_parameterHash = m_RandomForestML.initModule();
+	this->initialized = true;
 }
 #else
 NFIQ2::Algorithm::Impl::Impl()
@@ -47,7 +47,6 @@ NFIQ2::Algorithm::Impl::Impl()
 
 NFIQ2::Algorithm::Impl::Impl(
     const std::string &fileName, const std::string &fileHash)
-    : initialized { true }
 {
 #if defined(__linux) && defined(__i386__)
 	set_fpu(0x27F); /* use double-precision rounding */
@@ -56,6 +55,7 @@ NFIQ2::Algorithm::Impl::Impl(
 	try {
 		this->m_parameterHash = m_RandomForestML.initModule(
 		    fileName, fileHash);
+		this->initialized = true;
 	} catch (const cv::Exception &e) {
 		throw Exception(NFIQ2::ErrorCode::BadArguments,
 		    "Could not initialize random forest parameters with "

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_algorithm_impl.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_algorithm_impl.cpp
@@ -37,6 +37,11 @@ NFIQ2::NFIQ2Algorithm::Impl::Impl()
 	// init RF module that takes some time to load the parameters
 	this->m_parameterHash = m_RandomForestML.initModule();
 }
+#else
+NFIQ2::NFIQ2Algorithm::Impl::Impl()
+{
+	// default constructor
+}
 #endif
 
 NFIQ2::NFIQ2Algorithm::Impl::Impl(

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_algorithm_impl.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_algorithm_impl.cpp
@@ -80,6 +80,8 @@ NFIQ2::Algorithm::Impl::getQualityPrediction(
     const std::unordered_map<std::string, NFIQ2::QualityFeatureData> &features)
     const
 {
+	this->throwIfUninitialized();
+
 	const double utility {};
 	double deviation {};
 	double quality {};
@@ -93,6 +95,7 @@ NFIQ2::Algorithm::Impl::computeQualityScore(
     const std::vector<std::shared_ptr<NFIQ2::QualityFeatures::BaseFeature>>
 	&features) const
 {
+	this->throwIfUninitialized();
 
 	const std::unordered_map<std::string, NFIQ2::QualityFeatureData>
 	    quality = NFIQ2::QualityFeatures::getQualityFeatureData(features);
@@ -122,6 +125,7 @@ unsigned int
 NFIQ2::Algorithm::Impl::computeQualityScore(
     const NFIQ2::FingerprintImageData &rawImage) const
 {
+	this->throwIfUninitialized();
 
 	// --------------------------------------------------------
 	// compute quality features (including actionable feedback)
@@ -172,11 +176,23 @@ NFIQ2::Algorithm::Impl::computeQualityScore(
     const std::unordered_map<std::string, NFIQ2::QualityFeatureData> &features)
     const
 {
+	this->throwIfUninitialized();
+
 	return (unsigned int)getQualityPrediction(features);
 }
 
 std::string
 NFIQ2::Algorithm::Impl::getParameterHash() const
 {
+	this->throwIfUninitialized();
+
 	return (this->m_parameterHash);
+}
+
+void
+NFIQ2::Algorithm::Impl::throwIfUninitialized() const
+{
+	if (!this->initialized)
+		throw NFIQ2::Exception { NFIQ2::ErrorCode::MachineLearningError,
+			"Random forest parameters were not loaded" };
 }

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_algorithm_impl.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_algorithm_impl.cpp
@@ -192,7 +192,13 @@ NFIQ2::Algorithm::Impl::getParameterHash() const
 void
 NFIQ2::Algorithm::Impl::throwIfUninitialized() const
 {
-	if (!this->initialized)
+	if (!this->isInitialized())
 		throw NFIQ2::Exception { NFIQ2::ErrorCode::MachineLearningError,
 			"Random forest parameters were not loaded" };
+}
+
+bool
+NFIQ2::Algorithm::Impl::isInitialized() const
+{
+	return (this->initialized);
 }

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_algorithm_impl.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_algorithm_impl.cpp
@@ -30,6 +30,7 @@ set_fpu(unsigned int mode)
 
 #ifdef EMBED_RANDOMFOREST_PARAMETERS
 NFIQ2::NFIQ2Algorithm::Impl::Impl()
+    : initialized { true }
 {
 #if defined(__linux) && defined(__i386__)
 	set_fpu(0x27F); /* use double-precision rounding */
@@ -39,13 +40,14 @@ NFIQ2::NFIQ2Algorithm::Impl::Impl()
 }
 #else
 NFIQ2::NFIQ2Algorithm::Impl::Impl()
+    : initialized { false }
 {
-	// default constructor
 }
 #endif
 
 NFIQ2::NFIQ2Algorithm::Impl::Impl(
     const std::string &fileName, const std::string &fileHash)
+    : initialized { true }
 {
 #if defined(__linux) && defined(__i386__)
 	set_fpu(0x27F); /* use double-precision rounding */

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_algorithm_impl.hpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_algorithm_impl.hpp
@@ -87,6 +87,7 @@ class NFIQ2Algorithm::Impl {
 	std::string getParameterHash() const;
 
     private:
+	bool initialized {};
 	/**
 	 * @throws NFIQException
 	 * Failure to compute (OpenCV reason contained within message string).

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_algorithm_impl.hpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_algorithm_impl.hpp
@@ -83,7 +83,8 @@ class Algorithm::Impl {
 	std::string getParameterHash() const;
 
     private:
-	bool initialized {};
+	/** Whether or not random forest parameters have been loaded. */
+	bool initialized { false };
 	/**
 	 * @throws Exception
 	 * Failure to compute (OpenCV reason contained within message string).

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_algorithm_impl.hpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_algorithm_impl.hpp
@@ -93,6 +93,15 @@ class Algorithm::Impl {
 	    const std::unordered_map<std::string, NFIQ2::QualityFeatureData>
 		&features) const;
 
+	/**
+	 * @brief
+	 * Throw an exception if random forest parameters have not been loaded.
+	 *
+	 * @throw
+	 * NFIQ2::Exception if random forest parameters have not been loaded.
+	 */
+	void throwIfUninitialized() const;
+
 	NFIQ2::Prediction::RandomForestML m_RandomForestML;
 	std::string m_parameterHash {};
 };

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_algorithm_impl.hpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_algorithm_impl.hpp
@@ -91,6 +91,9 @@ class Algorithm::Impl {
 	 */
 	std::string getParameterHash() const;
 
+	/** @return Whether or not random forest parameters have been loaded. */
+	bool isInitialized() const;
+
     private:
 	/** Whether or not random forest parameters have been loaded. */
 	bool initialized { false };

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_algorithm_impl.hpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_algorithm_impl.hpp
@@ -46,6 +46,8 @@ class Algorithm::Impl {
 	 * data
 	 * @param rawImage fingerprint image in raw format
 	 * @return achieved quality score
+	 * @throw Exception
+	 * Called before random forest parameters were loaded
 	 */
 	unsigned int computeQualityScore(
 	    const NFIQ2::FingerprintImageData &rawImage) const;
@@ -57,6 +59,8 @@ class Algorithm::Impl {
 	 * @param features list of computed feature metrics that contain quality
 	 * information for a fingerprint image
 	 * @return achieved quality score
+	 * @throw Exception
+	 * Called before random forest parameters were loaded
 	 */
 	unsigned int computeQualityScore(const std::vector<
 	    std::shared_ptr<NFIQ2::QualityFeatures::BaseFeature>> &features)
@@ -68,6 +72,8 @@ class Algorithm::Impl {
 	 * quality feature data
 	 * @param features map of string, quality feature data pairs
 	 * @return achieved quality score
+	 * @throw Exception
+	 * Called before random forest parameters were loaded
 	 */
 	unsigned int computeQualityScore(
 	    const std::unordered_map<std::string, NFIQ2::QualityFeatureData>
@@ -79,6 +85,9 @@ class Algorithm::Impl {
 	 *
 	 * @return
 	 * MD5 checksum of the Random Forest parameter file loaded.
+	 *
+	 * @throw Exception
+	 * Called before random forest parameters were loaded
 	 */
 	std::string getParameterHash() const;
 
@@ -87,7 +96,8 @@ class Algorithm::Impl {
 	bool initialized { false };
 	/**
 	 * @throws Exception
-	 * Failure to compute (OpenCV reason contained within message string).
+	 * Failure to compute (OpenCV reason contained within message string) or
+	 * called before random forest parameters loaded.
 	 */
 	double getQualityPrediction(
 	    const std::unordered_map<std::string, NFIQ2::QualityFeatureData>
@@ -97,8 +107,8 @@ class Algorithm::Impl {
 	 * @brief
 	 * Throw an exception if random forest parameters have not been loaded.
 	 *
-	 * @throw
-	 * NFIQ2::Exception if random forest parameters have not been loaded.
+	 * @throw NFIQ2::Exception
+	 * Random forest parameters have not been loaded.
 	 */
 	void throwIfUninitialized() const;
 

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_algorithm_impl.hpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_algorithm_impl.hpp
@@ -30,6 +30,8 @@ class NFIQ2Algorithm::Impl {
 	 */
 #ifdef EMBED_RANDOMFOREST_PARAMETERS
 	Impl();
+#else
+	Impl();
 #endif
 	Impl(const std::string &fileName, const std::string &fileHash);
 

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_algorithm_impl.hpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_algorithm_impl.hpp
@@ -28,11 +28,7 @@ class Algorithm::Impl {
 	/**
 	 * @brief Default constructor of Impl
 	 */
-#ifdef EMBED_RANDOMFOREST_PARAMETERS
 	Impl();
-#else
-	Impl();
-#endif
 	Impl(const std::string &fileName, const std::string &fileHash);
 
 	/**

--- a/examples/example_api.cpp
+++ b/examples/example_api.cpp
@@ -66,9 +66,9 @@ main(int argc, char **argv)
 
 	// This segment loads the model into memory so that it can be used to
 	// generate a NFIQ 2 score.
-	std::unique_ptr<NFIQ2::Algorithm> model {};
+	NFIQ2::Algorithm model {};
 	try {
-		model.reset(new NFIQ2::Algorithm(modelInfoObj));
+		model = NFIQ2::Algorithm(modelInfoObj);
 	} catch (...) {
 		std::cout
 		    << "Could not initialize model from model info file\n";
@@ -111,7 +111,7 @@ main(int argc, char **argv)
 	// NFIQ 2 quality score
 	unsigned int nfiq2 {};
 	try {
-		nfiq2 = model->computeQualityScore(features);
+		nfiq2 = model.computeQualityScore(features);
 	} catch (...) {
 		std::cout << "Error in calculating NFIQ 2 score\n";
 		return (EXIT_FAILURE);


### PR DESCRIPTION
Closes #187 

Implements a default constructor for the Algorithm object. Makes slight modifications to pimpl implementation for compatibility. Updated API example code to work with new default constructor.