### PR TITLE
Remove quality_feature_result_t returnCode

### DIFF
--- a/NFIQ2/NFIQ2Algorithm/include/features/FeatureFunctions.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/FeatureFunctions.h
@@ -45,9 +45,6 @@ cv::Mat computeNumericalGradientX(const cv::Mat &mat);
 void computeNumericalGradients(
     const cv::Mat &mat, cv::Mat &grad_x, cv::Mat &grad_y);
 
-void addSamplingFeatures(
-    std::vector<NFIQ2::QualityFeatureResult> &featureDataList,
-    std::string featurePrefix, std::vector<double> &dataVector);
 void addHistogramFeatures(
     std::vector<NFIQ2::QualityFeatureResult> &featureDataList,
     std::string featurePrefix, std::vector<double> &binBoundaries,

--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2_interfacedefinitions.hpp
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2_interfacedefinitions.hpp
@@ -96,8 +96,6 @@ typedef struct feature_speed_t {
 typedef struct quality_feature_result_t {
 	/** The quality feature data. */
 	NFIQ2::QualityFeatureData featureData;
-	/** The return code of the quality feature extraction operation. */
-	uint32_t returnCode;
 } QualityFeatureResult;
 
 /** This type represents the result of a comparison scores computation. */

--- a/NFIQ2/NFIQ2Algorithm/src/features/FJFXMinutiaeQualityFeatures.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FJFXMinutiaeQualityFeatures.cpp
@@ -52,7 +52,6 @@ NFIQ2::QualityFeatures::FJFXMinutiaeQualityFeature::computeFeatureData(
 	fd_mu.featureDataDouble = -1;
 	NFIQ2::QualityFeatureResult res_mu;
 	res_mu.featureData = fd_mu;
-	res_mu.returnCode = 0;
 
 	NFIQ2::QualityFeatureData fd_ocl;
 	fd_ocl.featureID = "FJFXPos_OCL_MinutiaeQuality_80";
@@ -60,15 +59,12 @@ NFIQ2::QualityFeatures::FJFXMinutiaeQualityFeature::computeFeatureData(
 	fd_ocl.featureDataDouble = -1;
 	NFIQ2::QualityFeatureResult res_ocl;
 	res_ocl.featureData = fd_ocl;
-	res_ocl.returnCode = 0;
 
 	if (!this->templateCouldBeExtracted_) {
 		res_mu.featureData.featureDataDouble = -1;
-		res_mu.returnCode = 0;
 		featureDataList.push_back(res_mu);
 
 		res_ocl.featureData.featureDataDouble = -1;
-		res_ocl.returnCode = 0;
 		featureDataList.push_back(res_ocl);
 
 		// Speed
@@ -113,7 +109,6 @@ NFIQ2::QualityFeatures::FJFXMinutiaeQualityFeature::computeFeatureData(
 		}
 
 		// return mu_2 quality value
-		res_mu.returnCode = 0;
 		// return relative value in relation to minutiae count
 		res_mu.featureData.featureDataDouble = (double)vecRanges.at(2) /
 		    (double)this->minutiaData_.size();
@@ -147,7 +142,6 @@ NFIQ2::QualityFeatures::FJFXMinutiaeQualityFeature::computeFeatureData(
 			}
 		}
 
-		res_ocl.returnCode = 0;
 		// return relative value in relation to minutiae count
 		res_ocl.featureData.featureDataDouble = (double)vecRangesOCL.at(
 							    4) /

--- a/NFIQ2/NFIQ2Algorithm/src/features/FeatureFunctions.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FeatureFunctions.cpp
@@ -575,7 +575,6 @@ NFIQ2::QualityFeatures::addHistogramFeatures(
 
 		NFIQ2::QualityFeatureResult result;
 		result.featureData = fd;
-		result.returnCode = 0;
 
 		featureDataList.push_back(result);
 	}
@@ -595,13 +594,11 @@ NFIQ2::QualityFeatures::addHistogramFeatures(
 	meanFD.featureDataType = NFIQ2::e_QualityFeatureDataTypeDouble;
 	meanFD.featureDataDouble = mean.val[0];
 	meanFR.featureData = meanFD;
-	meanFR.returnCode = 0;
 
 	stdDevFD.featureID = stdDevSs.str();
 	stdDevFD.featureDataType = NFIQ2::e_QualityFeatureDataTypeDouble;
 	stdDevFD.featureDataDouble = stdDev.val[0];
 	stdDevFR.featureData = stdDevFD;
-	stdDevFR.returnCode = 0;
 
 	featureDataList.push_back(meanFR);
 	featureDataList.push_back(stdDevFR);

--- a/NFIQ2/NFIQ2Algorithm/src/features/FeatureFunctions.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FeatureFunctions.cpp
@@ -528,43 +528,6 @@ NFIQ2::QualityFeatures::computeNumericalGradients(
 }
 
 void
-NFIQ2::QualityFeatures::addSamplingFeatures(
-    std::vector<NFIQ2::QualityFeatureResult> &featureDataList,
-    std::string featurePrefix, std::vector<double> &dataVector)
-{
-	const auto sampleSize = dataVector.size();
-
-	// randomize data
-	std::random_shuffle(dataVector.begin(), dataVector.end());
-
-	for (int i = 0; i < maxSampleCount; i++) {
-		NFIQ2::QualityFeatureData fd;
-
-		std::stringstream s;
-		s << featurePrefix << i;
-
-		fd.featureID = s.str();
-		fd.featureDataType = NFIQ2::e_QualityFeatureDataTypeDouble;
-		bool canComputeValue = true;
-		if (i < sampleSize) {
-			fd.featureDataDouble = dataVector.at(i);
-		} else {
-			canComputeValue = false;
-		}
-
-		NFIQ2::QualityFeatureResult result;
-		result.featureData = fd;
-		if (canComputeValue) {
-			result.returnCode = 0;
-		} else {
-			result.returnCode = 1;
-		}
-
-		featureDataList.push_back(result);
-	}
-}
-
-void
 NFIQ2::QualityFeatures::addHistogramFeatures(
     std::vector<NFIQ2::QualityFeatureResult> &featureDataList,
     std::string featurePrefix, std::vector<double> &binBoundaries,

--- a/NFIQ2/NFIQ2Algorithm/src/features/FingerJetFXFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FingerJetFXFeature.cpp
@@ -112,7 +112,6 @@ NFIQ2::QualityFeatures::FingerJetFXFeature::computeFeatureData(
 	fd_min_cnt.featureDataDouble = 0;
 	NFIQ2::QualityFeatureResult res_min_cnt;
 	res_min_cnt.featureData = fd_min_cnt;
-	res_min_cnt.returnCode = 0;
 
 	NFIQ2::QualityFeatureData fd_min_cnt_comrect200x200;
 	fd_min_cnt_comrect200x200.featureID =
@@ -122,7 +121,6 @@ NFIQ2::QualityFeatures::FingerJetFXFeature::computeFeatureData(
 	fd_min_cnt_comrect200x200.featureDataDouble = 0;
 	NFIQ2::QualityFeatureResult res_min_cnt_comrect200x200;
 	res_min_cnt_comrect200x200.featureData = fd_min_cnt_comrect200x200;
-	res_min_cnt_comrect200x200.returnCode = 0;
 
 	NFIQ2::Timer timer;
 	timer.start();
@@ -220,11 +218,9 @@ NFIQ2::QualityFeatures::FingerJetFXFeature::computeFeatureData(
 		    0; // no minutiae found
 		res_min_cnt_comrect200x200.featureData =
 		    fd_min_cnt_comrect200x200;
-		res_min_cnt_comrect200x200.returnCode = 0;
 		featureDataList.push_back(res_min_cnt_comrect200x200);
 
 		fd_min_cnt.featureDataDouble = 0; // no minutiae found
-		res_min_cnt.returnCode = 0;
 		res_min_cnt.featureData = fd_min_cnt;
 		featureDataList.push_back(res_min_cnt);
 
@@ -270,11 +266,9 @@ NFIQ2::QualityFeatures::FingerJetFXFeature::computeFeatureData(
 	// return features
 	fd_min_cnt_comrect200x200.featureDataDouble = noOfMinInRect200x200;
 	res_min_cnt_comrect200x200.featureData = fd_min_cnt_comrect200x200;
-	res_min_cnt_comrect200x200.returnCode = 0;
 	featureDataList.push_back(res_min_cnt_comrect200x200);
 
 	fd_min_cnt.featureDataDouble = minCnt;
-	res_min_cnt.returnCode = 0;
 	res_min_cnt.featureData = fd_min_cnt;
 	featureDataList.push_back(res_min_cnt);
 

--- a/NFIQ2/NFIQ2Algorithm/src/features/ImgProcROIFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/ImgProcROIFeature.cpp
@@ -73,7 +73,6 @@ NFIQ2::QualityFeatures::ImgProcROIFeature::computeFeatureData(
 		    this->imgProcResults_.meanOfROIPixels;
 		NFIQ2::QualityFeatureResult res_roi_pixel_area_mean;
 		res_roi_pixel_area_mean.featureData = fd_roi_pixel_area_mean;
-		res_roi_pixel_area_mean.returnCode = 0;
 
 		featureDataList.push_back(res_roi_pixel_area_mean);
 

--- a/NFIQ2/NFIQ2Algorithm/src/features/MuFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/MuFeature.cpp
@@ -91,7 +91,6 @@ NFIQ2::QualityFeatures::MuFeature::computeFeatureData(
 		fd_mmb.featureDataDouble = avg;
 		NFIQ2::QualityFeatureResult res_mmb;
 		res_mmb.featureData = fd_mmb;
-		res_mmb.returnCode = 0;
 
 		featureDataList.push_back(res_mmb);
 	} catch (const cv::Exception &e) {
@@ -128,7 +127,6 @@ NFIQ2::QualityFeatures::MuFeature::computeFeatureData(
 		fd_mu.featureDataDouble = mu.val[0];
 		NFIQ2::QualityFeatureResult res_mu;
 		res_mu.featureData = fd_mu;
-		res_mu.returnCode = 0;
 
 		featureDataList.push_back(res_mu);
 	} catch (const cv::Exception &e) {

--- a/NFIQ2/NFIQ2Algorithm/src/features/QualityMapFeatures.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/QualityMapFeatures.cpp
@@ -70,7 +70,6 @@ NFIQ2::QualityFeatures::QualityMapFeatures::computeFeatureData(
 		fd_om_2.featureDataDouble = coherenceRelFilter;
 		NFIQ2::QualityFeatureResult res_om_2;
 		res_om_2.featureData = fd_om_2;
-		res_om_2.returnCode = 0;
 
 		featureDataList.push_back(res_om_2);
 
@@ -80,7 +79,6 @@ NFIQ2::QualityFeatures::QualityMapFeatures::computeFeatureData(
 		fd_om_1.featureDataDouble = coherenceSumFilter;
 		NFIQ2::QualityFeatureResult res_om_1;
 		res_om_1.featureData = fd_om_1;
-		res_om_1.returnCode = 0;
 
 		featureDataList.push_back(res_om_1);
 

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures_impl.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures_impl.cpp
@@ -60,14 +60,8 @@ NFIQ2::QualityFeatures::Impl::getQualityFeatureData(
 	auto counter = 0;
 	for (const auto &feature : features) {
 		for (auto &result : feature->getFeatures()) {
-			if (result.returnCode == 0) {
-				quality[qualityIdentifiers.at(counter)] =
-				    result.featureData;
-			} else {
-				result.featureData.featureDataDouble = 0;
-				quality[qualityIdentifiers.at(counter)] =
-				    result.featureData;
-			}
+			quality[qualityIdentifiers.at(counter)] =
+			    result.featureData;
 			counter++;
 		}
 	}


### PR DESCRIPTION
After investigation, the value of `quality_feature_result_t.returnCode` is always 0, except for one case in a piece of dead code. This PR removes the dead code and `returnCode` to avoid ambiguity.

Closes #217.
Closes #218.