### PR TITLE
Fixed Compiler warnings

### DIFF
--- a/NFIQ2/NFIQ2Algorithm/CMakeLists.txt
+++ b/NFIQ2/NFIQ2Algorithm/CMakeLists.txt
@@ -4,6 +4,8 @@ project( nfiq2 )
 
 set (CMAKE_CXX_STANDARD 11)
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic")
+
 include(GNUInstallDirs)
 
 include( "${SUPERBUILD_ROOT_PATH}/cmake/colors.cmake" )

--- a/NFIQ2/NFIQ2Algorithm/CMakeLists.txt
+++ b/NFIQ2/NFIQ2Algorithm/CMakeLists.txt
@@ -4,8 +4,6 @@ project( nfiq2 )
 
 set (CMAKE_CXX_STANDARD 11)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic")
-
 include(GNUInstallDirs)
 
 include( "${SUPERBUILD_ROOT_PATH}/cmake/colors.cmake" )

--- a/NFIQ2/NFIQ2Algorithm/include/features/FeatureFunctions.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/FeatureFunctions.h
@@ -33,7 +33,7 @@ void getRotatedBlock(const cv::Mat &block, const double orientation,
 void getRidgeValleyStructure(const cv::Mat &blockCropped,
     std::vector<uint8_t> &ridval, std::vector<double> &dt);
 void Conv2D(const cv::Mat &im, const cv::Mat &filter, cv::Mat &ConvOut,
-    const cv::Size &imageSize, const cv::Size &dftSize, bool imDFTFlag);
+    const cv::Size &imageSize, const cv::Size &dftSize);
 void GaborFilterCx(const int ksize, const double theta, const double freq,
     const int sigma, cv::Mat &FilterOut);
 
@@ -42,20 +42,20 @@ double calccoh(double gxx, double gyy, double gxy);
 double calcof(double gsxavg, double gsyavg);
 
 cv::Mat computeNumericalGradientX(const cv::Mat &mat);
-void computeNumericalGradients(
-    const cv::Mat &mat, cv::Mat &grad_x, cv::Mat &grad_y);
+void computeNumericalGradients(const cv::Mat &mat, cv::Mat &grad_x,
+    cv::Mat &grad_y);
 
-void addSamplingFeatures(
-    std::vector<NFIQ2::QualityFeatureResult> &featureDataList,
+void
+addSamplingFeatures(std::vector<NFIQ2::QualityFeatureResult> &featureDataList,
     std::string featurePrefix, std::vector<double> &dataVector);
-void addHistogramFeatures(
-    std::vector<NFIQ2::QualityFeatureResult> &featureDataList,
+void
+addHistogramFeatures(std::vector<NFIQ2::QualityFeatureResult> &featureDataList,
     std::string featurePrefix, std::vector<double> &binBoundaries,
     std::vector<double> &dataVector, int binCount);
-void addSamplingFeatureNames(
-    std::vector<std::string> &featureNames, const char *prefix);
-void addHistogramFeatureNames(
-    std::vector<std::string> &featureNames, const char *prefix, int binCount);
+void addSamplingFeatureNames(std::vector<std::string> &featureNames,
+    const char *prefix);
+void addHistogramFeatureNames(std::vector<std::string> &featureNames,
+    const char *prefix, int binCount);
 #endif
 }
 }

