### PR TITLE
Remove QualityFeatureData from the public API

### DIFF
--- a/NFIQ2/NFIQ2Algorithm/include/features/BaseFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/BaseFeature.h
@@ -22,18 +22,18 @@ class BaseFeature {
 	virtual NFIQ2::QualityFeatureSpeed getSpeed() const;
 
 	/** @return computed quality features */
-	virtual std::vector<NFIQ2::QualityFeatureResult> getFeatures() const;
+	virtual std::vector<NFIQ2::QualityFeatureData> getFeatures() const;
 
     protected:
 	void setSpeed(const NFIQ2::QualityFeatureSpeed &featureSpeed);
 
 	void setFeatures(
-	    const std::vector<NFIQ2::QualityFeatureResult> &featureResult);
+	    const std::vector<NFIQ2::QualityFeatureData> &featureResult);
 
     private:
 	NFIQ2::QualityFeatureSpeed speed {};
 
-	std::vector<NFIQ2::QualityFeatureResult> features {};
+	std::vector<NFIQ2::QualityFeatureData> features {};
 };
 
 }}

--- a/NFIQ2/NFIQ2Algorithm/include/features/BaseFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/BaseFeature.h
@@ -22,18 +22,18 @@ class BaseFeature {
 	virtual NFIQ2::QualityFeatureSpeed getSpeed() const;
 
 	/** @return computed quality features */
-	virtual std::vector<NFIQ2::QualityFeatureData> getFeatures() const;
+	virtual std::unordered_map<std::string, double> getFeatures() const;
 
     protected:
 	void setSpeed(const NFIQ2::QualityFeatureSpeed &featureSpeed);
 
 	void setFeatures(
-	    const std::vector<NFIQ2::QualityFeatureData> &featureResult);
+	    const std::unordered_map<std::string, double> &featureResult);
 
     private:
 	NFIQ2::QualityFeatureSpeed speed {};
 
-	std::vector<NFIQ2::QualityFeatureData> features {};
+	std::unordered_map<std::string, double> features {};
 };
 
 }}

