### PR TITLE
Remove unnecessary check for template creation

### DIFF
--- a/NFIQ2/NFIQ2Algorithm/include/features/FJFXMinutiaeQualityFeatures.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/FJFXMinutiaeQualityFeatures.h
@@ -30,8 +30,7 @@ class FJFXMinutiaeQualityFeature : public BaseFeature {
 
 	FJFXMinutiaeQualityFeature(
 	    const NFIQ2::FingerprintImageData &fingerprintImage,
-	    const std::vector<FingerJetFXFeature::Minutia> &minutiaData,
-	    const bool templateCouldBeExtracted);
+	    const std::vector<FingerJetFXFeature::Minutia> &minutiaData);
 
 	virtual ~FJFXMinutiaeQualityFeature();
 
@@ -46,14 +45,11 @@ class FJFXMinutiaeQualityFeature : public BaseFeature {
 	 */
 	std::vector<FingerJetFXFeature::Minutia> getMinutiaData() const;
 
-	bool getTemplateStatus() const;
-
     private:
 	std::vector<NFIQ2::QualityFeatureResult> computeFeatureData(
 	    const NFIQ2::FingerprintImageData &fingerprintImage);
 
 	std::vector<FingerJetFXFeature::Minutia> minutiaData_ {};
-	bool templateCouldBeExtracted_ { false };
 	std::vector<MinutiaData> computeMuMinQuality(
 	    int bs, const NFIQ2::FingerprintImageData &fingerprintImage);
 

--- a/NFIQ2/NFIQ2Algorithm/include/features/FingerJetFXFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/FingerJetFXFeature.h
@@ -113,12 +113,7 @@ class FingerJetFXFeature : public BaseFeature {
 
 	static std::string parseFRFXLLError(const FRFXLL_RESULT fxRes);
 
-	/** @throw NFIQ2::NFIQException
-	 * Template could not be extracted.
-	 */
 	std::vector<FingerJetFXFeature::Minutia> getMinutiaData() const;
-
-	bool getTemplateStatus() const;
 
     private:
 	std::vector<NFIQ2::QualityFeatureResult> computeFeatureData(
@@ -128,7 +123,6 @@ class FingerJetFXFeature : public BaseFeature {
 	createContext(FRFXLL_HANDLE_PT phContext);
 
 	std::vector<FingerJetFXFeature::Minutia> minutiaData_ {};
-	bool templateCouldBeExtracted_ { false };
 
 	FJFXROIResults computeROI(int bs,
 	    const NFIQ2::FingerprintImageData &fingerprintImage,

--- a/NFIQ2/NFIQ2Algorithm/src/features/FJFXMinutiaeQualityFeatures.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FJFXMinutiaeQualityFeatures.cpp
@@ -7,10 +7,8 @@
 
 NFIQ2::QualityFeatures::FJFXMinutiaeQualityFeature::FJFXMinutiaeQualityFeature(
     const NFIQ2::FingerprintImageData &fingerprintImage,
-    const std::vector<FingerJetFXFeature::Minutia> &minutiaData,
-    const bool templateCouldBeExtracted)
+    const std::vector<FingerJetFXFeature::Minutia> &minutiaData)
     : minutiaData_ { minutiaData }
-    , templateCouldBeExtracted_ { templateCouldBeExtracted }
 {
 	this->setFeatures(computeFeatureData(fingerprintImage));
 };
@@ -25,19 +23,7 @@ const std::string
 std::vector<NFIQ2::QualityFeatures::FingerJetFXFeature::Minutia>
 NFIQ2::QualityFeatures::FJFXMinutiaeQualityFeature::getMinutiaData() const
 {
-	if (!this->templateCouldBeExtracted_) {
-		// This should never be reached but is here for consistency
-		throw NFIQ2::Exception { NFIQ2::ErrorCode::NoDataAvailable,
-			"Template could not be extracted." };
-	}
-
 	return (this->minutiaData_);
-}
-
-bool
-NFIQ2::QualityFeatures::FJFXMinutiaeQualityFeature::getTemplateStatus() const
-{
-	return (this->templateCouldBeExtracted_);
 }
 
 std::vector<NFIQ2::QualityFeatureResult>
@@ -57,25 +43,6 @@ NFIQ2::QualityFeatures::FJFXMinutiaeQualityFeature::computeFeatureData(
 	fd_ocl.featureDataDouble = -1;
 	NFIQ2::QualityFeatureResult res_ocl;
 	res_ocl.featureData = fd_ocl;
-
-	if (!this->templateCouldBeExtracted_) {
-		res_mu.featureData.featureDataDouble = -1;
-		featureDataList.push_back(res_mu);
-
-		res_ocl.featureData.featureDataDouble = -1;
-		featureDataList.push_back(res_ocl);
-
-		// Speed
-		NFIQ2::QualityFeatureSpeed speed;
-		speed.featureIDGroup =
-		    FJFXMinutiaeQualityFeature::speedFeatureIDGroup;
-		speed.featureIDs.push_back("FJFXPos_Mu_MinutiaeQuality_2");
-		speed.featureIDs.push_back("FJFXPos_OCL_MinutiaeQuality_80");
-		speed.featureSpeed = 0;
-		this->setSpeed(speed);
-
-		return featureDataList;
-	}
 
 	try {
 		NFIQ2::Timer timer;

--- a/NFIQ2/NFIQ2Algorithm/src/features/FingerJetFXFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FingerJetFXFeature.cpp
@@ -71,20 +71,9 @@ NFIQ2::QualityFeatures::FingerJetFXFeature::parseFRFXLLError(
 	}
 }
 
-bool
-NFIQ2::QualityFeatures::FingerJetFXFeature::getTemplateStatus() const
-{
-	return (this->templateCouldBeExtracted_);
-}
-
 std::vector<NFIQ2::QualityFeatures::FingerJetFXFeature::Minutia>
 NFIQ2::QualityFeatures::FingerJetFXFeature::getMinutiaData() const
 {
-	if (!this->templateCouldBeExtracted_) {
-		throw NFIQ2::Exception { NFIQ2::ErrorCode::NoDataAvailable,
-			"Template could not be extracted." };
-	}
-
 	return (this->minutiaData_);
 }
 
@@ -92,8 +81,6 @@ std::vector<NFIQ2::QualityFeatureResult>
 NFIQ2::QualityFeatures::FingerJetFXFeature::computeFeatureData(
     const NFIQ2::FingerprintImageData &fingerprintImage)
 {
-	this->templateCouldBeExtracted_ = false;
-
 	std::vector<NFIQ2::QualityFeatureResult> featureDataList;
 
 	// make local copy of fingerprint image
@@ -206,8 +193,6 @@ NFIQ2::QualityFeatures::FingerJetFXFeature::computeFeatureData(
 
 	// close handle
 	FRFXLLCloseHandle(&hFeatureSet);
-
-	this->templateCouldBeExtracted_ = true;
 
 	if (minCnt == 0) {
 		// return features

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures_impl.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures_impl.cpp
@@ -241,8 +241,7 @@ NFIQ2::QualityFeatures::Impl::computeQualityFeatures(
 	features.push_back(fjfxFeatureModule);
 
 	features.push_back(std::make_shared<FJFXMinutiaeQualityFeature>(
-	    croppedImage, fjfxFeatureModule->getMinutiaData(),
-	    fjfxFeatureModule->getTemplateStatus()));
+	    croppedImage, fjfxFeatureModule->getMinutiaData()));
 
 	std::shared_ptr<ImgProcROIFeature> roiFeatureModule =
 	    std::make_shared<ImgProcROIFeature>(croppedImage);


### PR DESCRIPTION
FingerJetFXFeature throws NFIQ2::Exception from the constructor in the event that a template could not be created.