--- a/NFIQ2/NFIQ2Algorithm/include/prediction/RandomForestML.h
+++ b/NFIQ2/NFIQ2Algorithm/include/prediction/RandomForestML.h
@@ -21,14 +21,12 @@ class RandomForestML {
 #ifdef NFIQ2_EMBED_RANDOM_FOREST_PARAMETERS
 	std::string initModule();
 #endif
-	std::string initModule(
-	    const std::string &fileName, const std::string &fileHash);
+	std::string initModule(const std::string &fileName,
+	    const std::string &fileHash);
 
-	void evaluate(
-	    const std::unordered_map<std::string, NFIQ2::QualityFeatureData>
-		&features,
-	    const double &utilityValue, double &qualityValue,
-	    double &deviation) const;
+	void evaluate(const std::unordered_map<std::string,
+			  NFIQ2::QualityFeatureData> &features,
+	    double &qualityValue) const;
 
     private:
 	cv::Ptr<cv::ml::RTrees> m_pTrainedRF;

--- a/NFIQ2/NFIQ2Algorithm/src/features/FeatureFunctions.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FeatureFunctions.cpp
@@ -307,8 +307,8 @@ NFIQ2::QualityFeatures::getRotatedBlock(const cv::Mat &block,
 	}
 
 	if (padFlag) {
-		cv::copyMakeBorder(
-		    block, Inblock, 2, 2, 2, 2, cv::BORDER_CONSTANT, 0);
+		cv::copyMakeBorder(block, Inblock, 2, 2, 2, 2,
+		    cv::BORDER_CONSTANT, 0);
 	} else {
 		Inblock = block;
 	}
@@ -318,8 +318,8 @@ NFIQ2::QualityFeatures::getRotatedBlock(const cv::Mat &block,
 		//   rad2deg(orientation), 'nearest', 'crop');
 		rotatedBlock.create(block.rows, block.cols, block.type());
 		double orientDegrees = orientation * Rad2Deg;
-		cv::Point2f center(
-		    ((float)Inblock.cols / 2.0f), ((float)Inblock.rows / 2.0f));
+		cv::Point2f center(((float)Inblock.cols / 2.0f),
+		    ((float)Inblock.rows / 2.0f));
 		rot_mat = getRotationMatrix2D(center, orientDegrees, 1);
 		cv::warpAffine(Inblock, rotatedBlock, rot_mat,
 		    rotatedBlock.size(), cv::INTER_NEAREST);
@@ -383,6 +383,7 @@ NFIQ2::QualityFeatures::getRidgeValleyStructure(const cv::Mat &blockCropped,
 	// platforms (10^10)
 
 	dt1.forEach<double>([&](double &val, const int *position) {
+		(void)position;
 		val = round(val * 10000000000) / 10000000000;
 	});
 
@@ -437,8 +438,8 @@ NFIQ2::QualityFeatures::GaborFilterCx(const int ksize, const double theta,
 			tmpreal = tmp * cos(2 * CV_PI * freq * x1);
 			tmpimag = tmp * sin(2 * CV_PI * freq * x1);
 			std::complex<double> fourier(tmpreal, tmpimag);
-			FilterOut.at<std::complex<double>>(
-			    j + ks2, i + ks2) = fourier;
+			FilterOut.at<std::complex<double>>(j + ks2,
+			    i + ks2) = fourier;
 		}
 	}
 	return;
@@ -448,8 +449,7 @@ NFIQ2::QualityFeatures::GaborFilterCx(const int ksize, const double theta,
 
 void
 NFIQ2::QualityFeatures::Conv2D(const cv::Mat &imDFT, const cv::Mat &filter,
-    cv::Mat &ConvOut, const cv::Size &imageSize, const cv::Size &dftSize,
-    bool imDFTFlag)
+    cv::Mat &ConvOut, const cv::Size &imageSize, const cv::Size &dftSize)
 {
 	int OutType = filter.type();
 	ConvOut.create(imageSize, OutType);
@@ -460,8 +460,8 @@ NFIQ2::QualityFeatures::Conv2D(const cv::Mat &imDFT, const cv::Mat &filter,
 
 	cv::Mat kernTmp(dftSize, filter.type(), cv::Scalar::all(0));
 	// Copy the filter to the upper left corner of the tmp array
-	cv::Mat kernROI(
-	    kernTmp, cv::Range(0, filter.rows), cv::Range(0, filter.cols));
+	cv::Mat kernROI(kernTmp, cv::Range(0, filter.rows),
+	    cv::Range(0, filter.cols));
 	filter.copyTo(kernROI);
 	cv::dft(kernTmp, kernTmp, cv::DFT_COMPLEX_OUTPUT);
 
@@ -518,8 +518,8 @@ NFIQ2::QualityFeatures::computeNumericalGradientX(const cv::Mat &mat)
 }
 
 void
-NFIQ2::QualityFeatures::computeNumericalGradients(
-    const cv::Mat &mat, cv::Mat &grad_x, cv::Mat &grad_y)
+NFIQ2::QualityFeatures::computeNumericalGradients(const cv::Mat &mat,
+    cv::Mat &grad_x, cv::Mat &grad_y)
 {
 	// get x-gradient
 	grad_x = computeNumericalGradientX(mat);

--- a/NFIQ2/NFIQ2Algorithm/src/features/FeatureFunctions.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FeatureFunctions.cpp
@@ -382,8 +382,7 @@ NFIQ2::QualityFeatures::getRidgeValleyStructure(const cv::Mat &blockCropped,
 	// Round to 10 decimal points to preserve score consistency across
 	// platforms (10^10)
 
-	dt1.forEach<double>([&](double &val, const int *position) {
-		(void)position;
+	dt1.forEach<double>([&](double &val, const int *) {
 		val = round(val * 10000000000) / 10000000000;
 	});
 

--- a/NFIQ2/NFIQ2Algorithm/src/features/FingerJetFXFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FingerJetFXFeature.cpp
@@ -28,8 +28,9 @@ NFIQ2::QualityFeatures::FingerJetFXFeature::centerOfMinutiaeMass(
 		lx += m.x;
 		ly += m.y;
 	}
-	return std::make_pair<unsigned int, unsigned int>(
-	    lx / minutiaData.size(), ly / minutiaData.size());
+	return std::make_pair<unsigned int, unsigned int>(lx /
+		minutiaData.size(),
+	    ly / minutiaData.size());
 }
 
 std::string
@@ -166,8 +167,8 @@ NFIQ2::QualityFeatures::FingerJetFXFeature::computeFeatureData(
 	}
 
 	unsigned int minCnt { 0 };
-	const FRFXLL_RESULT fxResMin = FRFXLLGetMinutiaInfo(
-	    hFeatureSet, &minCnt, nullptr);
+	const FRFXLL_RESULT fxResMin = FRFXLLGetMinutiaInfo(hFeatureSet,
+	    &minCnt, nullptr);
 	if (!FRFXLL_SUCCESS(fxResMin)) {
 		FRFXLLCloseHandle(&hFeatureSet);
 		throw NFIQ2::Exception(
@@ -185,8 +186,8 @@ NFIQ2::QualityFeatures::FingerJetFXFeature::computeFeatureData(
 		    "Could not allocate space for extracted minutiae records.");
 	}
 
-	const FRFXLL_RESULT fxResData = FRFXLLGetMinutiae(
-	    hFeatureSet, BASIC_19794_2_MINUTIA_STRUCT, &minCnt, mdata.get());
+	const FRFXLL_RESULT fxResData = FRFXLLGetMinutiae(hFeatureSet,
+	    BASIC_19794_2_MINUTIA_STRUCT, &minCnt, mdata.get());
 	if (!FRFXLL_SUCCESS(fxResData)) {
 		FRFXLLCloseHandle(&hFeatureSet);
 		throw NFIQ2::Exception(
@@ -197,9 +198,9 @@ NFIQ2::QualityFeatures::FingerJetFXFeature::computeFeatureData(
 
 	this->minutiaData_.clear();
 	this->minutiaData_.reserve(minCnt);
-	for (int i = 0; i < minCnt; i++) {
-		this->minutiaData_.emplace_back(
-		    static_cast<unsigned int>(mdata[i].x),
+	for (unsigned int i = 0; i < minCnt; i++) {
+		this->minutiaData_.emplace_back(static_cast<unsigned int>(
+						    mdata[i].x),
 		    static_cast<unsigned int>(mdata[i].y),
 		    static_cast<unsigned int>(mdata[i].a),
 		    static_cast<unsigned int>(mdata[i].q),
@@ -247,8 +248,8 @@ NFIQ2::QualityFeatures::FingerJetFXFeature::computeFeatureData(
 	rect200x200.height = 200;
 	vecRectDimensions.push_back(rect200x200);
 
-	FingerJetFXFeature::FJFXROIResults roiResults = computeROI(
-	    32, fingerprintImage, vecRectDimensions);
+	FingerJetFXFeature::FJFXROIResults roiResults = computeROI(32,
+	    fingerprintImage, vecRectDimensions);
 	double noOfMinInRect200x200 = 0;
 	for (unsigned int i = 0;
 	     i < roiResults.vecNoOfMinutiaeInRectangular.size(); i++) {
@@ -373,8 +374,10 @@ NFIQ2::QualityFeatures::FingerJetFXFeature::computeROI(int bs,
 
 		unsigned int noOfMinutiaeInRect = 0;
 		for (const auto &m : this->minutiaData_) {
-			if (m.x >= startX && m.x <= endX && m.y >= startY &&
-			    m.y <= endY) {
+			if (m.x >= static_cast<unsigned int>(startX) &&
+			    m.x <= static_cast<unsigned int>(endX) &&
+			    m.y >= static_cast<unsigned int>(startY) &&
+			    m.y <= static_cast<unsigned int>(endY)) {
 				// minutia is inside rectangular
 				noOfMinutiaeInRect++;
 			}

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_algorithm_impl.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_algorithm_impl.cpp
@@ -28,14 +28,14 @@ NFIQ2::Algorithm::Impl::Impl()
 #endif
 }
 
-NFIQ2::Algorithm::Impl::Impl(
-    const std::string &fileName, const std::string &fileHash)
+NFIQ2::Algorithm::Impl::Impl(const std::string &fileName,
+    const std::string &fileHash)
     : initialized { false }
 {
 	// init RF module that takes some time to load the parameters
 	try {
-		this->m_parameterHash = m_RandomForestML.initModule(
-		    fileName, fileHash);
+		this->m_parameterHash = m_RandomForestML.initModule(fileName,
+		    fileHash);
 		this->initialized = true;
 	} catch (const cv::Exception &e) {
 		throw Exception(NFIQ2::ErrorCode::BadArguments,
@@ -66,7 +66,7 @@ NFIQ2::Algorithm::Impl::getQualityPrediction(
 	const double utility {};
 	double deviation {};
 	double quality {};
-	m_RandomForestML.evaluate(features, utility, quality, deviation);
+	m_RandomForestML.evaluate(features, quality);
 
 	return quality;
 }
@@ -124,8 +124,8 @@ NFIQ2::Algorithm::Impl::computeQualityScore(
 		 * Nothing should get here, but computeQualityFeatures() calls
 		 * a lot of code...
 		 */
-		throw NFIQ2::Exception(
-		    NFIQ2::ErrorCode::UnknownError, e.what());
+		throw NFIQ2::Exception(NFIQ2::ErrorCode::UnknownError,
+		    e.what());
 	}
 
 	const std::unordered_map<std::string, NFIQ2::QualityFeatureData>

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_algorithm_impl.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_algorithm_impl.cpp
@@ -63,8 +63,6 @@ NFIQ2::Algorithm::Impl::getQualityPrediction(
 {
 	this->throwIfUninitialized();
 
-	const double utility {};
-	double deviation {};
 	double quality {};
 	m_RandomForestML.evaluate(features, quality);
 

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures_impl.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures_impl.cpp
@@ -31,7 +31,8 @@ NFIQ2::QualityFeatures::Impl::getQualityFeatureSpeeds(
 
 	std::unordered_map<std::string, NFIQ2::QualityFeatureSpeed> speedMap {};
 
-	for (auto i = 0; i < speedIdentifiers.size(); i++) {
+	for (std::vector<std::string>::size_type i = 0;
+	     i < speedIdentifiers.size(); i++) {
 		speedMap[speedIdentifiers.at(i)] = features.at(i)->getSpeed();
 	}
 
@@ -90,7 +91,7 @@ NFIQ2::QualityFeatures::Impl::getActionableQualityFeedback(
 	std::unordered_map<std::string, NFIQ2::ActionableQualityFeedback>
 	    actionableMap {};
 
-	for (const auto feature : features) {
+	for (const auto &feature : features) {
 		if (feature->getModuleName().compare("NFIQ2_Mu") == 0) {
 			// Uniform and Contrast
 			const std::shared_ptr<MuFeature> muFeatureModule =
@@ -211,13 +212,20 @@ NFIQ2::QualityFeatures::Impl::getActionableQualityFeedback(
 	return actionableMap;
 }
 
+// Defined in 32-bit linux operating systems with floating point
+// mode as a paramenter, otherwise this parameter is unused.
+#if defined(__linux) && defined(__i386__)
 void
 NFIQ2::QualityFeatures::Impl::setFPU(unsigned int mode)
 {
-#if defined(__linux) && defined(__i386__)
 	asm("fldcw %0" : : "m"(*&mode));
-#endif
 }
+#else
+void
+NFIQ2::QualityFeatures::Impl::setFPU(unsigned int)
+{
+}
+#endif
 
 std::vector<std::shared_ptr<NFIQ2::QualityFeatures::BaseFeature>>
 NFIQ2::QualityFeatures::Impl::computeQualityFeatures(
@@ -238,9 +246,10 @@ NFIQ2::QualityFeatures::Impl::computeQualityFeatures(
 	    std::make_shared<FingerJetFXFeature>(croppedImage);
 	features.push_back(fjfxFeatureModule);
 
-	features.push_back(std::make_shared<FJFXMinutiaeQualityFeature>(
-	    croppedImage, fjfxFeatureModule->getMinutiaData(),
-	    fjfxFeatureModule->getTemplateStatus()));
+	features.push_back(
+	    std::make_shared<FJFXMinutiaeQualityFeature>(croppedImage,
+		fjfxFeatureModule->getMinutiaData(),
+		fjfxFeatureModule->getTemplateStatus()));
 
 	std::shared_ptr<ImgProcROIFeature> roiFeatureModule =
 	    std::make_shared<ImgProcROIFeature>(croppedImage);
@@ -254,8 +263,8 @@ NFIQ2::QualityFeatures::Impl::computeQualityFeatures(
 
 	features.push_back(std::make_shared<OFFeature>(croppedImage));
 
-	features.push_back(std::make_shared<QualityMapFeatures>(
-	    croppedImage, roiFeatureModule->getImgProcResults()));
+	features.push_back(std::make_shared<QualityMapFeatures>(croppedImage,
+	    roiFeatureModule->getImgProcResults()));
 
 	features.push_back(
 	    std::make_shared<RVUPHistogramFeature>(croppedImage));
@@ -297,8 +306,8 @@ NFIQ2::QualityFeatures::Impl::getAllQualityFeatureIDs()
 	std::vector<std::string> qualityFeatureIDs {};
 
 	for (auto &vec : vov) {
-		qualityFeatureIDs.insert(
-		    qualityFeatureIDs.end(), vec.cbegin(), vec.cend());
+		qualityFeatureIDs.insert(qualityFeatureIDs.end(), vec.cbegin(),
+		    vec.cend());
 	}
 
 	return qualityFeatureIDs;

--- a/NFIQ2/NFIQ2Algorithm/src/prediction/RandomForestML.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/prediction/RandomForestML.cpp
@@ -103,8 +103,8 @@ NFIQ2::Prediction::RandomForestML::initModule()
 #endif
 
 std::string
-NFIQ2::Prediction::RandomForestML::initModule(
-    const std::string &fileName, const std::string &fileHash)
+NFIQ2::Prediction::RandomForestML::initModule(const std::string &fileName,
+    const std::string &fileHash)
 {
 	std::ifstream input(fileName);
 	std::string params((std::istreambuf_iterator<char>(input)),
@@ -125,7 +125,7 @@ NFIQ2::Prediction::RandomForestML::initModule(
 void
 NFIQ2::Prediction::RandomForestML::evaluate(
     const std::unordered_map<std::string, NFIQ2::QualityFeatureData> &features,
-    const double &utilityValue, double &qualityValue, double &deviation) const
+    double &qualityValue) const
 {
 	/**
 	   The following ordering of feature keys is critical to the
@@ -171,11 +171,9 @@ NFIQ2::Prediction::RandomForestML::evaluate(
 			    "prediction!");
 		}
 
-		deviation = 0.0; // ignore deviation here
-
 		// copy data to structure
-		cv::Mat sample_data = cv::Mat(
-		    1, featureVector.size(), CV_32FC1);
+		cv::Mat sample_data = cv::Mat(1, featureVector.size(),
+		    CV_32FC1);
 		std::vector<NFIQ2::QualityFeatureData>::const_iterator it_feat;
 		unsigned int counterFeatures = 0;
 		for (it_feat = featureVector.begin();
@@ -185,16 +183,16 @@ NFIQ2::Prediction::RandomForestML::evaluate(
 				sample_data.at<float>(0, counterFeatures) =
 				    (float)it_feat->featureDataDouble;
 			} else {
-				sample_data.at<float>(
-				    0, counterFeatures) = 0.0f;
+				sample_data.at<float>(0,
+				    counterFeatures) = 0.0f;
 			}
 			counterFeatures++;
 		}
 
 		// returns probability that between 0 and 1 that result belongs
 		// to second class
-		float prob = m_pTrainedRF->predict(
-		    sample_data, cv::noArray(), cv::ml::StatModel::RAW_OUTPUT);
+		float prob = m_pTrainedRF->predict(sample_data, cv::noArray(),
+		    cv::ml::StatModel::RAW_OUTPUT);
 		// return quality value
 		qualityValue = (int)(prob + 0.5);
 


### PR DESCRIPTION
Added -Wall -Wextra -pedantic compiler options to Mac build to see additional compiler warnings that are otherwise suppressed. Fixed the issues that appeared