--- a/NFIQ2/NFIQ2Algorithm/include/features/BaseFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/BaseFeature.h
@@ -5,6 +5,7 @@
 #include <nfiq2_interfacedefinitions.hpp>
 
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 namespace NFIQ2 { namespace QualityFeatures {

--- a/NFIQ2/NFIQ2Algorithm/include/features/FDAFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/FDAFeature.h
@@ -30,7 +30,7 @@ class FDAFeature : public BaseFeature {
 	static const std::string moduleName;
 
     private:
-	std::vector<NFIQ2::QualityFeatureResult> computeFeatureData(
+	std::vector<NFIQ2::QualityFeatureData> computeFeatureData(
 	    const NFIQ2::FingerprintImageData &fingerprintImage);
 
 	const int blocksize { 32 };

--- a/NFIQ2/NFIQ2Algorithm/include/features/FDAFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/FDAFeature.h
@@ -30,7 +30,7 @@ class FDAFeature : public BaseFeature {
 	static const std::string moduleName;
 
     private:
-	std::vector<NFIQ2::QualityFeatureData> computeFeatureData(
+	std::unordered_map<std::string, double> computeFeatureData(
 	    const NFIQ2::FingerprintImageData &fingerprintImage);
 
 	const int blocksize { 32 };

--- a/NFIQ2/NFIQ2Algorithm/include/features/FJFXMinutiaeQualityFeatures.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/FJFXMinutiaeQualityFeatures.h
@@ -49,7 +49,7 @@ class FJFXMinutiaeQualityFeature : public BaseFeature {
 	bool getTemplateStatus() const;
 
     private:
-	std::vector<NFIQ2::QualityFeatureResult> computeFeatureData(
+	std::vector<NFIQ2::QualityFeatureData> computeFeatureData(
 	    const NFIQ2::FingerprintImageData &fingerprintImage);
 
 	std::vector<FingerJetFXFeature::Minutia> minutiaData_ {};

--- a/NFIQ2/NFIQ2Algorithm/include/features/FJFXMinutiaeQualityFeatures.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/FJFXMinutiaeQualityFeatures.h
@@ -49,7 +49,7 @@ class FJFXMinutiaeQualityFeature : public BaseFeature {
 	bool getTemplateStatus() const;
 
     private:
-	std::vector<NFIQ2::QualityFeatureData> computeFeatureData(
+	std::unordered_map<std::string, double> computeFeatureData(
 	    const NFIQ2::FingerprintImageData &fingerprintImage);
 
 	std::vector<FingerJetFXFeature::Minutia> minutiaData_ {};

--- a/NFIQ2/NFIQ2Algorithm/include/features/FeatureFunctions.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/FeatureFunctions.h
@@ -46,7 +46,7 @@ void computeNumericalGradients(
     const cv::Mat &mat, cv::Mat &grad_x, cv::Mat &grad_y);
 
 void addHistogramFeatures(
-    std::vector<NFIQ2::QualityFeatureData> &featureDataList,
+    std::unordered_map<std::string, double> &featureDataList,
     std::string featurePrefix, std::vector<double> &binBoundaries,
     std::vector<double> &dataVector, int binCount);
 void addSamplingFeatureNames(

--- a/NFIQ2/NFIQ2Algorithm/include/features/FeatureFunctions.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/FeatureFunctions.h
@@ -46,7 +46,7 @@ void computeNumericalGradients(
     const cv::Mat &mat, cv::Mat &grad_x, cv::Mat &grad_y);
 
 void addHistogramFeatures(
-    std::vector<NFIQ2::QualityFeatureResult> &featureDataList,
+    std::vector<NFIQ2::QualityFeatureData> &featureDataList,
     std::string featurePrefix, std::vector<double> &binBoundaries,
     std::vector<double> &dataVector, int binCount);
 void addSamplingFeatureNames(

--- a/NFIQ2/NFIQ2Algorithm/include/features/FeatureFunctions.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/FeatureFunctions.h
@@ -4,6 +4,8 @@
 #include <nfiq2_interfacedefinitions.hpp>
 #include <opencv2/core.hpp>
 
+#include <unordered_map>
+
 namespace NFIQ2 {
 
 namespace QualityFeatures {

--- a/NFIQ2/NFIQ2Algorithm/include/features/FingerJetFXFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/FingerJetFXFeature.h
@@ -121,7 +121,7 @@ class FingerJetFXFeature : public BaseFeature {
 	bool getTemplateStatus() const;
 
     private:
-	std::vector<NFIQ2::QualityFeatureResult> computeFeatureData(
+	std::vector<NFIQ2::QualityFeatureData> computeFeatureData(
 	    const NFIQ2::FingerprintImageData &fingerprintImage);
 
 	FRFXLL_RESULT

--- a/NFIQ2/NFIQ2Algorithm/include/features/FingerJetFXFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/FingerJetFXFeature.h
@@ -121,7 +121,7 @@ class FingerJetFXFeature : public BaseFeature {
 	bool getTemplateStatus() const;
 
     private:
-	std::vector<NFIQ2::QualityFeatureData> computeFeatureData(
+	std::unordered_map<std::string, double> computeFeatureData(
 	    const NFIQ2::FingerprintImageData &fingerprintImage);
 
 	FRFXLL_RESULT

--- a/NFIQ2/NFIQ2Algorithm/include/features/ImgProcROIFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/ImgProcROIFeature.h
@@ -52,7 +52,7 @@ class ImgProcROIFeature : public BaseFeature {
 	ImgProcROIResults getImgProcResults();
 
     private:
-	std::vector<NFIQ2::QualityFeatureData> computeFeatureData(
+	std::unordered_map<std::string, double> computeFeatureData(
 	    const NFIQ2::FingerprintImageData &fingerprintImage);
 
 	ImgProcROIResults imgProcResults_ {};

--- a/NFIQ2/NFIQ2Algorithm/include/features/ImgProcROIFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/ImgProcROIFeature.h
@@ -52,7 +52,7 @@ class ImgProcROIFeature : public BaseFeature {
 	ImgProcROIResults getImgProcResults();
 
     private:
-	std::vector<NFIQ2::QualityFeatureResult> computeFeatureData(
+	std::vector<NFIQ2::QualityFeatureData> computeFeatureData(
 	    const NFIQ2::FingerprintImageData &fingerprintImage);
 
 	ImgProcROIResults imgProcResults_ {};

--- a/NFIQ2/NFIQ2Algorithm/include/features/LCSFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/LCSFeature.h
@@ -25,7 +25,7 @@ class LCSFeature : public BaseFeature {
 	static const std::string moduleName;
 
     private:
-	std::vector<NFIQ2::QualityFeatureData> computeFeatureData(
+	std::unordered_map<std::string, double> computeFeatureData(
 	    const NFIQ2::FingerprintImageData &fingerprintImage);
 
 	const int blocksize { 32 };

--- a/NFIQ2/NFIQ2Algorithm/include/features/LCSFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/LCSFeature.h
@@ -25,7 +25,7 @@ class LCSFeature : public BaseFeature {
 	static const std::string moduleName;
 
     private:
-	std::vector<NFIQ2::QualityFeatureResult> computeFeatureData(
+	std::vector<NFIQ2::QualityFeatureData> computeFeatureData(
 	    const NFIQ2::FingerprintImageData &fingerprintImage);
 
 	const int blocksize { 32 };

--- a/NFIQ2/NFIQ2Algorithm/include/features/MuFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/MuFeature.h
@@ -27,7 +27,7 @@ class MuFeature : public BaseFeature {
 	static const std::string moduleName;
 
     private:
-	std::vector<NFIQ2::QualityFeatureResult> computeFeatureData(
+	std::vector<NFIQ2::QualityFeatureData> computeFeatureData(
 	    const NFIQ2::FingerprintImageData &fingerprintImage);
 
 	bool sigmaComputed { false };

--- a/NFIQ2/NFIQ2Algorithm/include/features/MuFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/MuFeature.h
@@ -27,7 +27,7 @@ class MuFeature : public BaseFeature {
 	static const std::string moduleName;
 
     private:
-	std::vector<NFIQ2::QualityFeatureData> computeFeatureData(
+	std::unordered_map<std::string, double> computeFeatureData(
 	    const NFIQ2::FingerprintImageData &fingerprintImage);
 
 	bool sigmaComputed { false };

--- a/NFIQ2/NFIQ2Algorithm/include/features/OCLHistogramFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/OCLHistogramFeature.h
@@ -32,7 +32,7 @@ class OCLHistogramFeature : public BaseFeature {
 	static bool getOCLValueOfBlock(const cv::Mat &block, double &ocl);
 
     private:
-	std::vector<NFIQ2::QualityFeatureData> computeFeatureData(
+	std::unordered_map<std::string, double> computeFeatureData(
 	    const NFIQ2::FingerprintImageData &fingerprintImage);
 };
 

--- a/NFIQ2/NFIQ2Algorithm/include/features/OCLHistogramFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/OCLHistogramFeature.h
@@ -32,7 +32,7 @@ class OCLHistogramFeature : public BaseFeature {
 	static bool getOCLValueOfBlock(const cv::Mat &block, double &ocl);
 
     private:
-	std::vector<NFIQ2::QualityFeatureResult> computeFeatureData(
+	std::vector<NFIQ2::QualityFeatureData> computeFeatureData(
 	    const NFIQ2::FingerprintImageData &fingerprintImage);
 };
 

--- a/NFIQ2/NFIQ2Algorithm/include/features/OFFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/OFFeature.h
@@ -31,7 +31,7 @@ class OFFeature : public BaseFeature {
 	static const std::string moduleName;
 
     private:
-	std::vector<NFIQ2::QualityFeatureData> computeFeatureData(
+	std::unordered_map<std::string, double> computeFeatureData(
 	    const NFIQ2::FingerprintImageData &fingerprintImage);
 
 	/** Processing is done in subblocks of this size. */

--- a/NFIQ2/NFIQ2Algorithm/include/features/OFFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/OFFeature.h
@@ -31,7 +31,7 @@ class OFFeature : public BaseFeature {
 	static const std::string moduleName;
 
     private:
-	std::vector<NFIQ2::QualityFeatureResult> computeFeatureData(
+	std::vector<NFIQ2::QualityFeatureData> computeFeatureData(
 	    const NFIQ2::FingerprintImageData &fingerprintImage);
 
 	/** Processing is done in subblocks of this size. */

--- a/NFIQ2/NFIQ2Algorithm/include/features/QualityMapFeatures.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/QualityMapFeatures.h
@@ -54,7 +54,7 @@ class QualityMapFeatures : public BaseFeature {
 	    const cv::Mat &mat, cv::Mat &grad_x, cv::Mat &grad_y);
 
     private:
-	std::vector<NFIQ2::QualityFeatureResult> computeFeatureData(
+	std::vector<NFIQ2::QualityFeatureData> computeFeatureData(
 	    const NFIQ2::FingerprintImageData &fingerprintImage);
 
 	ImgProcROIFeature::ImgProcROIResults imgProcResults_ {};

--- a/NFIQ2/NFIQ2Algorithm/include/features/QualityMapFeatures.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/QualityMapFeatures.h
@@ -54,7 +54,7 @@ class QualityMapFeatures : public BaseFeature {
 	    const cv::Mat &mat, cv::Mat &grad_x, cv::Mat &grad_y);
 
     private:
-	std::vector<NFIQ2::QualityFeatureData> computeFeatureData(
+	std::unordered_map<std::string, double> computeFeatureData(
 	    const NFIQ2::FingerprintImageData &fingerprintImage);
 
 	ImgProcROIFeature::ImgProcROIResults imgProcResults_ {};

--- a/NFIQ2/NFIQ2Algorithm/include/features/RVUPHistogramFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/RVUPHistogramFeature.h
@@ -25,7 +25,7 @@ class RVUPHistogramFeature : public BaseFeature {
 	static const std::string moduleName;
 
     private:
-	std::vector<NFIQ2::QualityFeatureResult> computeFeatureData(
+	std::vector<NFIQ2::QualityFeatureData> computeFeatureData(
 	    const NFIQ2::FingerprintImageData &fingerprintImage);
 
 	const int blocksize { 32 };

--- a/NFIQ2/NFIQ2Algorithm/include/features/RVUPHistogramFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/RVUPHistogramFeature.h
@@ -25,7 +25,7 @@ class RVUPHistogramFeature : public BaseFeature {
 	static const std::string moduleName;
 
     private:
-	std::vector<NFIQ2::QualityFeatureData> computeFeatureData(
+	std::unordered_map<std::string, double> computeFeatureData(
 	    const NFIQ2::FingerprintImageData &fingerprintImage);
 
 	const int blocksize { 32 };

--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2_algorithm.hpp
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2_algorithm.hpp
@@ -113,8 +113,7 @@ class Algorithm {
 	 * Called before random forest parameters were loaded.
 	 */
 	unsigned int computeQualityScore(
-	    const std::unordered_map<std::string, NFIQ2::QualityFeatureData>
-		&features) const;
+	    const std::unordered_map<std::string, double> &features) const;
 
 	/**
 	 * @brief

--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2_interfacedefinitions.hpp
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2_interfacedefinitions.hpp
@@ -108,19 +108,6 @@ typedef struct utility_sample_t {
 } UtilitySample;
 
 /**
- * This type represents the content of a quality feature exchange file
- */
-typedef struct quality_feature_sample_t {
-	/** The ID of the fingerprint image. */
-	NFIQ2::ImageID fingerprintImageID;
-	/**
-	 * The result of the quality feature computation
-	 * (value + return code).
-	 */
-	NFIQ2::QualityFeatureResult featureResult;
-} QualityFeatureSample;
-
-/**
  * This type represents the structure of a probe result for comparison scores
  * computation.
  */

--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2_interfacedefinitions.hpp
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2_interfacedefinitions.hpp
@@ -4,6 +4,7 @@
 #include <nfiq2_data.hpp>
 
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace NFIQ2 {
@@ -49,15 +50,8 @@ typedef struct image_id_t {
 	uint8_t acquisitionNumber;
 } ImageID;
 
-/** This type represents a structure for quality feature data. */
-typedef struct feature_data_t {
-	/** The unique ID of the feature data. */
-	std::string featureID;
-	/**
-	 * The feature value in floating point format
-	 */
-	double featureDataDouble;
-} QualityFeatureData;
+/** Convenience type to store quality feature data. */
+using QualityFeatureData = std::pair<std::string, double>;
 
 /** This type represents a structure for timing information of features. */
 typedef struct feature_speed_t {

--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2_interfacedefinitions.hpp
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2_interfacedefinitions.hpp
@@ -66,14 +66,6 @@ typedef struct feature_speed_t {
 	double featureSpeed;
 } QualityFeatureSpeed;
 
-/**
- * This type represents the result of a quality feature extraction
- */
-typedef struct quality_feature_result_t {
-	/** The quality feature data. */
-	NFIQ2::QualityFeatureData featureData;
-} QualityFeatureResult;
-
 /** This type represents the result of a comparison scores computation. */
 typedef struct comparison_result_t {
 	/** The image ID of the reference image. */

--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2_interfacedefinitions.hpp
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2_interfacedefinitions.hpp
@@ -51,9 +51,6 @@ typedef struct image_id_t {
 	uint8_t acquisitionNumber;
 } ImageID;
 
-/** Convenience type to store quality feature data. */
-using QualityFeatureData = std::pair<std::string, double>;
-
 /** This type represents a structure for timing information of features. */
 typedef struct feature_speed_t {
 	/** The name of the feature group. */

--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2_interfacedefinitions.hpp
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2_interfacedefinitions.hpp
@@ -4,8 +4,6 @@
 #include <nfiq2_data.hpp>
 
 #include <string>
-#include <unordered_map>
-#include <utility>
 #include <vector>
 
 namespace NFIQ2 {

--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2_interfacedefinitions.hpp
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2_interfacedefinitions.hpp
@@ -4,6 +4,7 @@
 #include <nfiq2_data.hpp>
 
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 

--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2_qualityfeatures.hpp
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2_qualityfeatures.hpp
@@ -92,8 +92,7 @@ getActionableQualityFeedback(const NFIQ2::FingerprintImageData &rawImage);
  * @return
  * A map of string, quality feature data pairs.
  */
-std::unordered_map<std::string, NFIQ2::QualityFeatureData>
-getQualityFeatureData(
+std::unordered_map<std::string, double> getQualityFeatureData(
     const std::vector<std::shared_ptr<NFIQ2::QualityFeatures::BaseFeature>>
 	&features);
 
@@ -107,8 +106,8 @@ getQualityFeatureData(
  * @return
  * A map of string, quality feature data pairs.
  */
-std::unordered_map<std::string, NFIQ2::QualityFeatureData>
-getQualityFeatureData(const NFIQ2::FingerprintImageData &rawImage);
+std::unordered_map<std::string, double> getQualityFeatureData(
+    const NFIQ2::FingerprintImageData &rawImage);
 
 /**
  * @brief

--- a/NFIQ2/NFIQ2Algorithm/include/prediction/RandomForestML.h
+++ b/NFIQ2/NFIQ2Algorithm/include/prediction/RandomForestML.h
@@ -42,9 +42,7 @@ class RandomForestML {
 	 * Compute NFIQ2 quality score based on model and provided
 	 * QualityFeatureData.
 	 */
-	void evaluate(
-	    const std::unordered_map<std::string, NFIQ2::QualityFeatureData>
-		&features,
+	void evaluate(const std::unordered_map<std::string, double> &features,
 	    double &qualityValue) const;
 
     private:

--- a/NFIQ2/NFIQ2Algorithm/include/tool/nfiq2_ui_log.h
+++ b/NFIQ2/NFIQ2Algorithm/include/tool/nfiq2_ui_log.h
@@ -72,8 +72,7 @@ class Log {
 	void printScore(const std::string &name, uint8_t fingerCode,
 	    unsigned int score, const std::string &errmsg, const bool quantized,
 	    const bool resampled,
-	    const std::unordered_map<std::string, NFIQ2::QualityFeatureData>
-		&features,
+	    const std::unordered_map<std::string, double> &features,
 	    const std::unordered_map<std::string, NFIQ2::QualityFeatureSpeed>
 		&speed,
 	    const std::unordered_map<std::string,

--- a/NFIQ2/NFIQ2Algorithm/src/features/BaseFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/BaseFeature.cpp
@@ -13,7 +13,7 @@ NFIQ2::QualityFeatures::BaseFeature::getSpeed() const
 	return this->speed;
 }
 
-std::vector<NFIQ2::QualityFeatureResult>
+std::vector<NFIQ2::QualityFeatureData>
 NFIQ2::QualityFeatures::BaseFeature::getFeatures() const
 {
 	return this->features;
@@ -28,7 +28,7 @@ NFIQ2::QualityFeatures::BaseFeature::setSpeed(
 
 void
 NFIQ2::QualityFeatures::BaseFeature::setFeatures(
-    const std::vector<NFIQ2::QualityFeatureResult> &featureResult)
+    const std::vector<NFIQ2::QualityFeatureData> &featureResult)
 {
 	this->features = featureResult;
 }

--- a/NFIQ2/NFIQ2Algorithm/src/features/BaseFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/BaseFeature.cpp
@@ -13,7 +13,7 @@ NFIQ2::QualityFeatures::BaseFeature::getSpeed() const
 	return this->speed;
 }
 
-std::vector<NFIQ2::QualityFeatureData>
+std::unordered_map<std::string, double>
 NFIQ2::QualityFeatures::BaseFeature::getFeatures() const
 {
 	return this->features;
@@ -28,7 +28,7 @@ NFIQ2::QualityFeatures::BaseFeature::setSpeed(
 
 void
 NFIQ2::QualityFeatures::BaseFeature::setFeatures(
-    const std::vector<NFIQ2::QualityFeatureData> &featureResult)
+    const std::unordered_map<std::string, double> &featureResult)
 {
 	this->features = featureResult;
 }

--- a/NFIQ2/NFIQ2Algorithm/src/features/FDAFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FDAFeature.cpp
@@ -39,11 +39,11 @@ NFIQ2::QualityFeatures::FDAFeature::getModuleName() const
 	return moduleName;
 }
 
-std::vector<NFIQ2::QualityFeatureData>
+std::unordered_map<std::string, double>
 NFIQ2::QualityFeatures::FDAFeature::computeFeatureData(
     const NFIQ2::FingerprintImageData &fingerprintImage)
 {
-	std::vector<NFIQ2::QualityFeatureData> featureDataList;
+	std::unordered_map<std::string, double> featureDataList;
 
 	// check if input image has 500 dpi
 	if (fingerprintImage.m_ImageDPI != NFIQ2::e_ImageResolution_500dpi) {

--- a/NFIQ2/NFIQ2Algorithm/src/features/FDAFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FDAFeature.cpp
@@ -39,11 +39,11 @@ NFIQ2::QualityFeatures::FDAFeature::getModuleName() const
 	return moduleName;
 }
 
-std::vector<NFIQ2::QualityFeatureResult>
+std::vector<NFIQ2::QualityFeatureData>
 NFIQ2::QualityFeatures::FDAFeature::computeFeatureData(
     const NFIQ2::FingerprintImageData &fingerprintImage)
 {
-	std::vector<NFIQ2::QualityFeatureResult> featureDataList;
+	std::vector<NFIQ2::QualityFeatureData> featureDataList;
 
 	// check if input image has 500 dpi
 	if (fingerprintImage.m_ImageDPI != NFIQ2::e_ImageResolution_500dpi) {

--- a/NFIQ2/NFIQ2Algorithm/src/features/FJFXMinutiaeQualityFeatures.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FJFXMinutiaeQualityFeatures.cpp
@@ -40,11 +40,11 @@ NFIQ2::QualityFeatures::FJFXMinutiaeQualityFeature::getTemplateStatus() const
 	return (this->templateCouldBeExtracted_);
 }
 
-std::vector<NFIQ2::QualityFeatureData>
+std::unordered_map<std::string, double>
 NFIQ2::QualityFeatures::FJFXMinutiaeQualityFeature::computeFeatureData(
     const NFIQ2::FingerprintImageData &fingerprintImage)
 {
-	std::vector<NFIQ2::QualityFeatureData> featureDataList;
+	std::unordered_map<std::string, double> featureDataList;
 
 	NFIQ2::QualityFeatureData fd_mu;
 	fd_mu = std::make_pair("FJFXPos_Mu_MinutiaeQuality_2", -1);
@@ -54,10 +54,10 @@ NFIQ2::QualityFeatures::FJFXMinutiaeQualityFeature::computeFeatureData(
 
 	if (!this->templateCouldBeExtracted_) {
 		fd_mu.second = -1;
-		featureDataList.push_back(fd_mu);
+		featureDataList[fd_mu.first] = fd_mu.second;
 
 		fd_ocl.second = -1;
-		featureDataList.push_back(fd_ocl);
+		featureDataList[fd_ocl.first] = fd_ocl.second;
 
 		// Speed
 		NFIQ2::QualityFeatureSpeed speed;
@@ -104,7 +104,7 @@ NFIQ2::QualityFeatures::FJFXMinutiaeQualityFeature::computeFeatureData(
 		// return relative value in relation to minutiae count
 		fd_mu.second = (double)vecRanges.at(2) /
 		    (double)this->minutiaData_.size();
-		featureDataList.push_back(fd_mu);
+		featureDataList[fd_mu.first] = fd_mu.second;
 
 		// compute minutiae quality based on OCL feature computed at
 		// minutiae positions
@@ -137,7 +137,7 @@ NFIQ2::QualityFeatures::FJFXMinutiaeQualityFeature::computeFeatureData(
 		// return relative value in relation to minutiae count
 		fd_ocl.second = (double)vecRangesOCL.at(4) /
 		    (double)this->minutiaData_.size();
-		featureDataList.push_back(fd_ocl);
+		featureDataList[fd_ocl.first] = fd_ocl.second;
 
 		// Speed
 		NFIQ2::QualityFeatureSpeed speed;

--- a/NFIQ2/NFIQ2Algorithm/src/features/FJFXMinutiaeQualityFeatures.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FJFXMinutiaeQualityFeatures.cpp
@@ -47,22 +47,20 @@ NFIQ2::QualityFeatures::FJFXMinutiaeQualityFeature::computeFeatureData(
 	std::vector<NFIQ2::QualityFeatureResult> featureDataList;
 
 	NFIQ2::QualityFeatureData fd_mu;
-	fd_mu.featureID = "FJFXPos_Mu_MinutiaeQuality_2";
-	fd_mu.featureDataDouble = -1;
+	fd_mu = std::make_pair("FJFXPos_Mu_MinutiaeQuality_2", -1);
 	NFIQ2::QualityFeatureResult res_mu;
 	res_mu.featureData = fd_mu;
 
 	NFIQ2::QualityFeatureData fd_ocl;
-	fd_ocl.featureID = "FJFXPos_OCL_MinutiaeQuality_80";
-	fd_ocl.featureDataDouble = -1;
+	fd_ocl = std::make_pair("FJFXPos_OCL_MinutiaeQuality_80", -1);
 	NFIQ2::QualityFeatureResult res_ocl;
 	res_ocl.featureData = fd_ocl;
 
 	if (!this->templateCouldBeExtracted_) {
-		res_mu.featureData.featureDataDouble = -1;
+		res_mu.featureData.second = -1;
 		featureDataList.push_back(res_mu);
 
-		res_ocl.featureData.featureDataDouble = -1;
+		res_ocl.featureData.second = -1;
 		featureDataList.push_back(res_ocl);
 
 		// Speed
@@ -108,7 +106,7 @@ NFIQ2::QualityFeatures::FJFXMinutiaeQualityFeature::computeFeatureData(
 
 		// return mu_2 quality value
 		// return relative value in relation to minutiae count
-		res_mu.featureData.featureDataDouble = (double)vecRanges.at(2) /
+		res_mu.featureData.second = (double)vecRanges.at(2) /
 		    (double)this->minutiaData_.size();
 		featureDataList.push_back(res_mu);
 
@@ -141,8 +139,7 @@ NFIQ2::QualityFeatures::FJFXMinutiaeQualityFeature::computeFeatureData(
 		}
 
 		// return relative value in relation to minutiae count
-		res_ocl.featureData.featureDataDouble = (double)vecRangesOCL.at(
-							    4) /
+		res_ocl.featureData.second = (double)vecRangesOCL.at(4) /
 		    (double)this->minutiaData_.size();
 		featureDataList.push_back(res_ocl);
 

--- a/NFIQ2/NFIQ2Algorithm/src/features/FJFXMinutiaeQualityFeatures.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FJFXMinutiaeQualityFeatures.cpp
@@ -46,10 +46,10 @@ NFIQ2::QualityFeatures::FJFXMinutiaeQualityFeature::computeFeatureData(
 {
 	std::unordered_map<std::string, double> featureDataList;
 
-	NFIQ2::QualityFeatureData fd_mu;
+	std::pair<std::string, double> fd_mu;
 	fd_mu = std::make_pair("FJFXPos_Mu_MinutiaeQuality_2", -1);
 
-	NFIQ2::QualityFeatureData fd_ocl;
+	std::pair<std::string, double> fd_ocl;
 	fd_ocl = std::make_pair("FJFXPos_OCL_MinutiaeQuality_80", -1);
 
 	if (!this->templateCouldBeExtracted_) {

--- a/NFIQ2/NFIQ2Algorithm/src/features/FJFXMinutiaeQualityFeatures.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FJFXMinutiaeQualityFeatures.cpp
@@ -40,28 +40,24 @@ NFIQ2::QualityFeatures::FJFXMinutiaeQualityFeature::getTemplateStatus() const
 	return (this->templateCouldBeExtracted_);
 }
 
-std::vector<NFIQ2::QualityFeatureResult>
+std::vector<NFIQ2::QualityFeatureData>
 NFIQ2::QualityFeatures::FJFXMinutiaeQualityFeature::computeFeatureData(
     const NFIQ2::FingerprintImageData &fingerprintImage)
 {
-	std::vector<NFIQ2::QualityFeatureResult> featureDataList;
+	std::vector<NFIQ2::QualityFeatureData> featureDataList;
 
 	NFIQ2::QualityFeatureData fd_mu;
 	fd_mu = std::make_pair("FJFXPos_Mu_MinutiaeQuality_2", -1);
-	NFIQ2::QualityFeatureResult res_mu;
-	res_mu.featureData = fd_mu;
 
 	NFIQ2::QualityFeatureData fd_ocl;
 	fd_ocl = std::make_pair("FJFXPos_OCL_MinutiaeQuality_80", -1);
-	NFIQ2::QualityFeatureResult res_ocl;
-	res_ocl.featureData = fd_ocl;
 
 	if (!this->templateCouldBeExtracted_) {
-		res_mu.featureData.second = -1;
-		featureDataList.push_back(res_mu);
+		fd_mu.second = -1;
+		featureDataList.push_back(fd_mu);
 
-		res_ocl.featureData.second = -1;
-		featureDataList.push_back(res_ocl);
+		fd_ocl.second = -1;
+		featureDataList.push_back(fd_ocl);
 
 		// Speed
 		NFIQ2::QualityFeatureSpeed speed;
@@ -106,9 +102,9 @@ NFIQ2::QualityFeatures::FJFXMinutiaeQualityFeature::computeFeatureData(
 
 		// return mu_2 quality value
 		// return relative value in relation to minutiae count
-		res_mu.featureData.second = (double)vecRanges.at(2) /
+		fd_mu.second = (double)vecRanges.at(2) /
 		    (double)this->minutiaData_.size();
-		featureDataList.push_back(res_mu);
+		featureDataList.push_back(fd_mu);
 
 		// compute minutiae quality based on OCL feature computed at
 		// minutiae positions
@@ -139,9 +135,9 @@ NFIQ2::QualityFeatures::FJFXMinutiaeQualityFeature::computeFeatureData(
 		}
 
 		// return relative value in relation to minutiae count
-		res_ocl.featureData.second = (double)vecRangesOCL.at(4) /
+		fd_ocl.second = (double)vecRangesOCL.at(4) /
 		    (double)this->minutiaData_.size();
-		featureDataList.push_back(res_ocl);
+		featureDataList.push_back(fd_ocl);
 
 		// Speed
 		NFIQ2::QualityFeatureSpeed speed;

--- a/NFIQ2/NFIQ2Algorithm/src/features/FeatureFunctions.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FeatureFunctions.cpp
@@ -569,8 +569,7 @@ NFIQ2::QualityFeatures::addHistogramFeatures(
 		std::stringstream s;
 		s << featurePrefix << i;
 
-		fd.featureID = s.str();
-		fd.featureDataDouble = bins[i];
+		fd = std::make_pair(s.str(), bins[i]);
 
 		NFIQ2::QualityFeatureResult result;
 		result.featureData = fd;
@@ -589,12 +588,10 @@ NFIQ2::QualityFeatures::addHistogramFeatures(
 	meanSs << featurePrefix << "Mean";
 	stdDevSs << featurePrefix << "StdDev";
 
-	meanFD.featureID = meanSs.str();
-	meanFD.featureDataDouble = mean.val[0];
+	meanFD = std::make_pair(meanSs.str(), mean.val[0]);
 	meanFR.featureData = meanFD;
 
-	stdDevFD.featureID = stdDevSs.str();
-	stdDevFD.featureDataDouble = stdDev.val[0];
+	stdDevFD = std::make_pair(stdDevSs.str(), stdDev.val[0]);
 	stdDevFR.featureData = stdDevFD;
 
 	featureDataList.push_back(meanFR);

--- a/NFIQ2/NFIQ2Algorithm/src/features/FeatureFunctions.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FeatureFunctions.cpp
@@ -564,7 +564,7 @@ NFIQ2::QualityFeatures::addHistogramFeatures(
 	}
 
 	for (int i = 0; i < binCount; i++) {
-		NFIQ2::QualityFeatureData fd;
+		std::pair<std::string, double> fd;
 
 		std::stringstream s;
 		s << featurePrefix << i;
@@ -578,7 +578,7 @@ NFIQ2::QualityFeatures::addHistogramFeatures(
 	cv::Scalar mean, stdDev;
 	cv::meanStdDev(dataMat, mean, stdDev);
 
-	NFIQ2::QualityFeatureData meanFD, stdDevFD;
+	std::pair<std::string, double> meanFD, stdDevFD;
 	std::stringstream meanSs, stdDevSs;
 
 	meanSs << featurePrefix << "Mean";

--- a/NFIQ2/NFIQ2Algorithm/src/features/FeatureFunctions.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FeatureFunctions.cpp
@@ -529,7 +529,7 @@ NFIQ2::QualityFeatures::computeNumericalGradients(
 
 void
 NFIQ2::QualityFeatures::addHistogramFeatures(
-    std::vector<NFIQ2::QualityFeatureData> &featureDataList,
+    std::unordered_map<std::string, double> &featureDataList,
     std::string featurePrefix, std::vector<double> &binBoundaries,
     std::vector<double> &dataVector, int binCount)
 {
@@ -571,7 +571,7 @@ NFIQ2::QualityFeatures::addHistogramFeatures(
 
 		fd = std::make_pair(s.str(), bins[i]);
 
-		featureDataList.push_back(fd);
+		featureDataList[fd.first] = fd.second;
 	}
 
 	cv::Mat dataMat(dataVector);
@@ -588,8 +588,8 @@ NFIQ2::QualityFeatures::addHistogramFeatures(
 
 	stdDevFD = std::make_pair(stdDevSs.str(), stdDev.val[0]);
 
-	featureDataList.push_back(meanFD);
-	featureDataList.push_back(stdDevFD);
+	featureDataList[meanFD.first] = meanFD.second;
+	featureDataList[stdDevFD.first] = stdDevFD.second;
 
 	if (bins) {
 		delete[] bins;

--- a/NFIQ2/NFIQ2Algorithm/src/features/FeatureFunctions.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FeatureFunctions.cpp
@@ -529,7 +529,7 @@ NFIQ2::QualityFeatures::computeNumericalGradients(
 
 void
 NFIQ2::QualityFeatures::addHistogramFeatures(
-    std::vector<NFIQ2::QualityFeatureResult> &featureDataList,
+    std::vector<NFIQ2::QualityFeatureData> &featureDataList,
     std::string featurePrefix, std::vector<double> &binBoundaries,
     std::vector<double> &dataVector, int binCount)
 {
@@ -571,10 +571,7 @@ NFIQ2::QualityFeatures::addHistogramFeatures(
 
 		fd = std::make_pair(s.str(), bins[i]);
 
-		NFIQ2::QualityFeatureResult result;
-		result.featureData = fd;
-
-		featureDataList.push_back(result);
+		featureDataList.push_back(fd);
 	}
 
 	cv::Mat dataMat(dataVector);
@@ -582,20 +579,17 @@ NFIQ2::QualityFeatures::addHistogramFeatures(
 	cv::meanStdDev(dataMat, mean, stdDev);
 
 	NFIQ2::QualityFeatureData meanFD, stdDevFD;
-	NFIQ2::QualityFeatureResult meanFR, stdDevFR;
 	std::stringstream meanSs, stdDevSs;
 
 	meanSs << featurePrefix << "Mean";
 	stdDevSs << featurePrefix << "StdDev";
 
 	meanFD = std::make_pair(meanSs.str(), mean.val[0]);
-	meanFR.featureData = meanFD;
 
 	stdDevFD = std::make_pair(stdDevSs.str(), stdDev.val[0]);
-	stdDevFR.featureData = stdDevFD;
 
-	featureDataList.push_back(meanFR);
-	featureDataList.push_back(stdDevFR);
+	featureDataList.push_back(meanFD);
+	featureDataList.push_back(stdDevFD);
 
 	if (bins) {
 		delete[] bins;

--- a/NFIQ2/NFIQ2Algorithm/src/features/FingerJetFXFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FingerJetFXFeature.cpp
@@ -88,13 +88,13 @@ NFIQ2::QualityFeatures::FingerJetFXFeature::getMinutiaData() const
 	return (this->minutiaData_);
 }
 
-std::vector<NFIQ2::QualityFeatureData>
+std::unordered_map<std::string, double>
 NFIQ2::QualityFeatures::FingerJetFXFeature::computeFeatureData(
     const NFIQ2::FingerprintImageData &fingerprintImage)
 {
 	this->templateCouldBeExtracted_ = false;
 
-	std::vector<NFIQ2::QualityFeatureData> featureDataList;
+	std::unordered_map<std::string, double> featureDataList;
 
 	// make local copy of fingerprint image
 	// since FJFX somehow transforms the input image
@@ -206,10 +206,11 @@ NFIQ2::QualityFeatures::FingerJetFXFeature::computeFeatureData(
 	if (minCnt == 0) {
 		// return features
 		fd_min_cnt_comrect200x200.second = 0; // no minutiae found
-		featureDataList.push_back(fd_min_cnt_comrect200x200);
+		featureDataList[fd_min_cnt_comrect200x200.first] =
+		    fd_min_cnt_comrect200x200.second;
 
 		fd_min_cnt.second = 0; // no minutiae found
-		featureDataList.push_back(fd_min_cnt);
+		featureDataList[fd_min_cnt.first] = fd_min_cnt.second;
 
 		// Speed
 		NFIQ2::QualityFeatureSpeed speed;
@@ -252,10 +253,11 @@ NFIQ2::QualityFeatures::FingerJetFXFeature::computeFeatureData(
 
 	// return features
 	fd_min_cnt_comrect200x200.second = noOfMinInRect200x200;
-	featureDataList.push_back(fd_min_cnt_comrect200x200);
+	featureDataList[fd_min_cnt_comrect200x200.first] =
+	    fd_min_cnt_comrect200x200.second;
 
 	fd_min_cnt.second = minCnt;
-	featureDataList.push_back(fd_min_cnt);
+	featureDataList[fd_min_cnt.first] = fd_min_cnt.second;
 
 	NFIQ2::QualityFeatureSpeed speed;
 	speed.featureIDGroup = FingerJetFXFeature::speedFeatureIDGroup;

--- a/NFIQ2/NFIQ2Algorithm/src/features/FingerJetFXFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FingerJetFXFeature.cpp
@@ -88,13 +88,13 @@ NFIQ2::QualityFeatures::FingerJetFXFeature::getMinutiaData() const
 	return (this->minutiaData_);
 }
 
-std::vector<NFIQ2::QualityFeatureResult>
+std::vector<NFIQ2::QualityFeatureData>
 NFIQ2::QualityFeatures::FingerJetFXFeature::computeFeatureData(
     const NFIQ2::FingerprintImageData &fingerprintImage)
 {
 	this->templateCouldBeExtracted_ = false;
 
-	std::vector<NFIQ2::QualityFeatureResult> featureDataList;
+	std::vector<NFIQ2::QualityFeatureData> featureDataList;
 
 	// make local copy of fingerprint image
 	// since FJFX somehow transforms the input image
@@ -108,14 +108,10 @@ NFIQ2::QualityFeatures::FingerJetFXFeature::computeFeatureData(
 
 	NFIQ2::QualityFeatureData fd_min_cnt;
 	fd_min_cnt = std::make_pair("FingerJetFX_MinutiaeCount", 0);
-	NFIQ2::QualityFeatureResult res_min_cnt;
-	res_min_cnt.featureData = fd_min_cnt;
 
 	NFIQ2::QualityFeatureData fd_min_cnt_comrect200x200;
 	fd_min_cnt_comrect200x200 = std::make_pair(
 	    "FingerJetFX_MinCount_COMMinRect200x200", 0);
-	NFIQ2::QualityFeatureResult res_min_cnt_comrect200x200;
-	res_min_cnt_comrect200x200.featureData = fd_min_cnt_comrect200x200;
 
 	NFIQ2::Timer timer;
 	timer.start();
@@ -210,13 +206,10 @@ NFIQ2::QualityFeatures::FingerJetFXFeature::computeFeatureData(
 	if (minCnt == 0) {
 		// return features
 		fd_min_cnt_comrect200x200.second = 0; // no minutiae found
-		res_min_cnt_comrect200x200.featureData =
-		    fd_min_cnt_comrect200x200;
-		featureDataList.push_back(res_min_cnt_comrect200x200);
+		featureDataList.push_back(fd_min_cnt_comrect200x200);
 
 		fd_min_cnt.second = 0; // no minutiae found
-		res_min_cnt.featureData = fd_min_cnt;
-		featureDataList.push_back(res_min_cnt);
+		featureDataList.push_back(fd_min_cnt);
 
 		// Speed
 		NFIQ2::QualityFeatureSpeed speed;
@@ -259,12 +252,10 @@ NFIQ2::QualityFeatures::FingerJetFXFeature::computeFeatureData(
 
 	// return features
 	fd_min_cnt_comrect200x200.second = noOfMinInRect200x200;
-	res_min_cnt_comrect200x200.featureData = fd_min_cnt_comrect200x200;
-	featureDataList.push_back(res_min_cnt_comrect200x200);
+	featureDataList.push_back(fd_min_cnt_comrect200x200);
 
 	fd_min_cnt.second = minCnt;
-	res_min_cnt.featureData = fd_min_cnt;
-	featureDataList.push_back(res_min_cnt);
+	featureDataList.push_back(fd_min_cnt);
 
 	NFIQ2::QualityFeatureSpeed speed;
 	speed.featureIDGroup = FingerJetFXFeature::speedFeatureIDGroup;

--- a/NFIQ2/NFIQ2Algorithm/src/features/FingerJetFXFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FingerJetFXFeature.cpp
@@ -107,15 +107,13 @@ NFIQ2::QualityFeatures::FingerJetFXFeature::computeFeatureData(
 	    fingerprintImage.size());
 
 	NFIQ2::QualityFeatureData fd_min_cnt;
-	fd_min_cnt.featureID = "FingerJetFX_MinutiaeCount";
-	fd_min_cnt.featureDataDouble = 0;
+	fd_min_cnt = std::make_pair("FingerJetFX_MinutiaeCount", 0);
 	NFIQ2::QualityFeatureResult res_min_cnt;
 	res_min_cnt.featureData = fd_min_cnt;
 
 	NFIQ2::QualityFeatureData fd_min_cnt_comrect200x200;
-	fd_min_cnt_comrect200x200.featureID =
-	    "FingerJetFX_MinCount_COMMinRect200x200";
-	fd_min_cnt_comrect200x200.featureDataDouble = 0;
+	fd_min_cnt_comrect200x200 = std::make_pair(
+	    "FingerJetFX_MinCount_COMMinRect200x200", 0);
 	NFIQ2::QualityFeatureResult res_min_cnt_comrect200x200;
 	res_min_cnt_comrect200x200.featureData = fd_min_cnt_comrect200x200;
 
@@ -211,13 +209,12 @@ NFIQ2::QualityFeatures::FingerJetFXFeature::computeFeatureData(
 
 	if (minCnt == 0) {
 		// return features
-		fd_min_cnt_comrect200x200.featureDataDouble =
-		    0; // no minutiae found
+		fd_min_cnt_comrect200x200.second = 0; // no minutiae found
 		res_min_cnt_comrect200x200.featureData =
 		    fd_min_cnt_comrect200x200;
 		featureDataList.push_back(res_min_cnt_comrect200x200);
 
-		fd_min_cnt.featureDataDouble = 0; // no minutiae found
+		fd_min_cnt.second = 0; // no minutiae found
 		res_min_cnt.featureData = fd_min_cnt;
 		featureDataList.push_back(res_min_cnt);
 
@@ -261,11 +258,11 @@ NFIQ2::QualityFeatures::FingerJetFXFeature::computeFeatureData(
 	}
 
 	// return features
-	fd_min_cnt_comrect200x200.featureDataDouble = noOfMinInRect200x200;
+	fd_min_cnt_comrect200x200.second = noOfMinInRect200x200;
 	res_min_cnt_comrect200x200.featureData = fd_min_cnt_comrect200x200;
 	featureDataList.push_back(res_min_cnt_comrect200x200);
 
-	fd_min_cnt.featureDataDouble = minCnt;
+	fd_min_cnt.second = minCnt;
 	res_min_cnt.featureData = fd_min_cnt;
 	featureDataList.push_back(res_min_cnt);
 

--- a/NFIQ2/NFIQ2Algorithm/src/features/FingerJetFXFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FingerJetFXFeature.cpp
@@ -106,10 +106,10 @@ NFIQ2::QualityFeatures::FingerJetFXFeature::computeFeatureData(
 	memcpy((void *)localFingerprintImage.data(), fingerprintImage.data(),
 	    fingerprintImage.size());
 
-	NFIQ2::QualityFeatureData fd_min_cnt;
+	std::pair<std::string, double> fd_min_cnt;
 	fd_min_cnt = std::make_pair("FingerJetFX_MinutiaeCount", 0);
 
-	NFIQ2::QualityFeatureData fd_min_cnt_comrect200x200;
+	std::pair<std::string, double> fd_min_cnt_comrect200x200;
 	fd_min_cnt_comrect200x200 = std::make_pair(
 	    "FingerJetFX_MinCount_COMMinRect200x200", 0);
 

--- a/NFIQ2/NFIQ2Algorithm/src/features/ImgProcROIFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/ImgProcROIFeature.cpp
@@ -65,7 +65,7 @@ NFIQ2::QualityFeatures::ImgProcROIFeature::computeFeatureData(
 		this->imgProcResults_ = computeROI(
 		    img, 16); // block size = 16x16 pixels
 
-		NFIQ2::QualityFeatureData fd_roi_pixel_area_mean;
+		std::pair<std::string, double> fd_roi_pixel_area_mean;
 		fd_roi_pixel_area_mean = std::make_pair("ImgProcROIArea_Mean",
 		    this->imgProcResults_.meanOfROIPixels);
 		featureDataList[fd_roi_pixel_area_mean.first] =

--- a/NFIQ2/NFIQ2Algorithm/src/features/ImgProcROIFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/ImgProcROIFeature.cpp
@@ -28,11 +28,11 @@ NFIQ2::QualityFeatures::ImgProcROIFeature::getImgProcResults()
 	return (this->imgProcResults_);
 }
 
-std::vector<NFIQ2::QualityFeatureResult>
+std::vector<NFIQ2::QualityFeatureData>
 NFIQ2::QualityFeatures::ImgProcROIFeature::computeFeatureData(
     const NFIQ2::FingerprintImageData &fingerprintImage)
 {
-	std::vector<NFIQ2::QualityFeatureResult> featureDataList;
+	std::vector<NFIQ2::QualityFeatureData> featureDataList;
 
 	// check if input image has 500 dpi
 	if (fingerprintImage.m_ImageDPI != NFIQ2::e_ImageResolution_500dpi) {
@@ -68,10 +68,7 @@ NFIQ2::QualityFeatures::ImgProcROIFeature::computeFeatureData(
 		NFIQ2::QualityFeatureData fd_roi_pixel_area_mean;
 		fd_roi_pixel_area_mean = std::make_pair("ImgProcROIArea_Mean",
 		    this->imgProcResults_.meanOfROIPixels);
-		NFIQ2::QualityFeatureResult res_roi_pixel_area_mean;
-		res_roi_pixel_area_mean.featureData = fd_roi_pixel_area_mean;
-
-		featureDataList.push_back(res_roi_pixel_area_mean);
+		featureDataList.push_back(fd_roi_pixel_area_mean);
 
 		// Speed
 		NFIQ2::QualityFeatureSpeed speed;

--- a/NFIQ2/NFIQ2Algorithm/src/features/ImgProcROIFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/ImgProcROIFeature.cpp
@@ -28,11 +28,11 @@ NFIQ2::QualityFeatures::ImgProcROIFeature::getImgProcResults()
 	return (this->imgProcResults_);
 }
 
-std::vector<NFIQ2::QualityFeatureData>
+std::unordered_map<std::string, double>
 NFIQ2::QualityFeatures::ImgProcROIFeature::computeFeatureData(
     const NFIQ2::FingerprintImageData &fingerprintImage)
 {
-	std::vector<NFIQ2::QualityFeatureData> featureDataList;
+	std::unordered_map<std::string, double> featureDataList;
 
 	// check if input image has 500 dpi
 	if (fingerprintImage.m_ImageDPI != NFIQ2::e_ImageResolution_500dpi) {
@@ -68,7 +68,8 @@ NFIQ2::QualityFeatures::ImgProcROIFeature::computeFeatureData(
 		NFIQ2::QualityFeatureData fd_roi_pixel_area_mean;
 		fd_roi_pixel_area_mean = std::make_pair("ImgProcROIArea_Mean",
 		    this->imgProcResults_.meanOfROIPixels);
-		featureDataList.push_back(fd_roi_pixel_area_mean);
+		featureDataList[fd_roi_pixel_area_mean.first] =
+		    fd_roi_pixel_area_mean.second;
 
 		// Speed
 		NFIQ2::QualityFeatureSpeed speed;

--- a/NFIQ2/NFIQ2Algorithm/src/features/ImgProcROIFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/ImgProcROIFeature.cpp
@@ -66,9 +66,8 @@ NFIQ2::QualityFeatures::ImgProcROIFeature::computeFeatureData(
 		    img, 16); // block size = 16x16 pixels
 
 		NFIQ2::QualityFeatureData fd_roi_pixel_area_mean;
-		fd_roi_pixel_area_mean.featureID = "ImgProcROIArea_Mean";
-		fd_roi_pixel_area_mean.featureDataDouble =
-		    this->imgProcResults_.meanOfROIPixels;
+		fd_roi_pixel_area_mean = std::make_pair("ImgProcROIArea_Mean",
+		    this->imgProcResults_.meanOfROIPixels);
 		NFIQ2::QualityFeatureResult res_roi_pixel_area_mean;
 		res_roi_pixel_area_mean.featureData = fd_roi_pixel_area_mean;
 

--- a/NFIQ2/NFIQ2Algorithm/src/features/LCSFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/LCSFeature.cpp
@@ -39,11 +39,11 @@ NFIQ2::QualityFeatures::LCSFeature::getAllFeatureIDs()
 const std::string NFIQ2::QualityFeatures::LCSFeature::speedFeatureIDGroup =
     "Local clarity";
 
-std::vector<NFIQ2::QualityFeatureData>
+std::unordered_map<std::string, double>
 NFIQ2::QualityFeatures::LCSFeature::computeFeatureData(
     const NFIQ2::FingerprintImageData &fingerprintImage)
 {
-	std::vector<NFIQ2::QualityFeatureData> featureDataList;
+	std::unordered_map<std::string, double> featureDataList;
 
 	// check if input image has 500 dpi
 	if (fingerprintImage.m_ImageDPI != NFIQ2::e_ImageResolution_500dpi) {

--- a/NFIQ2/NFIQ2Algorithm/src/features/LCSFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/LCSFeature.cpp
@@ -39,11 +39,11 @@ NFIQ2::QualityFeatures::LCSFeature::getAllFeatureIDs()
 const std::string NFIQ2::QualityFeatures::LCSFeature::speedFeatureIDGroup =
     "Local clarity";
 
-std::vector<NFIQ2::QualityFeatureResult>
+std::vector<NFIQ2::QualityFeatureData>
 NFIQ2::QualityFeatures::LCSFeature::computeFeatureData(
     const NFIQ2::FingerprintImageData &fingerprintImage)
 {
-	std::vector<NFIQ2::QualityFeatureResult> featureDataList;
+	std::vector<NFIQ2::QualityFeatureData> featureDataList;
 
 	// check if input image has 500 dpi
 	if (fingerprintImage.m_ImageDPI != NFIQ2::e_ImageResolution_500dpi) {

--- a/NFIQ2/NFIQ2Algorithm/src/features/MuFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/MuFeature.cpp
@@ -86,8 +86,7 @@ NFIQ2::QualityFeatures::MuFeature::computeFeatureData(
 
 		// return MMB value
 		NFIQ2::QualityFeatureData fd_mmb;
-		fd_mmb.featureID = "MMB";
-		fd_mmb.featureDataDouble = avg;
+		fd_mmb = std::make_pair("MMB", avg);
 		NFIQ2::QualityFeatureResult res_mmb;
 		res_mmb.featureData = fd_mmb;
 
@@ -121,8 +120,7 @@ NFIQ2::QualityFeatures::MuFeature::computeFeatureData(
 
 		// return mu value
 		NFIQ2::QualityFeatureData fd_mu;
-		fd_mu.featureID = "Mu";
-		fd_mu.featureDataDouble = mu.val[0];
+		fd_mu = std::make_pair("Mu", mu.val[0]);
 		NFIQ2::QualityFeatureResult res_mu;
 		res_mu.featureData = fd_mu;
 

--- a/NFIQ2/NFIQ2Algorithm/src/features/MuFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/MuFeature.cpp
@@ -85,7 +85,7 @@ NFIQ2::QualityFeatures::MuFeature::computeFeatureData(
 		}
 
 		// return MMB value
-		NFIQ2::QualityFeatureData fd_mmb;
+		std::pair<std::string, double> fd_mmb;
 		fd_mmb = std::make_pair("MMB", avg);
 
 		featureDataList[fd_mmb.first] = fd_mmb.second;
@@ -117,7 +117,7 @@ NFIQ2::QualityFeatures::MuFeature::computeFeatureData(
 		this->sigmaComputed = true;
 
 		// return mu value
-		NFIQ2::QualityFeatureData fd_mu;
+		std::pair<std::string, double> fd_mu;
 		fd_mu = std::make_pair("Mu", mu.val[0]);
 
 		featureDataList[fd_mu.first] = fd_mu.second;

--- a/NFIQ2/NFIQ2Algorithm/src/features/MuFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/MuFeature.cpp
@@ -16,11 +16,11 @@ NFIQ2::QualityFeatures::MuFeature::~MuFeature() = default;
 const std::string NFIQ2::QualityFeatures::MuFeature::speedFeatureIDGroup =
     "Contrast";
 
-std::vector<NFIQ2::QualityFeatureData>
+std::unordered_map<std::string, double>
 NFIQ2::QualityFeatures::MuFeature::computeFeatureData(
     const NFIQ2::FingerprintImageData &fingerprintImage)
 {
-	std::vector<NFIQ2::QualityFeatureData> featureDataList;
+	std::unordered_map<std::string, double> featureDataList;
 
 	// check if input image has 500 dpi
 	if (fingerprintImage.m_ImageDPI != NFIQ2::e_ImageResolution_500dpi) {
@@ -88,7 +88,7 @@ NFIQ2::QualityFeatures::MuFeature::computeFeatureData(
 		NFIQ2::QualityFeatureData fd_mmb;
 		fd_mmb = std::make_pair("MMB", avg);
 
-		featureDataList.push_back(fd_mmb);
+		featureDataList[fd_mmb.first] = fd_mmb.second;
 	} catch (const cv::Exception &e) {
 		std::stringstream ssErr;
 		ssErr << "Cannot compute feature Mu Mu Block (MMB): "
@@ -120,7 +120,7 @@ NFIQ2::QualityFeatures::MuFeature::computeFeatureData(
 		NFIQ2::QualityFeatureData fd_mu;
 		fd_mu = std::make_pair("Mu", mu.val[0]);
 
-		featureDataList.push_back(fd_mu);
+		featureDataList[fd_mu.first] = fd_mu.second;
 	} catch (const cv::Exception &e) {
 		std::stringstream ssErr;
 		ssErr << "Cannot compute feature Sigma (stddev) and Mu (mean): "

--- a/NFIQ2/NFIQ2Algorithm/src/features/MuFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/MuFeature.cpp
@@ -16,11 +16,11 @@ NFIQ2::QualityFeatures::MuFeature::~MuFeature() = default;
 const std::string NFIQ2::QualityFeatures::MuFeature::speedFeatureIDGroup =
     "Contrast";
 
-std::vector<NFIQ2::QualityFeatureResult>
+std::vector<NFIQ2::QualityFeatureData>
 NFIQ2::QualityFeatures::MuFeature::computeFeatureData(
     const NFIQ2::FingerprintImageData &fingerprintImage)
 {
-	std::vector<NFIQ2::QualityFeatureResult> featureDataList;
+	std::vector<NFIQ2::QualityFeatureData> featureDataList;
 
 	// check if input image has 500 dpi
 	if (fingerprintImage.m_ImageDPI != NFIQ2::e_ImageResolution_500dpi) {
@@ -87,10 +87,8 @@ NFIQ2::QualityFeatures::MuFeature::computeFeatureData(
 		// return MMB value
 		NFIQ2::QualityFeatureData fd_mmb;
 		fd_mmb = std::make_pair("MMB", avg);
-		NFIQ2::QualityFeatureResult res_mmb;
-		res_mmb.featureData = fd_mmb;
 
-		featureDataList.push_back(res_mmb);
+		featureDataList.push_back(fd_mmb);
 	} catch (const cv::Exception &e) {
 		std::stringstream ssErr;
 		ssErr << "Cannot compute feature Mu Mu Block (MMB): "
@@ -121,10 +119,8 @@ NFIQ2::QualityFeatures::MuFeature::computeFeatureData(
 		// return mu value
 		NFIQ2::QualityFeatureData fd_mu;
 		fd_mu = std::make_pair("Mu", mu.val[0]);
-		NFIQ2::QualityFeatureResult res_mu;
-		res_mu.featureData = fd_mu;
 
-		featureDataList.push_back(res_mu);
+		featureDataList.push_back(fd_mu);
 	} catch (const cv::Exception &e) {
 		std::stringstream ssErr;
 		ssErr << "Cannot compute feature Sigma (stddev) and Mu (mean): "

--- a/NFIQ2/NFIQ2Algorithm/src/features/OCLHistogramFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/OCLHistogramFeature.cpp
@@ -17,11 +17,11 @@ const std::string
     NFIQ2::QualityFeatures::OCLHistogramFeature::speedFeatureIDGroup =
 	"Orientation certainty";
 
-std::vector<NFIQ2::QualityFeatureResult>
+std::vector<NFIQ2::QualityFeatureData>
 NFIQ2::QualityFeatures::OCLHistogramFeature::computeFeatureData(
     const NFIQ2::FingerprintImageData &fingerprintImage)
 {
-	std::vector<NFIQ2::QualityFeatureResult> featureDataList;
+	std::vector<NFIQ2::QualityFeatureData> featureDataList;
 
 	cv::Mat img;
 

--- a/NFIQ2/NFIQ2Algorithm/src/features/OCLHistogramFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/OCLHistogramFeature.cpp
@@ -17,11 +17,11 @@ const std::string
     NFIQ2::QualityFeatures::OCLHistogramFeature::speedFeatureIDGroup =
 	"Orientation certainty";
 
-std::vector<NFIQ2::QualityFeatureData>
+std::unordered_map<std::string, double>
 NFIQ2::QualityFeatures::OCLHistogramFeature::computeFeatureData(
     const NFIQ2::FingerprintImageData &fingerprintImage)
 {
-	std::vector<NFIQ2::QualityFeatureData> featureDataList;
+	std::unordered_map<std::string, double> featureDataList;
 
 	cv::Mat img;
 

--- a/NFIQ2/NFIQ2Algorithm/src/features/OFFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/OFFeature.cpp
@@ -35,11 +35,11 @@ NFIQ2::QualityFeatures::OFFeature::getAllFeatureIDs()
 const std::string NFIQ2::QualityFeatures::OFFeature::speedFeatureIDGroup =
     "Orientation flow";
 
-std::vector<NFIQ2::QualityFeatureData>
+std::unordered_map<std::string, double>
 NFIQ2::QualityFeatures::OFFeature::computeFeatureData(
     const NFIQ2::FingerprintImageData &fingerprintImage)
 {
-	std::vector<NFIQ2::QualityFeatureData> featureDataList;
+	std::unordered_map<std::string, double> featureDataList;
 
 	// check if input image has 500 dpi
 	if (fingerprintImage.m_ImageDPI != NFIQ2::e_ImageResolution_500dpi) {

--- a/NFIQ2/NFIQ2Algorithm/src/features/OFFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/OFFeature.cpp
@@ -35,11 +35,11 @@ NFIQ2::QualityFeatures::OFFeature::getAllFeatureIDs()
 const std::string NFIQ2::QualityFeatures::OFFeature::speedFeatureIDGroup =
     "Orientation flow";
 
-std::vector<NFIQ2::QualityFeatureResult>
+std::vector<NFIQ2::QualityFeatureData>
 NFIQ2::QualityFeatures::OFFeature::computeFeatureData(
     const NFIQ2::FingerprintImageData &fingerprintImage)
 {
-	std::vector<NFIQ2::QualityFeatureResult> featureDataList;
+	std::vector<NFIQ2::QualityFeatureData> featureDataList;
 
 	// check if input image has 500 dpi
 	if (fingerprintImage.m_ImageDPI != NFIQ2::e_ImageResolution_500dpi) {

--- a/NFIQ2/NFIQ2Algorithm/src/features/QualityMapFeatures.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/QualityMapFeatures.cpp
@@ -20,11 +20,11 @@ const std::string
     NFIQ2::QualityFeatures::QualityMapFeatures::speedFeatureIDGroup =
 	"Quality map";
 
-std::vector<NFIQ2::QualityFeatureResult>
+std::vector<NFIQ2::QualityFeatureData>
 NFIQ2::QualityFeatures::QualityMapFeatures::computeFeatureData(
     const NFIQ2::FingerprintImageData &fingerprintImage)
 {
-	std::vector<NFIQ2::QualityFeatureResult> featureDataList;
+	std::vector<NFIQ2::QualityFeatureData> featureDataList;
 
 	// check if input image has 500 dpi
 	if (fingerprintImage.m_ImageDPI != NFIQ2::e_ImageResolution_500dpi) {
@@ -68,19 +68,15 @@ NFIQ2::QualityFeatures::QualityMapFeatures::computeFeatureData(
 		fd_om_2 = std::make_pair(
 		    "OrientationMap_ROIFilter_CoherenceRel",
 		    coherenceRelFilter);
-		NFIQ2::QualityFeatureResult res_om_2;
-		res_om_2.featureData = fd_om_2;
 
-		featureDataList.push_back(res_om_2);
+		featureDataList.push_back(fd_om_2);
 
 		NFIQ2::QualityFeatureData fd_om_1;
 		fd_om_1 = std::make_pair(
 		    "OrientationMap_ROIFilter_CoherenceSum",
 		    coherenceSumFilter);
-		NFIQ2::QualityFeatureResult res_om_1;
-		res_om_1.featureData = fd_om_1;
 
-		featureDataList.push_back(res_om_1);
+		featureDataList.push_back(fd_om_1);
 
 		NFIQ2::QualityFeatureSpeed speed;
 		speed.featureIDGroup = QualityMapFeatures::speedFeatureIDGroup;

--- a/NFIQ2/NFIQ2Algorithm/src/features/QualityMapFeatures.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/QualityMapFeatures.cpp
@@ -20,11 +20,11 @@ const std::string
     NFIQ2::QualityFeatures::QualityMapFeatures::speedFeatureIDGroup =
 	"Quality map";
 
-std::vector<NFIQ2::QualityFeatureData>
+std::unordered_map<std::string, double>
 NFIQ2::QualityFeatures::QualityMapFeatures::computeFeatureData(
     const NFIQ2::FingerprintImageData &fingerprintImage)
 {
-	std::vector<NFIQ2::QualityFeatureData> featureDataList;
+	std::unordered_map<std::string, double> featureDataList;
 
 	// check if input image has 500 dpi
 	if (fingerprintImage.m_ImageDPI != NFIQ2::e_ImageResolution_500dpi) {
@@ -69,14 +69,14 @@ NFIQ2::QualityFeatures::QualityMapFeatures::computeFeatureData(
 		    "OrientationMap_ROIFilter_CoherenceRel",
 		    coherenceRelFilter);
 
-		featureDataList.push_back(fd_om_2);
+		featureDataList[fd_om_2.first] = fd_om_2.second;
 
 		NFIQ2::QualityFeatureData fd_om_1;
 		fd_om_1 = std::make_pair(
 		    "OrientationMap_ROIFilter_CoherenceSum",
 		    coherenceSumFilter);
 
-		featureDataList.push_back(fd_om_1);
+		featureDataList[fd_om_1.first] = fd_om_1.second;
 
 		NFIQ2::QualityFeatureSpeed speed;
 		speed.featureIDGroup = QualityMapFeatures::speedFeatureIDGroup;

--- a/NFIQ2/NFIQ2Algorithm/src/features/QualityMapFeatures.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/QualityMapFeatures.cpp
@@ -65,16 +65,18 @@ NFIQ2::QualityFeatures::QualityMapFeatures::computeFeatureData(
 
 		// return features based on coherence values of orientation map
 		NFIQ2::QualityFeatureData fd_om_2;
-		fd_om_2.featureID = "OrientationMap_ROIFilter_CoherenceRel";
-		fd_om_2.featureDataDouble = coherenceRelFilter;
+		fd_om_2 = std::make_pair(
+		    "OrientationMap_ROIFilter_CoherenceRel",
+		    coherenceRelFilter);
 		NFIQ2::QualityFeatureResult res_om_2;
 		res_om_2.featureData = fd_om_2;
 
 		featureDataList.push_back(res_om_2);
 
 		NFIQ2::QualityFeatureData fd_om_1;
-		fd_om_1.featureID = "OrientationMap_ROIFilter_CoherenceSum";
-		fd_om_1.featureDataDouble = coherenceSumFilter;
+		fd_om_1 = std::make_pair(
+		    "OrientationMap_ROIFilter_CoherenceSum",
+		    coherenceSumFilter);
 		NFIQ2::QualityFeatureResult res_om_1;
 		res_om_1.featureData = fd_om_1;
 

--- a/NFIQ2/NFIQ2Algorithm/src/features/QualityMapFeatures.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/QualityMapFeatures.cpp
@@ -64,14 +64,14 @@ NFIQ2::QualityFeatures::QualityMapFeatures::computeFeatureData(
 		    this->imgProcResults_);
 
 		// return features based on coherence values of orientation map
-		NFIQ2::QualityFeatureData fd_om_2;
+		std::pair<std::string, double> fd_om_2;
 		fd_om_2 = std::make_pair(
 		    "OrientationMap_ROIFilter_CoherenceRel",
 		    coherenceRelFilter);
 
 		featureDataList[fd_om_2.first] = fd_om_2.second;
 
-		NFIQ2::QualityFeatureData fd_om_1;
+		std::pair<std::string, double> fd_om_1;
 		fd_om_1 = std::make_pair(
 		    "OrientationMap_ROIFilter_CoherenceSum",
 		    coherenceSumFilter);

--- a/NFIQ2/NFIQ2Algorithm/src/features/RVUPHistogramFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/RVUPHistogramFeature.cpp
@@ -23,11 +23,11 @@ const std::string
     NFIQ2::QualityFeatures::RVUPHistogramFeature::speedFeatureIDGroup =
 	"Ridge valley uniformity";
 
-std::vector<NFIQ2::QualityFeatureData>
+std::unordered_map<std::string, double>
 NFIQ2::QualityFeatures::RVUPHistogramFeature::computeFeatureData(
     const NFIQ2::FingerprintImageData &fingerprintImage)
 {
-	std::vector<NFIQ2::QualityFeatureData> featureDataList;
+	std::unordered_map<std::string, double> featureDataList;
 
 	// check if input image has 500 dpi
 	if (fingerprintImage.m_ImageDPI != NFIQ2::e_ImageResolution_500dpi) {

--- a/NFIQ2/NFIQ2Algorithm/src/features/RVUPHistogramFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/RVUPHistogramFeature.cpp
@@ -23,11 +23,11 @@ const std::string
     NFIQ2::QualityFeatures::RVUPHistogramFeature::speedFeatureIDGroup =
 	"Ridge valley uniformity";
 
-std::vector<NFIQ2::QualityFeatureResult>
+std::vector<NFIQ2::QualityFeatureData>
 NFIQ2::QualityFeatures::RVUPHistogramFeature::computeFeatureData(
     const NFIQ2::FingerprintImageData &fingerprintImage)
 {
-	std::vector<NFIQ2::QualityFeatureResult> featureDataList;
+	std::vector<NFIQ2::QualityFeatureData> featureDataList;
 
 	// check if input image has 500 dpi
 	if (fingerprintImage.m_ImageDPI != NFIQ2::e_ImageResolution_500dpi) {

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_algorithm.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_algorithm.cpp
@@ -49,8 +49,7 @@ NFIQ2::Algorithm::computeQualityScore(
 
 unsigned int
 NFIQ2::Algorithm::computeQualityScore(
-    const std::unordered_map<std::string, NFIQ2::QualityFeatureData> &features)
-    const
+    const std::unordered_map<std::string, double> &features) const
 {
 	return (this->pimpl->computeQualityScore(features));
 }

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_algorithm_impl.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_algorithm_impl.cpp
@@ -58,8 +58,7 @@ NFIQ2::Algorithm::Impl::~Impl() = default;
 
 double
 NFIQ2::Algorithm::Impl::getQualityPrediction(
-    const std::unordered_map<std::string, NFIQ2::QualityFeatureData> &features)
-    const
+    const std::unordered_map<std::string, double> &features) const
 {
 	this->throwIfUninitialized();
 
@@ -76,8 +75,8 @@ NFIQ2::Algorithm::Impl::computeQualityScore(
 {
 	this->throwIfUninitialized();
 
-	const std::unordered_map<std::string, NFIQ2::QualityFeatureData>
-	    quality = NFIQ2::QualityFeatures::getQualityFeatureData(features);
+	const std::unordered_map<std::string, double> quality =
+	    NFIQ2::QualityFeatures::getQualityFeatureData(features);
 
 	if (quality.size() == 0) {
 		// no features have been computed
@@ -126,8 +125,8 @@ NFIQ2::Algorithm::Impl::computeQualityScore(
 		    NFIQ2::ErrorCode::UnknownError, e.what());
 	}
 
-	const std::unordered_map<std::string, NFIQ2::QualityFeatureData>
-	    quality = NFIQ2::QualityFeatures::getQualityFeatureData(features);
+	const std::unordered_map<std::string, double> quality =
+	    NFIQ2::QualityFeatures::getQualityFeatureData(features);
 
 	if (quality.size() == 0) {
 		// no features have been computed
@@ -152,8 +151,7 @@ NFIQ2::Algorithm::Impl::computeQualityScore(
 
 unsigned int
 NFIQ2::Algorithm::Impl::computeQualityScore(
-    const std::unordered_map<std::string, NFIQ2::QualityFeatureData> &features)
-    const
+    const std::unordered_map<std::string, double> &features) const
 {
 	this->throwIfUninitialized();
 

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_algorithm_impl.hpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_algorithm_impl.hpp
@@ -94,8 +94,7 @@ class Algorithm::Impl {
 	 * Called before random forest parameters were loaded.
 	 */
 	unsigned int computeQualityScore(
-	    const std::unordered_map<std::string, NFIQ2::QualityFeatureData>
-		&features) const;
+	    const std::unordered_map<std::string, double> &features) const;
 
 	/**
 	 * @brief
@@ -157,8 +156,7 @@ class Algorithm::Impl {
 	 * called before random forest parameters loaded.
 	 */
 	double getQualityPrediction(
-	    const std::unordered_map<std::string, NFIQ2::QualityFeatureData>
-		&features) const;
+	    const std::unordered_map<std::string, double> &features) const;
 
 	/**
 	 * @brief

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures.cpp
@@ -45,7 +45,7 @@ NFIQ2::QualityFeatures::getActionableQualityFeedback(
 	    rawImage);
 }
 
-std::unordered_map<std::string, NFIQ2::QualityFeatureData>
+std::unordered_map<std::string, double>
 NFIQ2::QualityFeatures::getQualityFeatureData(
     const std::vector<std::shared_ptr<NFIQ2::QualityFeatures::BaseFeature>>
 	&features)
@@ -53,7 +53,7 @@ NFIQ2::QualityFeatures::getQualityFeatureData(
 	return NFIQ2::QualityFeatures::Impl::getQualityFeatureData(features);
 }
 
-std::unordered_map<std::string, NFIQ2::QualityFeatureData>
+std::unordered_map<std::string, double>
 NFIQ2::QualityFeatures::getQualityFeatureData(
     const NFIQ2::FingerprintImageData &rawImage)
 {

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures_impl.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures_impl.cpp
@@ -57,11 +57,9 @@ NFIQ2::QualityFeatures::Impl::getQualityFeatureData(
 
 	std::unordered_map<std::string, NFIQ2::QualityFeatureData> quality {};
 
-	auto counter = 0;
 	for (const auto &feature : features) {
-		for (auto &result : feature->getFeatures()) {
-			quality[qualityIdentifiers.at(counter)] = result;
-			counter++;
+		for (auto &qfd : feature->getFeatures()) {
+			quality[qfd.first] = qfd;
 		}
 	}
 
@@ -90,10 +88,10 @@ NFIQ2::QualityFeatures::Impl::getActionableQualityFeedback(
 			const std::shared_ptr<MuFeature> muFeatureModule =
 			    std::dynamic_pointer_cast<MuFeature>(feature);
 
-			std::vector<NFIQ2::QualityFeatureData> muFeatures =
+			std::unordered_map<std::string, double> muFeatures =
 			    muFeatureModule->getFeatures();
 
-			std::vector<NFIQ2::QualityFeatureData>::iterator
+			std::unordered_map<std::string, double>::iterator
 			    it_muFeatures;
 			// check for uniform image by using the Sigma value
 			bool isUniformImage = false;
@@ -150,10 +148,10 @@ NFIQ2::QualityFeatures::Impl::getActionableQualityFeedback(
 				std::dynamic_pointer_cast<FingerJetFXFeature>(
 				    feature);
 
-			std::vector<NFIQ2::QualityFeatureData> fjfxFeatures =
+			std::unordered_map<std::string, double> fjfxFeatures =
 			    fjfxFeatureModule->getFeatures();
 
-			std::vector<NFIQ2::QualityFeatureData>::iterator
+			std::unordered_map<std::string, double>::iterator
 			    it_fjfxFeatures;
 
 			for (it_fjfxFeatures = fjfxFeatures.begin();

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures_impl.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures_impl.cpp
@@ -117,12 +117,11 @@ NFIQ2::QualityFeatures::Impl::getActionableQualityFeedback(
 			for (it_muFeatures = muFeatures.begin();
 			     it_muFeatures != muFeatures.end();
 			     ++it_muFeatures) {
-				if (it_muFeatures->featureData.featureID
-					.compare("Mu") == 0) {
+				if (it_muFeatures->featureData.first.compare(
+					"Mu") == 0) {
 					NFIQ2::ActionableQualityFeedback fb;
 					fb.actionableQualityValue =
-					    it_muFeatures->featureData
-						.featureDataDouble;
+					    it_muFeatures->featureData.second;
 					fb.identifier = NFIQ2::
 					    ActionableQualityFeedbackIdentifier::
 						EmptyImageOrContrastTooLow;
@@ -162,15 +161,13 @@ NFIQ2::QualityFeatures::Impl::getActionableQualityFeedback(
 			for (it_fjfxFeatures = fjfxFeatures.begin();
 			     it_fjfxFeatures != fjfxFeatures.end();
 			     ++it_fjfxFeatures) {
-				if (it_fjfxFeatures->featureData.featureID
-					.compare("FingerJetFX_MinutiaeCount") ==
-				    0) {
+				if (it_fjfxFeatures->featureData.first.compare(
+					"FingerJetFX_MinutiaeCount") == 0) {
 					// return informative feature about
 					// number of minutiae
 					NFIQ2::ActionableQualityFeedback fb;
 					fb.actionableQualityValue =
-					    it_fjfxFeatures->featureData
-						.featureDataDouble;
+					    it_fjfxFeatures->featureData.second;
 					fb.identifier = NFIQ2::
 					    ActionableQualityFeedbackIdentifier::
 						FingerprintImageWithMinutiae;

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures_impl.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures_impl.cpp
@@ -39,7 +39,7 @@ NFIQ2::QualityFeatures::Impl::getQualityFeatureSpeeds(
 	return speedMap;
 }
 
-std::unordered_map<std::string, NFIQ2::QualityFeatureData>
+std::unordered_map<std::string, double>
 NFIQ2::QualityFeatures::Impl::getQualityFeatureData(
     const NFIQ2::FingerprintImageData &rawImage)
 {
@@ -47,7 +47,7 @@ NFIQ2::QualityFeatures::Impl::getQualityFeatureData(
 	    NFIQ2::QualityFeatures::computeQualityFeatures(rawImage));
 }
 
-std::unordered_map<std::string, NFIQ2::QualityFeatureData>
+std::unordered_map<std::string, double>
 NFIQ2::QualityFeatures::Impl::getQualityFeatureData(
     const std::vector<std::shared_ptr<NFIQ2::QualityFeatures::BaseFeature>>
 	&features)
@@ -55,12 +55,11 @@ NFIQ2::QualityFeatures::Impl::getQualityFeatureData(
 	std::vector<std::string> qualityIdentifiers =
 	    NFIQ2::QualityFeatures::Impl::getAllQualityFeatureIDs();
 
-	std::unordered_map<std::string, NFIQ2::QualityFeatureData> quality {};
+	std::unordered_map<std::string, double> quality {};
 
 	for (const auto &feature : features) {
-		for (auto &qfd : feature->getFeatures()) {
-			quality[qfd.first] = qfd;
-		}
+		const auto moduleFeatures = feature->getFeatures();
+		quality.insert(moduleFeatures.cbegin(), moduleFeatures.cend());
 	}
 
 	return quality;

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures_impl.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures_impl.cpp
@@ -60,8 +60,7 @@ NFIQ2::QualityFeatures::Impl::getQualityFeatureData(
 	auto counter = 0;
 	for (const auto &feature : features) {
 		for (auto &result : feature->getFeatures()) {
-			quality[qualityIdentifiers.at(counter)] =
-			    result.featureData;
+			quality[qualityIdentifiers.at(counter)] = result;
 			counter++;
 		}
 	}
@@ -91,10 +90,10 @@ NFIQ2::QualityFeatures::Impl::getActionableQualityFeedback(
 			const std::shared_ptr<MuFeature> muFeatureModule =
 			    std::dynamic_pointer_cast<MuFeature>(feature);
 
-			std::vector<NFIQ2::QualityFeatureResult> muFeatures =
+			std::vector<NFIQ2::QualityFeatureData> muFeatures =
 			    muFeatureModule->getFeatures();
 
-			std::vector<NFIQ2::QualityFeatureResult>::iterator
+			std::vector<NFIQ2::QualityFeatureData>::iterator
 			    it_muFeatures;
 			// check for uniform image by using the Sigma value
 			bool isUniformImage = false;
@@ -117,11 +116,10 @@ NFIQ2::QualityFeatures::Impl::getActionableQualityFeedback(
 			for (it_muFeatures = muFeatures.begin();
 			     it_muFeatures != muFeatures.end();
 			     ++it_muFeatures) {
-				if (it_muFeatures->featureData.first.compare(
-					"Mu") == 0) {
+				if (it_muFeatures->first.compare("Mu") == 0) {
 					NFIQ2::ActionableQualityFeedback fb;
 					fb.actionableQualityValue =
-					    it_muFeatures->featureData.second;
+					    it_muFeatures->second;
 					fb.identifier = NFIQ2::
 					    ActionableQualityFeedbackIdentifier::
 						EmptyImageOrContrastTooLow;
@@ -152,22 +150,22 @@ NFIQ2::QualityFeatures::Impl::getActionableQualityFeedback(
 				std::dynamic_pointer_cast<FingerJetFXFeature>(
 				    feature);
 
-			std::vector<NFIQ2::QualityFeatureResult> fjfxFeatures =
+			std::vector<NFIQ2::QualityFeatureData> fjfxFeatures =
 			    fjfxFeatureModule->getFeatures();
 
-			std::vector<NFIQ2::QualityFeatureResult>::iterator
+			std::vector<NFIQ2::QualityFeatureData>::iterator
 			    it_fjfxFeatures;
 
 			for (it_fjfxFeatures = fjfxFeatures.begin();
 			     it_fjfxFeatures != fjfxFeatures.end();
 			     ++it_fjfxFeatures) {
-				if (it_fjfxFeatures->featureData.first.compare(
+				if (it_fjfxFeatures->first.compare(
 					"FingerJetFX_MinutiaeCount") == 0) {
 					// return informative feature about
 					// number of minutiae
 					NFIQ2::ActionableQualityFeedback fb;
 					fb.actionableQualityValue =
-					    it_fjfxFeatures->featureData.second;
+					    it_fjfxFeatures->second;
 					fb.identifier = NFIQ2::
 					    ActionableQualityFeedbackIdentifier::
 						FingerprintImageWithMinutiae;

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures_impl.hpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures_impl.hpp
@@ -109,8 +109,7 @@ getActionableQualityFeedback(const NFIQ2::FingerprintImageData &rawImage);
  * @return
  * A map of string, quality feature data pairs.
  */
-std::unordered_map<std::string, NFIQ2::QualityFeatureData>
-getQualityFeatureData(
+std::unordered_map<std::string, double> getQualityFeatureData(
     const std::vector<std::shared_ptr<NFIQ2::QualityFeatures::BaseFeature>>
 	&features);
 
@@ -124,8 +123,8 @@ getQualityFeatureData(
  * @return
  * A map of string, quality feature data pairs.
  */
-std::unordered_map<std::string, NFIQ2::QualityFeatureData>
-getQualityFeatureData(const NFIQ2::FingerprintImageData &rawImage);
+std::unordered_map<std::string, double> getQualityFeatureData(
+    const NFIQ2::FingerprintImageData &rawImage);
 
 /**
  * @brief

--- a/NFIQ2/NFIQ2Algorithm/src/prediction/RandomForestML.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/prediction/RandomForestML.cpp
@@ -178,8 +178,8 @@ NFIQ2::Prediction::RandomForestML::evaluate(
 		unsigned int counterFeatures = 0;
 		for (it_feat = featureVector.begin();
 		     it_feat != featureVector.end(); it_feat++) {
-			sample_data.at<float>(0, counterFeatures) =
-			    (float)it_feat->featureDataDouble;
+			sample_data.at<float>(
+			    0, counterFeatures) = (float)it_feat->second;
 			counterFeatures++;
 		}
 

--- a/NFIQ2/NFIQ2Algorithm/src/prediction/RandomForestML.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/prediction/RandomForestML.cpp
@@ -124,7 +124,7 @@ NFIQ2::Prediction::RandomForestML::initModule(
 
 void
 NFIQ2::Prediction::RandomForestML::evaluate(
-    const std::unordered_map<std::string, NFIQ2::QualityFeatureData> &features,
+    const std::unordered_map<std::string, double> &features,
     double &qualityValue) const
 {
 	/**
@@ -157,11 +157,6 @@ NFIQ2::Prediction::RandomForestML::evaluate(
 		"RVUP_Bin10_5", "RVUP_Bin10_6", "RVUP_Bin10_7", "RVUP_Bin10_8",
 		"RVUP_Bin10_9", "RVUP_Bin10_Mean", "RVUP_Bin10_StdDev" };
 
-	std::vector<NFIQ2::QualityFeatureData> featureVector {};
-	for (const auto &i : rfFeatureOrder) {
-		featureVector.push_back(features.at(i));
-	}
-
 	try {
 		if (m_pTrainedRF.empty() || !m_pTrainedRF->isTrained() ||
 		    !m_pTrainedRF->isClassifier()) {
@@ -173,14 +168,11 @@ NFIQ2::Prediction::RandomForestML::evaluate(
 
 		// copy data to structure
 		cv::Mat sample_data = cv::Mat(
-		    1, featureVector.size(), CV_32FC1);
-		std::vector<NFIQ2::QualityFeatureData>::const_iterator it_feat;
-		unsigned int counterFeatures = 0;
-		for (it_feat = featureVector.begin();
-		     it_feat != featureVector.end(); it_feat++) {
-			sample_data.at<float>(
-			    0, counterFeatures) = (float)it_feat->second;
-			counterFeatures++;
+		    1, rfFeatureOrder.size(), CV_32FC1);
+
+		for (unsigned int i { 0 }; i < rfFeatureOrder.size(); ++i) {
+			sample_data.at<float>(0, i) = features.at(
+			    rfFeatureOrder[i]);
 		}
 
 		// returns probability that between 0 and 1 that result belongs
@@ -192,6 +184,9 @@ NFIQ2::Prediction::RandomForestML::evaluate(
 
 	} catch (const cv::Exception &e) {
 		throw Exception(NFIQ2::ErrorCode::MachineLearningError, e.msg);
+	} catch (const std::out_of_range &e) {
+		throw Exception(
+		    NFIQ2::ErrorCode::FeatureCalculationError, e.what());
 	}
 }
 

--- a/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_log.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_log.cpp
@@ -83,8 +83,8 @@ NFIQ2UI::Log::printScore(const std::string &name, uint8_t fingerCode,
 				*(this->out) << ",";
 			}
 
-			*(this->out) << NFIQ2UI::formatDouble(
-			    features.at(i).featureDataDouble, 5);
+			*(this->out)
+			    << NFIQ2UI::formatDouble(features.at(i).second, 5);
 		}
 		if (this->speed) {
 			*(this->out) << ",";

--- a/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_log.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_log.cpp
@@ -45,7 +45,7 @@ void
 NFIQ2UI::Log::printScore(const std::string &name, uint8_t fingerCode,
     unsigned int score, const std::string &errmsg, const bool quantized,
     const bool resampled,
-    const std::unordered_map<std::string, NFIQ2::QualityFeatureData> &features,
+    const std::unordered_map<std::string, double> &features,
     const std::unordered_map<std::string, NFIQ2::QualityFeatureSpeed> &speed,
     const std::unordered_map<std::string, NFIQ2::ActionableQualityFeedback>
 	&actionable) const
@@ -84,7 +84,7 @@ NFIQ2UI::Log::printScore(const std::string &name, uint8_t fingerCode,
 			}
 
 			*(this->out)
-			    << NFIQ2UI::formatDouble(features.at(i).second, 5);
+			    << NFIQ2UI::formatDouble(features.at(i), 5);
 		}
 		if (this->speed) {
 			*(this->out) << ",";

--- a/NFIQ2/NFIQ2Api/nfiq2api.cpp
+++ b/NFIQ2/NFIQ2Api/nfiq2api.cpp
@@ -114,7 +114,7 @@ ComputeNfiq2Score(int fpos, const unsigned char *pixels, int size, int width,
 			    pixels, size, width, height, fpos, ppi);
 			std::vector<NFIQ2::ActionableQualityFeedback>
 			    actionableQuality;
-			std::vector<NFIQ2::QualityFeatureData> featureVector;
+			std::unordered_map<std::string, double> featureVector;
 			std::vector<NFIQ2::QualityFeatureSpeed> featureTimings;
 			int qualityScore = (int)g_nfiq2->computeQualityScore(
 			    rawImage);

--- a/examples/example_api.cpp
+++ b/examples/example_api.cpp
@@ -181,13 +181,12 @@ main(int argc, char **argv)
 	std::vector<std::string> featureIDs =
 	    NFIQ2::QualityFeatures::getAllQualityFeatureIDs();
 
-	std::unordered_map<std::string, NFIQ2::QualityFeatureData>
-	    qualityFeatures = NFIQ2::QualityFeatures::getQualityFeatureData(
-		features);
+	std::unordered_map<std::string, double> qualityFeatures =
+	    NFIQ2::QualityFeatures::getQualityFeatureData(features);
 
-	for (const auto &i : featureIDs) {
-		std::cout << qualityFeatures.at(i).first << ": "
-			  << qualityFeatures.at(i).second << '\n';
+	for (const auto &featureID : featureIDs) {
+		std::cout << featureID << ": " << qualityFeatures.at(featureID)
+			  << '\n';
 	}
 
 	// Image Processed

--- a/examples/example_api.cpp
+++ b/examples/example_api.cpp
@@ -186,8 +186,8 @@ main(int argc, char **argv)
 		features);
 
 	for (const auto &i : featureIDs) {
-		std::cout << qualityFeatures.at(i).featureID << ": "
-			  << qualityFeatures.at(i).featureDataDouble << '\n';
+		std::cout << qualityFeatures.at(i).first << ": "
+			  << qualityFeatures.at(i).second << '\n';
 	}
 
 	// Image Processed


### PR DESCRIPTION
Remove two levels of indirection that were a result of `QualityFeatureResult` and `QualityFeatureData`. We have now simplified to an `unordered_map` of featureIDs and values.