### PR TITLE
Remove QualitySpeedFeatures

### DIFF
--- a/NFIQ2/NFIQ2Algorithm/include/features/BaseFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/BaseFeature.h
@@ -19,19 +19,19 @@ class BaseFeature {
 	virtual std::string getModuleName() const = 0;
 
 	/** @return computed quality feature speed */
-	virtual NFIQ2::QualityFeatureSpeed getSpeed() const;
+	virtual double getSpeed() const;
 
 	/** @return computed quality features */
 	virtual std::unordered_map<std::string, double> getFeatures() const;
 
     protected:
-	void setSpeed(const NFIQ2::QualityFeatureSpeed &featureSpeed);
+	void setSpeed(const double featureSpeed);
 
 	void setFeatures(
 	    const std::unordered_map<std::string, double> &featureResult);
 
     private:
-	NFIQ2::QualityFeatureSpeed speed {};
+	double speed {};
 
 	std::unordered_map<std::string, double> features {};
 };

--- a/NFIQ2/NFIQ2Algorithm/include/features/FDAFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/FDAFeature.h
@@ -26,7 +26,6 @@ class FDAFeature : public BaseFeature {
 	std::string getModuleName() const override;
 
 	static std::vector<std::string> getAllQualityFeatureIDs();
-	static const char SpeedFeatureIDGroup[];
 	static const char moduleName[];
 
     private:

--- a/NFIQ2/NFIQ2Algorithm/include/features/FDAFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/FDAFeature.h
@@ -25,7 +25,7 @@ class FDAFeature : public BaseFeature {
 
 	std::string getModuleName() const override;
 
-	static std::vector<std::string> getAllFeatureIDs();
+	static std::vector<std::string> getAllQualityFeatureIDs();
 	static const char SpeedFeatureIDGroup[];
 	static const char moduleName[];
 

--- a/NFIQ2/NFIQ2Algorithm/include/features/FDAFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/FDAFeature.h
@@ -25,7 +25,7 @@ class FDAFeature : public BaseFeature {
 
 	std::string getModuleName() const override;
 
-	static std::vector<std::string> getAllQualityFeatureIDs();
+	static std::vector<std::string> getQualityFeatureIDs();
 	static const char moduleName[];
 
     private:

--- a/NFIQ2/NFIQ2Algorithm/include/features/FJFXMinutiaeQualityFeatures.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/FJFXMinutiaeQualityFeatures.h
@@ -36,7 +36,7 @@ class FJFXMinutiaeQualityFeature : public BaseFeature {
 
 	std::string getModuleName() const override;
 
-	static std::vector<std::string> getAllQualityFeatureIDs();
+	static std::vector<std::string> getQualityFeatureIDs();
 
 	/** @throw NFIQ2::NFIQException
 	 * Template could not be extracted.

--- a/NFIQ2/NFIQ2Algorithm/include/features/FJFXMinutiaeQualityFeatures.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/FJFXMinutiaeQualityFeatures.h
@@ -37,7 +37,6 @@ class FJFXMinutiaeQualityFeature : public BaseFeature {
 	std::string getModuleName() const override;
 
 	static std::vector<std::string> getAllQualityFeatureIDs();
-	static const char SpeedFeatureIDGroup[];
 
 	/** @throw NFIQ2::NFIQException
 	 * Template could not be extracted.

--- a/NFIQ2/NFIQ2Algorithm/include/features/FJFXMinutiaeQualityFeatures.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/FJFXMinutiaeQualityFeatures.h
@@ -36,7 +36,7 @@ class FJFXMinutiaeQualityFeature : public BaseFeature {
 
 	std::string getModuleName() const override;
 
-	static std::vector<std::string> getAllFeatureIDs();
+	static std::vector<std::string> getAllQualityFeatureIDs();
 	static const char SpeedFeatureIDGroup[];
 
 	/** @throw NFIQ2::NFIQException

--- a/NFIQ2/NFIQ2Algorithm/include/features/FingerJetFXFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/FingerJetFXFeature.h
@@ -104,7 +104,7 @@ class FingerJetFXFeature : public BaseFeature {
 
 	std::string getModuleName() const override;
 
-	static std::vector<std::string> getAllFeatureIDs();
+	static std::vector<std::string> getAllQualityFeatureIDs();
 	static const char SpeedFeatureIDGroup[];
 
 	static std::pair<unsigned int, unsigned int> centerOfMinutiaeMass(

--- a/NFIQ2/NFIQ2Algorithm/include/features/FingerJetFXFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/FingerJetFXFeature.h
@@ -104,7 +104,7 @@ class FingerJetFXFeature : public BaseFeature {
 
 	std::string getModuleName() const override;
 
-	static std::vector<std::string> getAllQualityFeatureIDs();
+	static std::vector<std::string> getQualityFeatureIDs();
 
 	static std::pair<unsigned int, unsigned int> centerOfMinutiaeMass(
 	    const std::vector<FingerJetFXFeature::Minutia> &minutiaData);

--- a/NFIQ2/NFIQ2Algorithm/include/features/FingerJetFXFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/FingerJetFXFeature.h
@@ -105,7 +105,6 @@ class FingerJetFXFeature : public BaseFeature {
 	std::string getModuleName() const override;
 
 	static std::vector<std::string> getAllQualityFeatureIDs();
-	static const char SpeedFeatureIDGroup[];
 
 	static std::pair<unsigned int, unsigned int> centerOfMinutiaeMass(
 	    const std::vector<FingerJetFXFeature::Minutia> &minutiaData);

--- a/NFIQ2/NFIQ2Algorithm/include/features/ImgProcROIFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/ImgProcROIFeature.h
@@ -41,7 +41,6 @@ class ImgProcROIFeature : public BaseFeature {
 	std::string getModuleName() const override;
 
 	static std::vector<std::string> getAllQualityFeatureIDs();
-	static const char SpeedFeatureIDGroup[];
 
 	static ImgProcROIResults computeROI(cv::Mat &img, unsigned int bs);
 

--- a/NFIQ2/NFIQ2Algorithm/include/features/ImgProcROIFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/ImgProcROIFeature.h
@@ -40,7 +40,7 @@ class ImgProcROIFeature : public BaseFeature {
 
 	std::string getModuleName() const override;
 
-	static std::vector<std::string> getAllFeatureIDs();
+	static std::vector<std::string> getAllQualityFeatureIDs();
 	static const char SpeedFeatureIDGroup[];
 
 	static ImgProcROIResults computeROI(cv::Mat &img, unsigned int bs);

--- a/NFIQ2/NFIQ2Algorithm/include/features/ImgProcROIFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/ImgProcROIFeature.h
@@ -40,7 +40,7 @@ class ImgProcROIFeature : public BaseFeature {
 
 	std::string getModuleName() const override;
 
-	static std::vector<std::string> getAllQualityFeatureIDs();
+	static std::vector<std::string> getQualityFeatureIDs();
 
 	static ImgProcROIResults computeROI(cv::Mat &img, unsigned int bs);
 

--- a/NFIQ2/NFIQ2Algorithm/include/features/LCSFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/LCSFeature.h
@@ -20,7 +20,7 @@ class LCSFeature : public BaseFeature {
 
 	std::string getModuleName() const override;
 
-	static std::vector<std::string> getAllFeatureIDs();
+	static std::vector<std::string> getAllQualityFeatureIDs();
 	static const char SpeedFeatureIDGroup[];
 
     private:

--- a/NFIQ2/NFIQ2Algorithm/include/features/LCSFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/LCSFeature.h
@@ -21,7 +21,6 @@ class LCSFeature : public BaseFeature {
 	std::string getModuleName() const override;
 
 	static std::vector<std::string> getAllQualityFeatureIDs();
-	static const char SpeedFeatureIDGroup[];
 
     private:
 	std::unordered_map<std::string, double> computeFeatureData(

--- a/NFIQ2/NFIQ2Algorithm/include/features/LCSFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/LCSFeature.h
@@ -20,7 +20,7 @@ class LCSFeature : public BaseFeature {
 
 	std::string getModuleName() const override;
 
-	static std::vector<std::string> getAllQualityFeatureIDs();
+	static std::vector<std::string> getQualityFeatureIDs();
 
     private:
 	std::unordered_map<std::string, double> computeFeatureData(

--- a/NFIQ2/NFIQ2Algorithm/include/features/MuFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/MuFeature.h
@@ -22,7 +22,7 @@ class MuFeature : public BaseFeature {
 	 */
 	double getSigma() const;
 
-	static std::vector<std::string> getAllQualityFeatureIDs();
+	static std::vector<std::string> getQualityFeatureIDs();
 
     private:
 	std::unordered_map<std::string, double> computeFeatureData(

--- a/NFIQ2/NFIQ2Algorithm/include/features/MuFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/MuFeature.h
@@ -22,7 +22,7 @@ class MuFeature : public BaseFeature {
 	 */
 	double getSigma() const;
 
-	static std::vector<std::string> getAllFeatureIDs();
+	static std::vector<std::string> getAllQualityFeatureIDs();
 	static const char SpeedFeatureIDGroup[];
 
     private:

--- a/NFIQ2/NFIQ2Algorithm/include/features/MuFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/MuFeature.h
@@ -23,7 +23,6 @@ class MuFeature : public BaseFeature {
 	double getSigma() const;
 
 	static std::vector<std::string> getAllQualityFeatureIDs();
-	static const char SpeedFeatureIDGroup[];
 
     private:
 	std::unordered_map<std::string, double> computeFeatureData(

--- a/NFIQ2/NFIQ2Algorithm/include/features/OCLHistogramFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/OCLHistogramFeature.h
@@ -25,7 +25,6 @@ class OCLHistogramFeature : public BaseFeature {
 	std::string getModuleName() const override;
 
 	static std::vector<std::string> getAllQualityFeatureIDs();
-	static const char SpeedFeatureIDGroup[];
 
 	// compute OCL value of a given block with block size BSxBS
 	static bool getOCLValueOfBlock(const cv::Mat &block, double &ocl);

--- a/NFIQ2/NFIQ2Algorithm/include/features/OCLHistogramFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/OCLHistogramFeature.h
@@ -24,7 +24,7 @@ class OCLHistogramFeature : public BaseFeature {
 
 	std::string getModuleName() const override;
 
-	static std::vector<std::string> getAllFeatureIDs();
+	static std::vector<std::string> getAllQualityFeatureIDs();
 	static const char SpeedFeatureIDGroup[];
 
 	// compute OCL value of a given block with block size BSxBS

--- a/NFIQ2/NFIQ2Algorithm/include/features/OCLHistogramFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/OCLHistogramFeature.h
@@ -24,7 +24,7 @@ class OCLHistogramFeature : public BaseFeature {
 
 	std::string getModuleName() const override;
 
-	static std::vector<std::string> getAllQualityFeatureIDs();
+	static std::vector<std::string> getQualityFeatureIDs();
 
 	// compute OCL value of a given block with block size BSxBS
 	static bool getOCLValueOfBlock(const cv::Mat &block, double &ocl);

--- a/NFIQ2/NFIQ2Algorithm/include/features/OFFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/OFFeature.h
@@ -27,7 +27,6 @@ class OFFeature : public BaseFeature {
 	std::string getModuleName() const override;
 
 	static std::vector<std::string> getAllQualityFeatureIDs();
-	static const char SpeedFeatureIDGroup[];
 
     private:
 	std::unordered_map<std::string, double> computeFeatureData(

--- a/NFIQ2/NFIQ2Algorithm/include/features/OFFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/OFFeature.h
@@ -26,7 +26,7 @@ class OFFeature : public BaseFeature {
 
 	std::string getModuleName() const override;
 
-	static std::vector<std::string> getAllQualityFeatureIDs();
+	static std::vector<std::string> getQualityFeatureIDs();
 
     private:
 	std::unordered_map<std::string, double> computeFeatureData(

--- a/NFIQ2/NFIQ2Algorithm/include/features/OFFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/OFFeature.h
@@ -26,7 +26,7 @@ class OFFeature : public BaseFeature {
 
 	std::string getModuleName() const override;
 
-	static std::vector<std::string> getAllFeatureIDs();
+	static std::vector<std::string> getAllQualityFeatureIDs();
 	static const char SpeedFeatureIDGroup[];
 
     private:

--- a/NFIQ2/NFIQ2Algorithm/include/features/QualityMapFeatures.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/QualityMapFeatures.h
@@ -25,7 +25,7 @@ class QualityMapFeatures : public BaseFeature {
 
 	std::string getModuleName() const override;
 
-	static std::vector<std::string> getAllQualityFeatureIDs();
+	static std::vector<std::string> getQualityFeatureIDs();
 
 	// compute orientation angle of a block
 	static bool getAngleOfBlock(

--- a/NFIQ2/NFIQ2Algorithm/include/features/QualityMapFeatures.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/QualityMapFeatures.h
@@ -26,7 +26,6 @@ class QualityMapFeatures : public BaseFeature {
 	std::string getModuleName() const override;
 
 	static std::vector<std::string> getAllQualityFeatureIDs();
-	static const char SpeedFeatureIDGroup[];
 
 	// compute orientation angle of a block
 	static bool getAngleOfBlock(

--- a/NFIQ2/NFIQ2Algorithm/include/features/QualityMapFeatures.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/QualityMapFeatures.h
@@ -25,7 +25,7 @@ class QualityMapFeatures : public BaseFeature {
 
 	std::string getModuleName() const override;
 
-	static std::vector<std::string> getAllFeatureIDs();
+	static std::vector<std::string> getAllQualityFeatureIDs();
 	static const char SpeedFeatureIDGroup[];
 
 	// compute orientation angle of a block

--- a/NFIQ2/NFIQ2Algorithm/include/features/RVUPHistogramFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/RVUPHistogramFeature.h
@@ -20,7 +20,7 @@ class RVUPHistogramFeature : public BaseFeature {
 
 	std::string getModuleName() const override;
 
-	static std::vector<std::string> getAllFeatureIDs();
+	static std::vector<std::string> getAllQualityFeatureIDs();
 	static const char SpeedFeatureIDGroup[];
 
     private:

--- a/NFIQ2/NFIQ2Algorithm/include/features/RVUPHistogramFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/RVUPHistogramFeature.h
@@ -20,7 +20,7 @@ class RVUPHistogramFeature : public BaseFeature {
 
 	std::string getModuleName() const override;
 
-	static std::vector<std::string> getAllQualityFeatureIDs();
+	static std::vector<std::string> getQualityFeatureIDs();
 
     private:
 	std::unordered_map<std::string, double> computeFeatureData(

--- a/NFIQ2/NFIQ2Algorithm/include/features/RVUPHistogramFeature.h
+++ b/NFIQ2/NFIQ2Algorithm/include/features/RVUPHistogramFeature.h
@@ -21,7 +21,6 @@ class RVUPHistogramFeature : public BaseFeature {
 	std::string getModuleName() const override;
 
 	static std::vector<std::string> getAllQualityFeatureIDs();
-	static const char SpeedFeatureIDGroup[];
 
     private:
 	std::unordered_map<std::string, double> computeFeatureData(

--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2_interfacedefinitions.hpp
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2_interfacedefinitions.hpp
@@ -342,19 +342,6 @@ extern const double FingerprintImageWithMinutiae;
 extern const double SufficientFingerprintForeground;
 } /* Thresholds::ActionableQualityFeedback */
 } /* Thresholds */
-
-/** This type represents a structure for timing information of features. */
-typedef struct feature_speed_t {
-	/** The name of the feature group. */
-	std::string featureIDGroup;
-	/**
-	 * The unique IDs of the features that are used for determining the
-	 * speed.
-	 */
-	std::vector<std::string> featureIDs;
-	/** The speed of feature data computation in milliseconds. */
-	double featureSpeed;
-} QualityFeatureSpeed;
-} // namespace NFIQ
+} /* NFIQ2 */
 
 #endif /* NFIQ2_INTERFACEDEFINITIONS_HPP_ */

--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2_qualityfeatures.hpp
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2_qualityfeatures.hpp
@@ -43,15 +43,6 @@ std::vector<std::string> getAllQualityFeatureIDs();
 
 /**
  * @brief
- * Obtain all speed feature groups from quality modules.
- *
- * @return
- * Vector of strings containing all speed feature groups.
- */
-std::vector<std::string> getAllSpeedFeatureGroups();
-
-/**
- * @brief
  * Obtain computed quality feature data from a fingerprint image.
  *
  * @param rawImage

--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2_qualityfeatures.hpp
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2_qualityfeatures.hpp
@@ -91,7 +91,7 @@ std::unordered_map<std::string, double> getActionableQualityFeedback(
  * @return
  * A map of string, quality feature data pairs.
  */
-std::unordered_map<std::string, double> getQualityFeatureData(
+std::unordered_map<std::string, double> getQualityFeatureValues(
     const std::vector<std::shared_ptr<NFIQ2::QualityFeatures::BaseFeature>>
 	&features);
 
@@ -105,7 +105,7 @@ std::unordered_map<std::string, double> getQualityFeatureData(
  * @return
  * A map of string, quality feature data pairs.
  */
-std::unordered_map<std::string, double> getQualityFeatureData(
+std::unordered_map<std::string, double> getQualityFeatureValues(
     const NFIQ2::FingerprintImageData &rawImage);
 
 /**

--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2_qualityfeatures.hpp
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2_qualityfeatures.hpp
@@ -21,7 +21,7 @@ class BaseFeature;
  * Vector of strings containing all actionable quality feedback
  * identifiers.
  */
-std::vector<std::string> getAllActionableIdentifiers();
+std::vector<std::string> getAllActionableQualityFeedbackIDs();
 
 /**
  * @briefq

--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2_qualityfeatures.hpp
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2_qualityfeatures.hpp
@@ -127,8 +127,7 @@ std::unordered_map<std::string, double> getQualityFeatureData(
  * @return
  * A map of string, quality feature speed pairs.
  */
-std::unordered_map<std::string, NFIQ2::QualityFeatureSpeed>
-getQualityFeatureSpeeds(
+std::unordered_map<std::string, double> getQualityFeatureSpeeds(
     const std::vector<std::shared_ptr<NFIQ2::QualityFeatures::BaseFeature>>
 	&features);
 

--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2_qualityfeatures.hpp
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2_qualityfeatures.hpp
@@ -116,9 +116,9 @@ std::unordered_map<std::string, double> getQualityFeatureData(
  * A vector of BaseFeatures obtained from a raw fingerprint image.
  *
  * @return
- * A map of string, quality feature speed pairs.
+ * A map of Identifier::QualityModule, speed pairs.
  */
-std::unordered_map<std::string, double> getQualityFeatureSpeeds(
+std::unordered_map<std::string, double> getQualityModuleSpeeds(
     const std::vector<std::shared_ptr<NFIQ2::QualityFeatures::BaseFeature>>
 	&features);
 

--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2_qualityfeatures.hpp
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2_qualityfeatures.hpp
@@ -24,6 +24,15 @@ class BaseFeature;
 std::vector<std::string> getAllActionableIdentifiers();
 
 /**
+ * @briefq
+ * Obtain all quality module identifiers.
+ *
+ * @return
+ * Vector of strings with all identifiers from Identifiers::QualityModules.
+ */
+std::vector<std::string> getAllQualityModuleIDs();
+
+/**
  * @brief
  * Obtain all quality feature IDs from quality modules.
  *

--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2_qualityfeatures.hpp
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2_qualityfeatures.hpp
@@ -39,7 +39,7 @@ std::vector<std::string> getAllQualityModuleIDs();
  * @return
  * Vector of strings containing all quality feature IDs.
  */
-std::vector<std::string> getAllQualityFeatureIDs();
+std::vector<std::string> getQualityFeatureIDs();
 
 /**
  * @brief

--- a/NFIQ2/NFIQ2Algorithm/include/tool/nfiq2_ui_log.h
+++ b/NFIQ2/NFIQ2Algorithm/include/tool/nfiq2_ui_log.h
@@ -73,8 +73,7 @@ class Log {
 	    unsigned int score, const std::string &errmsg, const bool quantized,
 	    const bool resampled,
 	    const std::unordered_map<std::string, double> &features,
-	    const std::unordered_map<std::string, NFIQ2::QualityFeatureSpeed>
-		&speed,
+	    const std::unordered_map<std::string, double> &speed,
 	    const std::unordered_map<std::string, double> &actionable) const;
 
 	/**

--- a/NFIQ2/NFIQ2Algorithm/src/features/BaseFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/BaseFeature.cpp
@@ -7,7 +7,7 @@ NFIQ2::QualityFeatures::BaseFeature::BaseFeature() = default;
 
 NFIQ2::QualityFeatures::BaseFeature::~BaseFeature() = default;
 
-NFIQ2::QualityFeatureSpeed
+double
 NFIQ2::QualityFeatures::BaseFeature::getSpeed() const
 {
 	return this->speed;
@@ -20,8 +20,7 @@ NFIQ2::QualityFeatures::BaseFeature::getFeatures() const
 }
 
 void
-NFIQ2::QualityFeatures::BaseFeature::setSpeed(
-    const NFIQ2::QualityFeatureSpeed &featureSpeed)
+NFIQ2::QualityFeatures::BaseFeature::setSpeed(const double featureSpeed)
 {
 	this->speed = featureSpeed;
 }

--- a/NFIQ2/NFIQ2Algorithm/src/features/FDAFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FDAFeature.cpp
@@ -52,7 +52,7 @@ NFIQ2::QualityFeatures::FDAFeature::FDAFeature(
 NFIQ2::QualityFeatures::FDAFeature::~FDAFeature() = default;
 
 std::vector<std::string>
-NFIQ2::QualityFeatures::FDAFeature::getAllQualityFeatureIDs()
+NFIQ2::QualityFeatures::FDAFeature::getQualityFeatureIDs()
 {
 	return { Identifiers::QualityFeatures::FrequencyDomainAnalysis::
 		     Histogram::Bin0,

--- a/NFIQ2/NFIQ2Algorithm/src/features/FDAFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FDAFeature.cpp
@@ -8,7 +8,7 @@
 #include <sstream>
 
 const char NFIQ2::Identifiers::QualityModules::FrequencyDomainAnalysis[] {
-	"NFIQ2_FDA"
+	"FrequencyDomainAnalysis"
 };
 static const char NFIQ2FDAFeaturePrefix[] { "FDA_Bin10_" };
 const char NFIQ2::Identifiers::QualityFeatures::FrequencyDomainAnalysis::
@@ -77,10 +77,6 @@ NFIQ2::QualityFeatures::FDAFeature::getAllQualityFeatureIDs()
 		Identifiers::QualityFeatures::FrequencyDomainAnalysis::Mean,
 		Identifiers::QualityFeatures::FrequencyDomainAnalysis::StdDev };
 }
-
-const char NFIQ2::QualityFeatures::FDAFeature::SpeedFeatureIDGroup[] {
-	"Frequency domain"
-};
 
 std::string
 NFIQ2::QualityFeatures::FDAFeature::getModuleName() const

--- a/NFIQ2/NFIQ2Algorithm/src/features/FDAFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FDAFeature.cpp
@@ -111,7 +111,6 @@ NFIQ2::QualityFeatures::FDAFeature::computeFeatureData(
 	// ----------------------------
 
 	NFIQ2::Timer timer;
-	double time = 0.0;
 	try {
 		timer.start();
 
@@ -212,18 +211,7 @@ NFIQ2::QualityFeatures::FDAFeature::computeFeatureData(
 		addHistogramFeatures(featureDataList, NFIQ2FDAFeaturePrefix,
 		    histogramBins10, dataVector, 10);
 
-		time = timer.stop();
-
-		// Speed
-		NFIQ2::QualityFeatureSpeed speed;
-		speed.featureIDGroup = FDAFeature::SpeedFeatureIDGroup;
-
-		addHistogramFeatureNames(
-		    speed.featureIDs, NFIQ2FDAFeaturePrefix, 10);
-
-		speed.featureSpeed = time;
-		this->setSpeed(speed);
-
+		this->setSpeed(timer.stop());
 	} catch (const cv::Exception &e) {
 		std::stringstream ssErr;
 		ssErr << "Cannot compute Frequency Domain Analysis (FDA): "

--- a/NFIQ2/NFIQ2Algorithm/src/features/FDAFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FDAFeature.cpp
@@ -52,7 +52,7 @@ NFIQ2::QualityFeatures::FDAFeature::FDAFeature(
 NFIQ2::QualityFeatures::FDAFeature::~FDAFeature() = default;
 
 std::vector<std::string>
-NFIQ2::QualityFeatures::FDAFeature::getAllFeatureIDs()
+NFIQ2::QualityFeatures::FDAFeature::getAllQualityFeatureIDs()
 {
 	return { Identifiers::QualityFeatures::FrequencyDomainAnalysis::
 		     Histogram::Bin0,

--- a/NFIQ2/NFIQ2Algorithm/src/features/FJFXMinutiaeQualityFeatures.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FJFXMinutiaeQualityFeatures.cpp
@@ -139,7 +139,7 @@ NFIQ2::QualityFeatures::FJFXMinutiaeQualityFeature::getModuleName() const
 }
 
 std::vector<std::string>
-NFIQ2::QualityFeatures::FJFXMinutiaeQualityFeature::getAllQualityFeatureIDs()
+NFIQ2::QualityFeatures::FJFXMinutiaeQualityFeature::getQualityFeatureIDs()
 {
 	return { Identifiers::QualityFeatures::Minutiae::QualityMu2,
 		Identifiers::QualityFeatures::Minutiae::QualityOCL80 };

--- a/NFIQ2/NFIQ2Algorithm/src/features/FJFXMinutiaeQualityFeatures.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FJFXMinutiaeQualityFeatures.cpp
@@ -119,17 +119,7 @@ NFIQ2::QualityFeatures::FJFXMinutiaeQualityFeature::computeFeatureData(
 		    (double)this->minutiaData_.size();
 		featureDataList[fd_ocl.first] = fd_ocl.second;
 
-		// Speed
-		NFIQ2::QualityFeatureSpeed speed;
-		speed.featureIDGroup =
-		    FJFXMinutiaeQualityFeature::SpeedFeatureIDGroup;
-		speed.featureIDs.push_back(
-		    Identifiers::QualityFeatures::Minutiae::QualityMu2);
-		speed.featureIDs.push_back(
-		    Identifiers::QualityFeatures::Minutiae::QualityOCL80);
-		speed.featureSpeed = timer.stop();
-		this->setSpeed(speed);
-
+		this->setSpeed(timer.stop());
 	} catch (const cv::Exception &e) {
 		std::stringstream ssErr;
 		ssErr << "Cannot compute FJFX based minutiae quality features: "

--- a/NFIQ2/NFIQ2Algorithm/src/features/FJFXMinutiaeQualityFeatures.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FJFXMinutiaeQualityFeatures.cpp
@@ -144,7 +144,7 @@ NFIQ2::QualityFeatures::FJFXMinutiaeQualityFeature::getModuleName() const
 }
 
 std::vector<std::string>
-NFIQ2::QualityFeatures::FJFXMinutiaeQualityFeature::getAllFeatureIDs()
+NFIQ2::QualityFeatures::FJFXMinutiaeQualityFeature::getAllQualityFeatureIDs()
 {
 	return { Identifiers::QualityFeatures::Minutiae::QualityMu2,
 		Identifiers::QualityFeatures::Minutiae::QualityOCL80 };

--- a/NFIQ2/NFIQ2Algorithm/src/features/FJFXMinutiaeQualityFeatures.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FJFXMinutiaeQualityFeatures.cpp
@@ -6,7 +6,7 @@
 #include <sstream>
 
 const char NFIQ2::Identifiers::QualityModules::MinutiaeQuality[] {
-	"NFIQ2_FJFXPos_MinutiaeQuality"
+	"MinutiaeQuality"
 };
 const char NFIQ2::Identifiers::QualityFeatures::Minutiae::QualityMu2[] {
 	"FJFXPos_Mu_MinutiaeQuality_2"
@@ -25,11 +25,6 @@ NFIQ2::QualityFeatures::FJFXMinutiaeQualityFeature::FJFXMinutiaeQualityFeature(
 
 NFIQ2::QualityFeatures::FJFXMinutiaeQualityFeature::
     ~FJFXMinutiaeQualityFeature() = default;
-
-const char
-    NFIQ2::QualityFeatures::FJFXMinutiaeQualityFeature::SpeedFeatureIDGroup[] {
-	    "Minutiae quality"
-    };
 
 std::vector<NFIQ2::QualityFeatures::FingerJetFXFeature::Minutia>
 NFIQ2::QualityFeatures::FJFXMinutiaeQualityFeature::getMinutiaData() const

--- a/NFIQ2/NFIQ2Algorithm/src/features/FingerJetFXFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FingerJetFXFeature.cpp
@@ -208,15 +208,7 @@ NFIQ2::QualityFeatures::FingerJetFXFeature::computeFeatureData(
 		fd_min_cnt.second = 0; // no minutiae found
 		featureDataList[fd_min_cnt.first] = fd_min_cnt.second;
 
-		// Speed
-		NFIQ2::QualityFeatureSpeed speed;
-		speed.featureIDGroup = FingerJetFXFeature::SpeedFeatureIDGroup;
-		speed.featureIDs.push_back(
-		    Identifiers::QualityFeatures::Minutiae::Count);
-		speed.featureIDs.push_back(
-		    Identifiers::QualityFeatures::Minutiae::CountCOM);
-		speed.featureSpeed = timer.stop();
-		this->setSpeed(speed);
+		this->setSpeed(timer.stop());
 
 		return featureDataList;
 	}
@@ -256,14 +248,7 @@ NFIQ2::QualityFeatures::FingerJetFXFeature::computeFeatureData(
 	fd_min_cnt.second = minCnt;
 	featureDataList[fd_min_cnt.first] = fd_min_cnt.second;
 
-	NFIQ2::QualityFeatureSpeed speed;
-	speed.featureIDGroup = FingerJetFXFeature::SpeedFeatureIDGroup;
-	speed.featureIDs.push_back(
-	    Identifiers::QualityFeatures::Minutiae::Count);
-	speed.featureIDs.push_back(
-	    Identifiers::QualityFeatures::Minutiae::CountCOM);
-	speed.featureSpeed = timer.stop();
-	this->setSpeed(speed);
+	this->setSpeed(timer.stop());
 
 	return featureDataList;
 }

--- a/NFIQ2/NFIQ2Algorithm/src/features/FingerJetFXFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FingerJetFXFeature.cpp
@@ -8,7 +8,7 @@
 #include <tuple>
 
 const char NFIQ2::Identifiers::QualityModules::MinutiaeCount[] {
-	"NFIQ2_FingerJetFX"
+	"MinutiaeCount"
 };
 const char NFIQ2::Identifiers::QualityFeatures::Minutiae::Count[] {
 	"FingerJetFX_MinutiaeCount"
@@ -24,10 +24,6 @@ NFIQ2::QualityFeatures::FingerJetFXFeature::FingerJetFXFeature(
 }
 
 NFIQ2::QualityFeatures::FingerJetFXFeature::~FingerJetFXFeature() = default;
-
-const char NFIQ2::QualityFeatures::FingerJetFXFeature::SpeedFeatureIDGroup[] {
-	"Minutiae"
-};
 
 std::pair<unsigned int, unsigned int>
 NFIQ2::QualityFeatures::FingerJetFXFeature::centerOfMinutiaeMass(

--- a/NFIQ2/NFIQ2Algorithm/src/features/FingerJetFXFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FingerJetFXFeature.cpp
@@ -260,7 +260,7 @@ NFIQ2::QualityFeatures::FingerJetFXFeature::getModuleName() const
 }
 
 std::vector<std::string>
-NFIQ2::QualityFeatures::FingerJetFXFeature::getAllFeatureIDs()
+NFIQ2::QualityFeatures::FingerJetFXFeature::getAllQualityFeatureIDs()
 {
 	return { Identifiers::QualityFeatures::Minutiae::CountCOM,
 		Identifiers::QualityFeatures::Minutiae::Count };

--- a/NFIQ2/NFIQ2Algorithm/src/features/FingerJetFXFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FingerJetFXFeature.cpp
@@ -256,7 +256,7 @@ NFIQ2::QualityFeatures::FingerJetFXFeature::getModuleName() const
 }
 
 std::vector<std::string>
-NFIQ2::QualityFeatures::FingerJetFXFeature::getAllQualityFeatureIDs()
+NFIQ2::QualityFeatures::FingerJetFXFeature::getQualityFeatureIDs()
 {
 	return { Identifiers::QualityFeatures::Minutiae::CountCOM,
 		Identifiers::QualityFeatures::Minutiae::Count };

--- a/NFIQ2/NFIQ2Algorithm/src/features/ImgProcROIFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/ImgProcROIFeature.cpp
@@ -79,14 +79,7 @@ NFIQ2::QualityFeatures::ImgProcROIFeature::computeFeatureData(
 		featureDataList[fd_roi_pixel_area_mean.first] =
 		    fd_roi_pixel_area_mean.second;
 
-		// Speed
-		NFIQ2::QualityFeatureSpeed speed;
-		speed.featureIDGroup = ImgProcROIFeature::SpeedFeatureIDGroup;
-		speed.featureIDs.push_back(
-		    Identifiers::QualityFeatures::RegionOfInterest::Mean);
-		speed.featureSpeed = timer.stop();
-		this->setSpeed(speed);
-
+		this->setSpeed(timer.stop());
 	} catch (const cv::Exception &e) {
 		std::stringstream ssErr;
 		ssErr << "Cannot compute feature (ImgProc)ROI area: "

--- a/NFIQ2/NFIQ2Algorithm/src/features/ImgProcROIFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/ImgProcROIFeature.cpp
@@ -102,7 +102,7 @@ NFIQ2::QualityFeatures::ImgProcROIFeature::getModuleName() const
 }
 
 std::vector<std::string>
-NFIQ2::QualityFeatures::ImgProcROIFeature::getAllQualityFeatureIDs()
+NFIQ2::QualityFeatures::ImgProcROIFeature::getQualityFeatureIDs()
 {
 	return { Identifiers::QualityFeatures::RegionOfInterest::Mean };
 }

--- a/NFIQ2/NFIQ2Algorithm/src/features/ImgProcROIFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/ImgProcROIFeature.cpp
@@ -106,7 +106,7 @@ NFIQ2::QualityFeatures::ImgProcROIFeature::getModuleName() const
 }
 
 std::vector<std::string>
-NFIQ2::QualityFeatures::ImgProcROIFeature::getAllFeatureIDs()
+NFIQ2::QualityFeatures::ImgProcROIFeature::getAllQualityFeatureIDs()
 {
 	return { Identifiers::QualityFeatures::RegionOfInterest::Mean };
 }

--- a/NFIQ2/NFIQ2Algorithm/src/features/ImgProcROIFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/ImgProcROIFeature.cpp
@@ -6,7 +6,7 @@
 #include <sstream>
 
 const char NFIQ2::Identifiers::QualityModules::RegionOfInterestMean[] {
-	"NFIQ2_ImgProcROI"
+	"RegionOfInterestMean"
 };
 const char NFIQ2::Identifiers::QualityFeatures::RegionOfInterest::Mean[] {
 	"ImgProcROIArea_Mean"
@@ -19,10 +19,6 @@ NFIQ2::QualityFeatures::ImgProcROIFeature::ImgProcROIFeature(
 }
 
 NFIQ2::QualityFeatures::ImgProcROIFeature::~ImgProcROIFeature() = default;
-
-const char NFIQ2::QualityFeatures::ImgProcROIFeature::SpeedFeatureIDGroup[] {
-	"Region of interest"
-};
 
 NFIQ2::QualityFeatures::ImgProcROIFeature::ImgProcROIResults
 NFIQ2::QualityFeatures::ImgProcROIFeature::getImgProcResults()

--- a/NFIQ2/NFIQ2Algorithm/src/features/LCSFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/LCSFeature.cpp
@@ -6,7 +6,9 @@
 
 #include <sstream>
 
-const char NFIQ2::Identifiers::QualityModules::LocalClarity[] { "NFIQ2_LCS" };
+const char NFIQ2::Identifiers::QualityModules::LocalClarity[] {
+	"LocalClarity"
+};
 static const char NFIQ2LCSFeaturePrefix[] { "LCS_Bin10_" };
 const char
     NFIQ2::Identifiers::QualityFeatures::LocalClarity::Histogram::Bin0[] {
@@ -88,10 +90,6 @@ NFIQ2::QualityFeatures::LCSFeature::getAllQualityFeatureIDs()
 		Identifiers::QualityFeatures::LocalClarity::Mean,
 		Identifiers::QualityFeatures::LocalClarity::StdDev };
 }
-
-const char NFIQ2::QualityFeatures::LCSFeature::SpeedFeatureIDGroup[] {
-	"Local clarity"
-};
 
 std::unordered_map<std::string, double>
 NFIQ2::QualityFeatures::LCSFeature::computeFeatureData(

--- a/NFIQ2/NFIQ2Algorithm/src/features/LCSFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/LCSFeature.cpp
@@ -121,7 +121,6 @@ NFIQ2::QualityFeatures::LCSFeature::computeFeatureData(
 	}
 
 	NFIQ2::Timer timerLCS;
-	double timeLCS = 0.0;
 	try {
 		timerLCS.start();
 
@@ -215,8 +214,6 @@ NFIQ2::QualityFeatures::LCSFeature::computeFeatureData(
 			bc = 0;
 		}
 
-		timeLCS = timerLCS.stop();
-
 		std::vector<double> histogramBins10;
 		histogramBins10.push_back(LCSHISTLIMITS[0]);
 		histogramBins10.push_back(LCSHISTLIMITS[1]);
@@ -230,16 +227,7 @@ NFIQ2::QualityFeatures::LCSFeature::computeFeatureData(
 		addHistogramFeatures(featureDataList, NFIQ2LCSFeaturePrefix,
 		    histogramBins10, dataVector, 10);
 
-		// Speed
-		NFIQ2::QualityFeatureSpeed speed;
-		speed.featureIDGroup = LCSFeature::SpeedFeatureIDGroup;
-
-		addHistogramFeatureNames(
-		    speed.featureIDs, NFIQ2LCSFeaturePrefix, 10);
-
-		speed.featureSpeed = timeLCS;
-		this->setSpeed(speed);
-
+		this->setSpeed(timerLCS.stop());
 	} catch (const cv::Exception &e) {
 		std::stringstream ssErr;
 		ssErr << "Cannot compute LCS: " << e.what();

--- a/NFIQ2/NFIQ2Algorithm/src/features/LCSFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/LCSFeature.cpp
@@ -73,7 +73,7 @@ NFIQ2::QualityFeatures::LCSFeature::getModuleName() const
 }
 
 std::vector<std::string>
-NFIQ2::QualityFeatures::LCSFeature::getAllFeatureIDs()
+NFIQ2::QualityFeatures::LCSFeature::getAllQualityFeatureIDs()
 {
 	return { Identifiers::QualityFeatures::LocalClarity::Histogram::Bin0,
 		Identifiers::QualityFeatures::LocalClarity::Histogram::Bin1,

--- a/NFIQ2/NFIQ2Algorithm/src/features/LCSFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/LCSFeature.cpp
@@ -75,7 +75,7 @@ NFIQ2::QualityFeatures::LCSFeature::getModuleName() const
 }
 
 std::vector<std::string>
-NFIQ2::QualityFeatures::LCSFeature::getAllQualityFeatureIDs()
+NFIQ2::QualityFeatures::LCSFeature::getQualityFeatureIDs()
 {
 	return { Identifiers::QualityFeatures::LocalClarity::Histogram::Bin0,
 		Identifiers::QualityFeatures::LocalClarity::Histogram::Bin1,

--- a/NFIQ2/NFIQ2Algorithm/src/features/MuFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/MuFeature.cpp
@@ -5,7 +5,7 @@
 
 #include <sstream>
 
-const char NFIQ2::Identifiers::QualityModules::Contrast[] { "NFIQ2_Mu" };
+const char NFIQ2::Identifiers::QualityModules::Contrast[] { "Contrast" };
 const char NFIQ2::Identifiers::QualityFeatures::Contrast::Mean[] { "Mu" };
 const char NFIQ2::Identifiers::QualityFeatures::Contrast::MeanBlock[] { "MMB" };
 
@@ -16,10 +16,6 @@ NFIQ2::QualityFeatures::MuFeature::MuFeature(
 }
 
 NFIQ2::QualityFeatures::MuFeature::~MuFeature() = default;
-
-const char NFIQ2::QualityFeatures::MuFeature::SpeedFeatureIDGroup[] {
-	"Contrast"
-};
 
 std::unordered_map<std::string, double>
 NFIQ2::QualityFeatures::MuFeature::computeFeatureData(

--- a/NFIQ2/NFIQ2Algorithm/src/features/MuFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/MuFeature.cpp
@@ -142,15 +142,7 @@ NFIQ2::QualityFeatures::MuFeature::computeFeatureData(
 		    "Unknown exception occurred!");
 	}
 
-	// Speed
-	NFIQ2::QualityFeatureSpeed speed;
-	speed.featureIDGroup = MuFeature::SpeedFeatureIDGroup;
-	speed.featureIDs.push_back(
-	    Identifiers::QualityFeatures::Contrast::MeanBlock);
-	speed.featureIDs.push_back(
-	    Identifiers::QualityFeatures::Contrast::Mean);
-	speed.featureSpeed = timer.stop();
-	this->setSpeed(speed);
+	this->setSpeed(timer.stop());
 
 	return featureDataList;
 }

--- a/NFIQ2/NFIQ2Algorithm/src/features/MuFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/MuFeature.cpp
@@ -160,7 +160,7 @@ NFIQ2::QualityFeatures::MuFeature::getModuleName() const
 }
 
 std::vector<std::string>
-NFIQ2::QualityFeatures::MuFeature::getAllQualityFeatureIDs()
+NFIQ2::QualityFeatures::MuFeature::getQualityFeatureIDs()
 {
 	std::vector<std::string> featureIDs;
 	featureIDs.push_back(Identifiers::QualityFeatures::Contrast::MeanBlock);

--- a/NFIQ2/NFIQ2Algorithm/src/features/MuFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/MuFeature.cpp
@@ -164,7 +164,7 @@ NFIQ2::QualityFeatures::MuFeature::getModuleName() const
 }
 
 std::vector<std::string>
-NFIQ2::QualityFeatures::MuFeature::getAllFeatureIDs()
+NFIQ2::QualityFeatures::MuFeature::getAllQualityFeatureIDs()
 {
 	std::vector<std::string> featureIDs;
 	featureIDs.push_back(Identifiers::QualityFeatures::Contrast::MeanBlock);

--- a/NFIQ2/NFIQ2Algorithm/src/features/OCLHistogramFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/OCLHistogramFeature.cpp
@@ -78,7 +78,6 @@ NFIQ2::QualityFeatures::OCLHistogramFeature::computeFeatureData(
 
 	// compute OCL
 	NFIQ2::Timer timerOCL;
-	double timeOCL = 0.0;
 	std::vector<double> oclres;
 	try {
 		timerOCL.start();
@@ -129,18 +128,7 @@ NFIQ2::QualityFeatures::OCLHistogramFeature::computeFeatureData(
 		addHistogramFeatures(featureDataList, NFIQ2OCLFeaturePrefix,
 		    histogramBins10, oclres, 10);
 
-		timeOCL = timerOCL.stop();
-
-		// Speed
-		NFIQ2::QualityFeatureSpeed speed;
-		speed.featureIDGroup = OCLHistogramFeature::SpeedFeatureIDGroup;
-
-		addHistogramFeatureNames(
-		    speed.featureIDs, NFIQ2OCLFeaturePrefix, 10);
-
-		speed.featureSpeed = timeOCL;
-		this->setSpeed(speed);
-
+		this->setSpeed(timerOCL.stop());
 	} catch (const cv::Exception &e) {
 		std::stringstream ssErr;
 		ssErr << "Cannot compute feature OCL histogram: " << e.what();

--- a/NFIQ2/NFIQ2Algorithm/src/features/OCLHistogramFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/OCLHistogramFeature.cpp
@@ -195,7 +195,7 @@ NFIQ2::QualityFeatures::OCLHistogramFeature::getModuleName() const
 }
 
 std::vector<std::string>
-NFIQ2::QualityFeatures::OCLHistogramFeature::getAllFeatureIDs()
+NFIQ2::QualityFeatures::OCLHistogramFeature::getAllQualityFeatureIDs()
 {
 	return { Identifiers::QualityFeatures::OrientationCertainty::Histogram::
 		     Bin0,

--- a/NFIQ2/NFIQ2Algorithm/src/features/OCLHistogramFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/OCLHistogramFeature.cpp
@@ -6,7 +6,7 @@
 #include <sstream>
 
 const char NFIQ2::Identifiers::QualityModules::OrientationCertainty[] {
-	"NFIQ2_OCLHistogram"
+	"OrientationCertainty"
 };
 static const char NFIQ2OCLFeaturePrefix[] { "OCL_Bin10_" };
 const char NFIQ2::Identifiers::QualityFeatures::OrientationCertainty::
@@ -43,10 +43,6 @@ NFIQ2::QualityFeatures::OCLHistogramFeature::OCLHistogramFeature(
 }
 
 NFIQ2::QualityFeatures::OCLHistogramFeature::~OCLHistogramFeature() = default;
-
-const char NFIQ2::QualityFeatures::OCLHistogramFeature::SpeedFeatureIDGroup[] {
-	"Orientation certainty"
-};
 
 std::unordered_map<std::string, double>
 NFIQ2::QualityFeatures::OCLHistogramFeature::computeFeatureData(

--- a/NFIQ2/NFIQ2Algorithm/src/features/OCLHistogramFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/OCLHistogramFeature.cpp
@@ -191,7 +191,7 @@ NFIQ2::QualityFeatures::OCLHistogramFeature::getModuleName() const
 }
 
 std::vector<std::string>
-NFIQ2::QualityFeatures::OCLHistogramFeature::getAllQualityFeatureIDs()
+NFIQ2::QualityFeatures::OCLHistogramFeature::getQualityFeatureIDs()
 {
 	return { Identifiers::QualityFeatures::OrientationCertainty::Histogram::
 		     Bin0,

--- a/NFIQ2/NFIQ2Algorithm/src/features/OFFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/OFFeature.cpp
@@ -8,7 +8,9 @@
 #include <cmath>
 #include <sstream>
 
-const char NFIQ2::Identifiers::QualityModules::OrientationFlow[] { "NFIQ2_OF" };
+const char NFIQ2::Identifiers::QualityModules::OrientationFlow[] {
+	"OrientationFlow"
+};
 static const char NFIQ2OFFeaturePrefix[] { "OF_Bin10_" };
 const char
     NFIQ2::Identifiers::QualityFeatures::OrientationFlow::Histogram::Bin0[] {
@@ -87,10 +89,6 @@ NFIQ2::QualityFeatures::OFFeature::getAllQualityFeatureIDs()
 		Identifiers::QualityFeatures::OrientationFlow::Mean,
 		Identifiers::QualityFeatures::OrientationFlow::StdDev };
 }
-
-const char NFIQ2::QualityFeatures::OFFeature::SpeedFeatureIDGroup[] {
-	"Orientation flow"
-};
 
 std::unordered_map<std::string, double>
 NFIQ2::QualityFeatures::OFFeature::computeFeatureData(

--- a/NFIQ2/NFIQ2Algorithm/src/features/OFFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/OFFeature.cpp
@@ -72,7 +72,7 @@ NFIQ2::QualityFeatures::OFFeature::getModuleName() const
 }
 
 std::vector<std::string>
-NFIQ2::QualityFeatures::OFFeature::getAllFeatureIDs()
+NFIQ2::QualityFeatures::OFFeature::getAllQualityFeatureIDs()
 {
 	return { Identifiers::QualityFeatures::OrientationFlow::Histogram::Bin0,
 		Identifiers::QualityFeatures::OrientationFlow::Histogram::Bin1,

--- a/NFIQ2/NFIQ2Algorithm/src/features/OFFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/OFFeature.cpp
@@ -74,7 +74,7 @@ NFIQ2::QualityFeatures::OFFeature::getModuleName() const
 }
 
 std::vector<std::string>
-NFIQ2::QualityFeatures::OFFeature::getAllQualityFeatureIDs()
+NFIQ2::QualityFeatures::OFFeature::getQualityFeatureIDs()
 {
 	return { Identifiers::QualityFeatures::OrientationFlow::Histogram::Bin0,
 		Identifiers::QualityFeatures::OrientationFlow::Histogram::Bin1,

--- a/NFIQ2/NFIQ2Algorithm/src/features/OFFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/OFFeature.cpp
@@ -120,7 +120,6 @@ NFIQ2::QualityFeatures::OFFeature::computeFeatureData(
 	}
 
 	NFIQ2::Timer timerOF;
-	double timeOF = 0.0;
 	try {
 		timerOF.start();
 
@@ -302,18 +301,7 @@ NFIQ2::QualityFeatures::OFFeature::computeFeatureData(
 		addHistogramFeatures(featureDataList, NFIQ2OFFeaturePrefix,
 		    histogramBins10, dataVector, 10);
 
-		timeOF = timerOF.stop();
-
-		// Speed
-		NFIQ2::QualityFeatureSpeed speed;
-		speed.featureIDGroup = OFFeature::SpeedFeatureIDGroup;
-
-		addHistogramFeatureNames(
-		    speed.featureIDs, NFIQ2OFFeaturePrefix, 10);
-
-		speed.featureSpeed = timeOF;
-		this->setSpeed(speed);
-
+		this->setSpeed(timerOF.stop());
 	} catch (const cv::Exception &e) {
 		std::stringstream ssErr;
 		ssErr << "Cannot compute Orientation Flow (OF): " << e.what();

--- a/NFIQ2/NFIQ2Algorithm/src/features/QualityMapFeatures.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/QualityMapFeatures.cpp
@@ -318,7 +318,7 @@ NFIQ2::QualityFeatures::QualityMapFeatures::getModuleName() const
 }
 
 std::vector<std::string>
-NFIQ2::QualityFeatures::QualityMapFeatures::getAllFeatureIDs()
+NFIQ2::QualityFeatures::QualityMapFeatures::getAllQualityFeatureIDs()
 {
 	return { Identifiers::QualityFeatures::RegionOfInterest::CoherenceMean,
 		Identifiers::QualityFeatures::RegionOfInterest::CoherenceSum };

--- a/NFIQ2/NFIQ2Algorithm/src/features/QualityMapFeatures.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/QualityMapFeatures.cpp
@@ -90,15 +90,7 @@ NFIQ2::QualityFeatures::QualityMapFeatures::computeFeatureData(
 
 		featureDataList[fd_om_1.first] = fd_om_1.second;
 
-		NFIQ2::QualityFeatureSpeed speed;
-		speed.featureIDGroup = QualityMapFeatures::SpeedFeatureIDGroup;
-		speed.featureIDs.push_back(Identifiers::QualityFeatures::
-			RegionOfInterest::CoherenceSum);
-		speed.featureIDs.push_back(Identifiers::QualityFeatures::
-			RegionOfInterest::CoherenceMean);
-		speed.featureSpeed = timer.stop();
-		this->setSpeed(speed);
-
+		this->setSpeed(timer.stop());
 	} catch (const cv::Exception &e) {
 		std::stringstream ssErr;
 		ssErr << "Cannot compute orientation map: " << e.what();

--- a/NFIQ2/NFIQ2Algorithm/src/features/QualityMapFeatures.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/QualityMapFeatures.cpp
@@ -7,7 +7,7 @@
 #include <sstream>
 
 const char NFIQ2::Identifiers::QualityModules::RegionOfInterestCoherence[] {
-	"NFIQ2_QualityMap"
+	"RegionOfInterestCoherence"
 };
 const char
     NFIQ2::Identifiers::QualityFeatures::RegionOfInterest::CoherenceSum[] {
@@ -27,10 +27,6 @@ NFIQ2::QualityFeatures::QualityMapFeatures::QualityMapFeatures(
 }
 
 NFIQ2::QualityFeatures::QualityMapFeatures::~QualityMapFeatures() = default;
-
-const char NFIQ2::QualityFeatures::QualityMapFeatures::SpeedFeatureIDGroup[] {
-	"Quality map"
-};
 
 std::unordered_map<std::string, double>
 NFIQ2::QualityFeatures::QualityMapFeatures::computeFeatureData(

--- a/NFIQ2/NFIQ2Algorithm/src/features/QualityMapFeatures.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/QualityMapFeatures.cpp
@@ -314,7 +314,7 @@ NFIQ2::QualityFeatures::QualityMapFeatures::getModuleName() const
 }
 
 std::vector<std::string>
-NFIQ2::QualityFeatures::QualityMapFeatures::getAllQualityFeatureIDs()
+NFIQ2::QualityFeatures::QualityMapFeatures::getQualityFeatureIDs()
 {
 	return { Identifiers::QualityFeatures::RegionOfInterest::CoherenceMean,
 		Identifiers::QualityFeatures::RegionOfInterest::CoherenceSum };

--- a/NFIQ2/NFIQ2Algorithm/src/features/RVUPHistogramFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/RVUPHistogramFeature.cpp
@@ -8,7 +8,7 @@
 #include <sstream>
 
 const char NFIQ2::Identifiers::QualityModules::RidgeValleyUniformity[] {
-	"NFIQ2_RVUPHistogram"
+	"RidgeValleyUniformity"
 };
 const char NFIQ2RVUPFeaturePrefix[] { "RVUP_Bin10_" };
 const char NFIQ2::Identifiers::QualityFeatures::RidgeValleyUniformity::
@@ -50,10 +50,6 @@ NFIQ2::QualityFeatures::RVUPHistogramFeature::RVUPHistogramFeature(
 }
 
 NFIQ2::QualityFeatures::RVUPHistogramFeature::~RVUPHistogramFeature() = default;
-
-const char NFIQ2::QualityFeatures::RVUPHistogramFeature::SpeedFeatureIDGroup[] {
-	"Ridge valley uniformity"
-};
 
 std::unordered_map<std::string, double>
 NFIQ2::QualityFeatures::RVUPHistogramFeature::computeFeatureData(

--- a/NFIQ2/NFIQ2Algorithm/src/features/RVUPHistogramFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/RVUPHistogramFeature.cpp
@@ -209,7 +209,7 @@ NFIQ2::QualityFeatures::RVUPHistogramFeature::getModuleName() const
 }
 
 std::vector<std::string>
-NFIQ2::QualityFeatures::RVUPHistogramFeature::getAllFeatureIDs()
+NFIQ2::QualityFeatures::RVUPHistogramFeature::getAllQualityFeatureIDs()
 {
 	return { Identifiers::QualityFeatures::RidgeValleyUniformity::
 		     Histogram::Bin0,

--- a/NFIQ2/NFIQ2Algorithm/src/features/RVUPHistogramFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/RVUPHistogramFeature.cpp
@@ -205,7 +205,7 @@ NFIQ2::QualityFeatures::RVUPHistogramFeature::getModuleName() const
 }
 
 std::vector<std::string>
-NFIQ2::QualityFeatures::RVUPHistogramFeature::getAllQualityFeatureIDs()
+NFIQ2::QualityFeatures::RVUPHistogramFeature::getQualityFeatureIDs()
 {
 	return { Identifiers::QualityFeatures::RidgeValleyUniformity::
 		     Histogram::Bin0,

--- a/NFIQ2/NFIQ2Algorithm/src/features/RVUPHistogramFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/RVUPHistogramFeature.cpp
@@ -87,7 +87,6 @@ NFIQ2::QualityFeatures::RVUPHistogramFeature::computeFeatureData(
 	// ----------
 
 	NFIQ2::Timer timerRVU;
-	double timeRVU = 0.0;
 	try {
 		timerRVU.start();
 
@@ -187,18 +186,7 @@ NFIQ2::QualityFeatures::RVUPHistogramFeature::computeFeatureData(
 		addHistogramFeatures(featureDataList, NFIQ2RVUPFeaturePrefix,
 		    histogramBins10, rvures, 10);
 
-		timeRVU = timerRVU.stop();
-
-		NFIQ2::QualityFeatureSpeed speed;
-		speed.featureIDGroup =
-		    RVUPHistogramFeature::SpeedFeatureIDGroup;
-
-		addHistogramFeatureNames(
-		    speed.featureIDs, NFIQ2RVUPFeaturePrefix, 10);
-
-		speed.featureSpeed = timeRVU;
-		this->setSpeed(speed);
-
+		this->setSpeed(timerRVU.stop());
 	} catch (const cv::Exception &e) {
 		std::stringstream ssErr;
 		ssErr << "Cannot compute RVU: " << e.what();

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_algorithm_impl.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_algorithm_impl.cpp
@@ -76,7 +76,7 @@ NFIQ2::Algorithm::Impl::computeQualityScore(
 	this->throwIfUninitialized();
 
 	const std::unordered_map<std::string, double> quality =
-	    NFIQ2::QualityFeatures::getQualityFeatureData(features);
+	    NFIQ2::QualityFeatures::getQualityFeatureValues(features);
 
 	if (quality.size() == 0) {
 		// no features have been computed
@@ -126,7 +126,7 @@ NFIQ2::Algorithm::Impl::computeQualityScore(
 	}
 
 	const std::unordered_map<std::string, double> quality =
-	    NFIQ2::QualityFeatures::getQualityFeatureData(features);
+	    NFIQ2::QualityFeatures::getQualityFeatureValues(features);
 
 	if (quality.size() == 0) {
 		// no features have been computed

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures.cpp
@@ -63,9 +63,9 @@ NFIQ2::QualityFeatures::getQualityFeatureData(
 }
 
 std::unordered_map<std::string, double>
-NFIQ2::QualityFeatures::getQualityFeatureSpeeds(
+NFIQ2::QualityFeatures::getQualityModuleSpeeds(
     const std::vector<std::shared_ptr<NFIQ2::QualityFeatures::BaseFeature>>
 	&features)
 {
-	return NFIQ2::QualityFeatures::Impl::getQualityFeatureSpeeds(features);
+	return NFIQ2::QualityFeatures::Impl::getQualityModuleSpeeds(features);
 }

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures.cpp
@@ -23,12 +23,6 @@ NFIQ2::QualityFeatures::getAllQualityModuleIDs()
 	return NFIQ2::QualityFeatures::Impl::getAllQualityModuleIDs();
 }
 
-std::vector<std::string>
-NFIQ2::QualityFeatures::getAllSpeedFeatureGroups()
-{
-	return NFIQ2::QualityFeatures::Impl::getAllSpeedFeatureGroups();
-}
-
 std::vector<std::shared_ptr<NFIQ2::QualityFeatures::BaseFeature>>
 NFIQ2::QualityFeatures::computeQualityFeatures(
     const NFIQ2::FingerprintImageData &rawImage)

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures.cpp
@@ -68,7 +68,7 @@ NFIQ2::QualityFeatures::getQualityFeatureData(
 	return NFIQ2::QualityFeatures::Impl::getQualityFeatureData(rawImage);
 }
 
-std::unordered_map<std::string, NFIQ2::QualityFeatureSpeed>
+std::unordered_map<std::string, double>
 NFIQ2::QualityFeatures::getQualityFeatureSpeeds(
     const std::vector<std::shared_ptr<NFIQ2::QualityFeatures::BaseFeature>>
 	&features)

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures.cpp
@@ -17,6 +17,12 @@ NFIQ2::QualityFeatures::getAllQualityFeatureIDs()
 }
 
 std::vector<std::string>
+NFIQ2::QualityFeatures::getAllQualityModuleIDs()
+{
+	return NFIQ2::QualityFeatures::Impl::getAllQualityModuleIDs();
+}
+
+std::vector<std::string>
 NFIQ2::QualityFeatures::getAllSpeedFeatureGroups()
 {
 	return NFIQ2::QualityFeatures::Impl::getAllSpeedFeatureGroups();
@@ -37,6 +43,7 @@ NFIQ2::QualityFeatures::getActionableQualityFeedback(
 	return NFIQ2::QualityFeatures::Impl::getActionableQualityFeedback(
 	    features);
 }
+
 std::unordered_map<std::string, double>
 NFIQ2::QualityFeatures::getActionableQualityFeedback(
     const NFIQ2::FingerprintImageData &rawImage)

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures.cpp
@@ -12,9 +12,9 @@ NFIQ2::QualityFeatures::getAllActionableQualityFeedbackIDs()
 }
 
 std::vector<std::string>
-NFIQ2::QualityFeatures::getAllQualityFeatureIDs()
+NFIQ2::QualityFeatures::getQualityFeatureIDs()
 {
-	return NFIQ2::QualityFeatures::Impl::getAllQualityFeatureIDs();
+	return NFIQ2::QualityFeatures::Impl::getQualityFeatureIDs();
 }
 
 std::vector<std::string>

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures.cpp
@@ -5,9 +5,10 @@
 #include <vector>
 
 std::vector<std::string>
-NFIQ2::QualityFeatures::getAllActionableIdentifiers()
+NFIQ2::QualityFeatures::getAllActionableQualityFeedbackIDs()
 {
-	return NFIQ2::QualityFeatures::Impl::getAllActionableIdentifiers();
+	return NFIQ2::QualityFeatures::Impl::
+	    getAllActionableQualityFeedbackIDs();
 }
 
 std::vector<std::string>

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures.cpp
@@ -48,18 +48,18 @@ NFIQ2::QualityFeatures::getActionableQualityFeedback(
 }
 
 std::unordered_map<std::string, double>
-NFIQ2::QualityFeatures::getQualityFeatureData(
+NFIQ2::QualityFeatures::getQualityFeatureValues(
     const std::vector<std::shared_ptr<NFIQ2::QualityFeatures::BaseFeature>>
 	&features)
 {
-	return NFIQ2::QualityFeatures::Impl::getQualityFeatureData(features);
+	return NFIQ2::QualityFeatures::Impl::getQualityFeatureValues(features);
 }
 
 std::unordered_map<std::string, double>
-NFIQ2::QualityFeatures::getQualityFeatureData(
+NFIQ2::QualityFeatures::getQualityFeatureValues(
     const NFIQ2::FingerprintImageData &rawImage)
 {
-	return NFIQ2::QualityFeatures::Impl::getQualityFeatureData(rawImage);
+	return NFIQ2::QualityFeatures::Impl::getQualityFeatureValues(rawImage);
 }
 
 std::unordered_map<std::string, double>

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures_impl.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures_impl.cpp
@@ -42,7 +42,7 @@ const double
 const double NFIQ2::Thresholds::ActionableQualityFeedback::
     SufficientFingerprintForeground { 50000.0 };
 
-std::unordered_map<std::string, NFIQ2::QualityFeatureSpeed>
+std::unordered_map<std::string, double>
 NFIQ2::QualityFeatures::Impl::getQualityFeatureSpeeds(
     const std::vector<std::shared_ptr<NFIQ2::QualityFeatures::BaseFeature>>
 	&features)
@@ -50,7 +50,7 @@ NFIQ2::QualityFeatures::Impl::getQualityFeatureSpeeds(
 	std::vector<std::string> speedIdentifiers =
 	    NFIQ2::QualityFeatures::getAllSpeedFeatureGroups();
 
-	std::unordered_map<std::string, NFIQ2::QualityFeatureSpeed> speedMap {};
+	std::unordered_map<std::string, double> speedMap {};
 
 	for (std::vector<std::string>::size_type i = 0;
 	     i < speedIdentifiers.size(); i++) {

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures_impl.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures_impl.cpp
@@ -48,7 +48,7 @@ NFIQ2::QualityFeatures::Impl::getQualityFeatureSpeeds(
 	&features)
 {
 	std::vector<std::string> speedIdentifiers =
-	    NFIQ2::QualityFeatures::getAllSpeedFeatureGroups();
+	    NFIQ2::QualityFeatures::getAllQualityModuleIDs();
 
 	std::unordered_map<std::string, double> speedMap {};
 
@@ -309,22 +309,4 @@ NFIQ2::QualityFeatures::Impl::getAllQualityModuleIDs()
 	};
 
 	return ids;
-}
-
-std::vector<std::string>
-NFIQ2::QualityFeatures::Impl::getAllSpeedFeatureGroups()
-{
-	static const std::vector<std::string> speedFeatureGroups {
-		FDAFeature::SpeedFeatureIDGroup,
-		FingerJetFXFeature::SpeedFeatureIDGroup,
-		FJFXMinutiaeQualityFeature::SpeedFeatureIDGroup,
-		ImgProcROIFeature::SpeedFeatureIDGroup,
-		LCSFeature::SpeedFeatureIDGroup, MuFeature::SpeedFeatureIDGroup,
-		OCLHistogramFeature::SpeedFeatureIDGroup,
-		OFFeature::SpeedFeatureIDGroup,
-		QualityMapFeatures::SpeedFeatureIDGroup,
-		RVUPHistogramFeature::SpeedFeatureIDGroup
-	};
-
-	return speedFeatureGroups;
 }

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures_impl.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures_impl.cpp
@@ -43,7 +43,7 @@ const double NFIQ2::Thresholds::ActionableQualityFeedback::
     SufficientFingerprintForeground { 50000.0 };
 
 std::unordered_map<std::string, double>
-NFIQ2::QualityFeatures::Impl::getQualityFeatureSpeeds(
+NFIQ2::QualityFeatures::Impl::getQualityModuleSpeeds(
     const std::vector<std::shared_ptr<NFIQ2::QualityFeatures::BaseFeature>>
 	&features)
 {

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures_impl.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures_impl.cpp
@@ -74,7 +74,7 @@ NFIQ2::QualityFeatures::Impl::getQualityFeatureValues(
 	&features)
 {
 	std::vector<std::string> qualityIdentifiers =
-	    NFIQ2::QualityFeatures::Impl::getAllQualityFeatureIDs();
+	    NFIQ2::QualityFeatures::Impl::getQualityFeatureIDs();
 
 	std::unordered_map<std::string, double> quality {};
 
@@ -267,19 +267,19 @@ NFIQ2::QualityFeatures::Impl::getAllActionableQualityFeedbackIDs()
 }
 
 std::vector<std::string>
-NFIQ2::QualityFeatures::Impl::getAllQualityFeatureIDs()
+NFIQ2::QualityFeatures::Impl::getQualityFeatureIDs()
 {
 	const std::vector<std::vector<std::string>> vov {
-		FDAFeature::getAllQualityFeatureIDs(),
-		FingerJetFXFeature::getAllQualityFeatureIDs(),
-		FJFXMinutiaeQualityFeature::getAllQualityFeatureIDs(),
-		ImgProcROIFeature::getAllQualityFeatureIDs(),
-		LCSFeature::getAllQualityFeatureIDs(),
-		MuFeature::getAllQualityFeatureIDs(),
-		OCLHistogramFeature::getAllQualityFeatureIDs(),
-		OFFeature::getAllQualityFeatureIDs(),
-		QualityMapFeatures::getAllQualityFeatureIDs(),
-		RVUPHistogramFeature::getAllQualityFeatureIDs()
+		FDAFeature::getQualityFeatureIDs(),
+		FingerJetFXFeature::getQualityFeatureIDs(),
+		FJFXMinutiaeQualityFeature::getQualityFeatureIDs(),
+		ImgProcROIFeature::getQualityFeatureIDs(),
+		LCSFeature::getQualityFeatureIDs(),
+		MuFeature::getQualityFeatureIDs(),
+		OCLHistogramFeature::getQualityFeatureIDs(),
+		OFFeature::getQualityFeatureIDs(),
+		QualityMapFeatures::getQualityFeatureIDs(),
+		RVUPHistogramFeature::getQualityFeatureIDs()
 	};
 
 	std::vector<std::string> qualityFeatureIDs {};

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures_impl.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures_impl.cpp
@@ -292,6 +292,25 @@ NFIQ2::QualityFeatures::Impl::getAllQualityFeatureIDs()
 }
 
 std::vector<std::string>
+NFIQ2::QualityFeatures::Impl::getAllQualityModuleIDs()
+{
+	static const std::vector<std::string> ids {
+		Identifiers::QualityModules::FrequencyDomainAnalysis,
+		Identifiers::QualityModules::MinutiaeCount,
+		Identifiers::QualityModules::MinutiaeQuality,
+		Identifiers::QualityModules::RegionOfInterestMean,
+		Identifiers::QualityModules::LocalClarity,
+		Identifiers::QualityModules::Contrast,
+		Identifiers::QualityModules::OrientationCertainty,
+		Identifiers::QualityModules::OrientationFlow,
+		Identifiers::QualityModules::RegionOfInterestCoherence,
+		Identifiers::QualityModules::RidgeValleyUniformity
+	};
+
+	return ids;
+}
+
+std::vector<std::string>
 NFIQ2::QualityFeatures::Impl::getAllSpeedFeatureGroups()
 {
 	static const std::vector<std::string> speedFeatureGroups {

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures_impl.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures_impl.cpp
@@ -61,15 +61,15 @@ NFIQ2::QualityFeatures::Impl::getQualityModuleSpeeds(
 }
 
 std::unordered_map<std::string, double>
-NFIQ2::QualityFeatures::Impl::getQualityFeatureData(
+NFIQ2::QualityFeatures::Impl::getQualityFeatureValues(
     const NFIQ2::FingerprintImageData &rawImage)
 {
-	return NFIQ2::QualityFeatures::getQualityFeatureData(
+	return NFIQ2::QualityFeatures::getQualityFeatureValues(
 	    NFIQ2::QualityFeatures::computeQualityFeatures(rawImage));
 }
 
 std::unordered_map<std::string, double>
-NFIQ2::QualityFeatures::Impl::getQualityFeatureData(
+NFIQ2::QualityFeatures::Impl::getQualityFeatureValues(
     const std::vector<std::shared_ptr<NFIQ2::QualityFeatures::BaseFeature>>
 	&features)
 {

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures_impl.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures_impl.cpp
@@ -270,15 +270,16 @@ std::vector<std::string>
 NFIQ2::QualityFeatures::Impl::getAllQualityFeatureIDs()
 {
 	const std::vector<std::vector<std::string>> vov {
-		FDAFeature::getAllFeatureIDs(),
-		FingerJetFXFeature::getAllFeatureIDs(),
-		FJFXMinutiaeQualityFeature::getAllFeatureIDs(),
-		ImgProcROIFeature::getAllFeatureIDs(),
-		LCSFeature::getAllFeatureIDs(), MuFeature::getAllFeatureIDs(),
-		OCLHistogramFeature::getAllFeatureIDs(),
-		OFFeature::getAllFeatureIDs(),
-		QualityMapFeatures::getAllFeatureIDs(),
-		RVUPHistogramFeature::getAllFeatureIDs()
+		FDAFeature::getAllQualityFeatureIDs(),
+		FingerJetFXFeature::getAllQualityFeatureIDs(),
+		FJFXMinutiaeQualityFeature::getAllQualityFeatureIDs(),
+		ImgProcROIFeature::getAllQualityFeatureIDs(),
+		LCSFeature::getAllQualityFeatureIDs(),
+		MuFeature::getAllQualityFeatureIDs(),
+		OCLHistogramFeature::getAllQualityFeatureIDs(),
+		OFFeature::getAllQualityFeatureIDs(),
+		QualityMapFeatures::getAllQualityFeatureIDs(),
+		RVUPHistogramFeature::getAllQualityFeatureIDs()
 	};
 
 	std::vector<std::string> qualityFeatureIDs {};

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures_impl.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures_impl.cpp
@@ -251,7 +251,7 @@ NFIQ2::QualityFeatures::Impl::computeQualityFeatures(
 }
 
 std::vector<std::string>
-NFIQ2::QualityFeatures::Impl::getAllActionableIdentifiers()
+NFIQ2::QualityFeatures::Impl::getAllActionableQualityFeedbackIDs()
 {
 	static const std::vector<std::string> actionableIdentifiers {
 		NFIQ2::Identifiers::ActionableQualityFeedback::UniformImage,

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures_impl.hpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures_impl.hpp
@@ -29,7 +29,7 @@ std::vector<std::string> getAllActionableQualityFeedbackIDs();
  * @return
  * Vector of strings containing all quality feature IDs.
  */
-std::vector<std::string> getAllQualityFeatureIDs();
+std::vector<std::string> getQualityFeatureIDs();
 
 /**
  * @brief

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures_impl.hpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures_impl.hpp
@@ -135,7 +135,7 @@ std::unordered_map<std::string, double> getQualityFeatureData(
  * @return
  * A map of string, quality feature speed pairs.
  */
-std::unordered_map<std::string, double> getQualityFeatureSpeeds(
+std::unordered_map<std::string, double> getQualityModuleSpeeds(
     const std::vector<std::shared_ptr<NFIQ2::QualityFeatures::BaseFeature>>
 	&features);
 

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures_impl.hpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures_impl.hpp
@@ -108,7 +108,7 @@ std::unordered_map<std::string, double> getActionableQualityFeedback(
  * @return
  * A map of string, quality feature data pairs.
  */
-std::unordered_map<std::string, double> getQualityFeatureData(
+std::unordered_map<std::string, double> getQualityFeatureValues(
     const std::vector<std::shared_ptr<NFIQ2::QualityFeatures::BaseFeature>>
 	&features);
 
@@ -122,7 +122,7 @@ std::unordered_map<std::string, double> getQualityFeatureData(
  * @return
  * A map of string, quality feature data pairs.
  */
-std::unordered_map<std::string, double> getQualityFeatureData(
+std::unordered_map<std::string, double> getQualityFeatureValues(
     const NFIQ2::FingerprintImageData &rawImage);
 
 /**

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures_impl.hpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures_impl.hpp
@@ -20,7 +20,7 @@ namespace NFIQ2 { namespace QualityFeatures { namespace Impl {
  * Vector of strings containing all actionable quality feedback
  * identifiers.
  */
-std::vector<std::string> getAllActionableIdentifiers();
+std::vector<std::string> getAllActionableQualityFeedbackIDs();
 
 /**
  * @brief

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures_impl.hpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures_impl.hpp
@@ -42,15 +42,6 @@ std::vector<std::string> getAllQualityModuleIDs();
 
 /**
  * @brief
- * Obtain all speed feature groups from quality modules.
- *
- * @return
- * Vector of strings containing all speed feature groups.
- */
-std::vector<std::string> getAllSpeedFeatureGroups();
-
-/**
- * @brief
  * Updates the floating point precision mode used on 32-bit Linux
  * versions of NFIQ 2.
  *

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures_impl.hpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures_impl.hpp
@@ -144,8 +144,7 @@ std::unordered_map<std::string, double> getQualityFeatureData(
  * @return
  * A map of string, quality feature speed pairs.
  */
-std::unordered_map<std::string, NFIQ2::QualityFeatureSpeed>
-getQualityFeatureSpeeds(
+std::unordered_map<std::string, double> getQualityFeatureSpeeds(
     const std::vector<std::shared_ptr<NFIQ2::QualityFeatures::BaseFeature>>
 	&features);
 

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures_impl.hpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_qualityfeatures_impl.hpp
@@ -33,6 +33,15 @@ std::vector<std::string> getAllQualityFeatureIDs();
 
 /**
  * @brief
+ * Obtain all quality module identifiers.
+ *
+ * @return
+ * Vector of strings with all identifiers from Identifiers::QualityModules.
+ */
+std::vector<std::string> getAllQualityModuleIDs();
+
+/**
+ * @brief
  * Obtain all speed feature groups from quality modules.
  *
  * @return

--- a/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_log.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_log.cpp
@@ -59,8 +59,8 @@ NFIQ2UI::Log::printScore(const std::string &name, uint8_t fingerCode,
 
 	// Print out actionable first
 	if (this->actionable) {
-		const auto actionableIDs =
-		    NFIQ2::QualityFeatures::getAllActionableIdentifiers();
+		const auto actionableIDs = NFIQ2::QualityFeatures::
+		    getAllActionableQualityFeedbackIDs();
 		for (const auto &i : actionableIDs) {
 			if (i != actionableIDs.front()) {
 				*(this->out) << ",";
@@ -209,8 +209,8 @@ NFIQ2UI::Log::printCSVHeader() const
 	}
 
 	if (this->actionable) {
-		std::vector<std::string> vHeaders =
-		    NFIQ2::QualityFeatures::getAllActionableIdentifiers();
+		std::vector<std::string> vHeaders = NFIQ2::QualityFeatures::
+		    getAllActionableQualityFeedbackIDs();
 
 		for (auto it = vHeaders.begin(); it != vHeaders.end(); ++it) {
 			if (it != vHeaders.begin()) {

--- a/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_log.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_log.cpp
@@ -91,10 +91,10 @@ NFIQ2UI::Log::printScore(const std::string &name, uint8_t fingerCode,
 	}
 
 	if (this->speed) {
-		const auto speedIDs =
-		    NFIQ2::QualityFeatures::getAllSpeedFeatureGroups();
-		for (const auto &i : speedIDs) {
-			if (i != speedIDs.front()) {
+		const auto moduleIDs =
+		    NFIQ2::QualityFeatures::getAllQualityModuleIDs();
+		for (const auto &i : moduleIDs) {
+			if (i != moduleIDs.front()) {
 				*(this->out) << ",";
 			}
 
@@ -241,7 +241,7 @@ NFIQ2UI::Log::printCSVHeader() const
 
 	if (this->speed) {
 		std::vector<std::string> sHeaders =
-		    NFIQ2::QualityFeatures::getAllSpeedFeatureGroups();
+		    NFIQ2::QualityFeatures::getAllQualityModuleIDs();
 
 		for (auto it = sHeaders.begin(); it != sHeaders.end(); ++it) {
 			if (it != sHeaders.begin()) {

--- a/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_log.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_log.cpp
@@ -76,7 +76,7 @@ NFIQ2UI::Log::printScore(const std::string &name, uint8_t fingerCode,
 
 	if (this->verbose) {
 		const auto featureIDs =
-		    NFIQ2::QualityFeatures::getAllQualityFeatureIDs();
+		    NFIQ2::QualityFeatures::getQualityFeatureIDs();
 		for (const auto &i : featureIDs) {
 			if (i != featureIDs.front()) {
 				*(this->out) << ",";
@@ -225,7 +225,7 @@ NFIQ2UI::Log::printCSVHeader() const
 
 	if (this->verbose) {
 		std::vector<std::string> vHeaders =
-		    NFIQ2::QualityFeatures::getAllQualityFeatureIDs();
+		    NFIQ2::QualityFeatures::getQualityFeatureIDs();
 
 		for (auto it = vHeaders.begin(); it != vHeaders.end(); ++it) {
 			if (it != vHeaders.begin()) {

--- a/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_log.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_log.cpp
@@ -247,8 +247,7 @@ NFIQ2UI::Log::printCSVHeader() const
 			if (it != sHeaders.begin()) {
 				*(this->out) << ',';
 			}
-			std::replace(it->begin(), it->end(), ' ', '_');
-			*(this->out) << *it;
+			*(this->out) << *it << "Speed";
 		}
 	}
 	*(this->out) << "\n";

--- a/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_log.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_log.cpp
@@ -46,7 +46,7 @@ NFIQ2UI::Log::printScore(const std::string &name, uint8_t fingerCode,
     unsigned int score, const std::string &errmsg, const bool quantized,
     const bool resampled,
     const std::unordered_map<std::string, double> &features,
-    const std::unordered_map<std::string, NFIQ2::QualityFeatureSpeed> &speed,
+    const std::unordered_map<std::string, double> &speed,
     const std::unordered_map<std::string, double> &actionable) const
 {
 	*(this->out) << "\"" << name << "\""
@@ -98,8 +98,7 @@ NFIQ2UI::Log::printScore(const std::string &name, uint8_t fingerCode,
 				*(this->out) << ",";
 			}
 
-			*(this->out)
-			    << std::setprecision(5) << speed.at(i).featureSpeed;
+			*(this->out) << std::setprecision(5) << speed.at(i);
 		}
 	}
 	*(this->out) << "\n";

--- a/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_refresh.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_refresh.cpp
@@ -392,7 +392,7 @@ NFIQ2UI::executeSingle(std::shared_ptr<BE::Image::Image> img,
 		// Print full score with optional headers
 		logger->printScore(name, fingerPosition, score, warning,
 		    imageProps.quantized, imageProps.resampled,
-		    NFIQ2::QualityFeatures::getQualityFeatureData(features),
+		    NFIQ2::QualityFeatures::getQualityFeatureValues(features),
 		    NFIQ2::QualityFeatures::getQualityModuleSpeeds(features),
 		    NFIQ2::QualityFeatures::getActionableQualityFeedback(
 			features));

--- a/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_refresh.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_refresh.cpp
@@ -393,7 +393,7 @@ NFIQ2UI::executeSingle(std::shared_ptr<BE::Image::Image> img,
 		logger->printScore(name, fingerPosition, score, warning,
 		    imageProps.quantized, imageProps.resampled,
 		    NFIQ2::QualityFeatures::getQualityFeatureData(features),
-		    NFIQ2::QualityFeatures::getQualityFeatureSpeeds(features),
+		    NFIQ2::QualityFeatures::getQualityModuleSpeeds(features),
 		    NFIQ2::QualityFeatures::getActionableQualityFeedback(
 			features));
 	}

--- a/examples/example_api.cpp
+++ b/examples/example_api.cpp
@@ -177,7 +177,7 @@ main(int argc, char **argv)
 
 	// Quality Feature Values
 	std::vector<std::string> featureIDs =
-	    NFIQ2::QualityFeatures::getAllQualityFeatureIDs();
+	    NFIQ2::QualityFeatures::getQualityFeatureIDs();
 
 	std::unordered_map<std::string, double> qualityFeatures =
 	    NFIQ2::QualityFeatures::getQualityFeatureValues(features);

--- a/examples/example_api.cpp
+++ b/examples/example_api.cpp
@@ -180,7 +180,7 @@ main(int argc, char **argv)
 	    NFIQ2::QualityFeatures::getAllQualityFeatureIDs();
 
 	std::unordered_map<std::string, double> qualityFeatures =
-	    NFIQ2::QualityFeatures::getQualityFeatureData(features);
+	    NFIQ2::QualityFeatures::getQualityFeatureValues(features);
 
 	for (const auto &featureID : featureIDs) {
 		std::cout << featureID << ": " << qualityFeatures.at(featureID)

--- a/examples/example_api.cpp
+++ b/examples/example_api.cpp
@@ -165,7 +165,7 @@ main(int argc, char **argv)
 
 	// Actionable Feedback
 	std::vector<std::string> actionableIDs =
-	    NFIQ2::QualityFeatures::getAllActionableIdentifiers();
+	    NFIQ2::QualityFeatures::getAllActionableQualityFeedbackIDs();
 
 	std::unordered_map<std::string, double> actionableQuality =
 	    NFIQ2::QualityFeatures::getActionableQualityFeedback(features);

--- a/examples/print_feature_names.cpp
+++ b/examples/print_feature_names.cpp
@@ -7,7 +7,7 @@ main()
 {
 	std::cout << "NFIQ 2 Features:\n";
 	for (const auto &features :
-	    NFIQ2::QualityFeatures::getAllQualityFeatureIDs()) {
+	    NFIQ2::QualityFeatures::getQualityFeatureIDs()) {
 		std::cout << " * " << features << '\n';
 	}
 


### PR DESCRIPTION
- Speed feature groups can be obtained by other existing methods, so we don't need a unique type for this.
- Rename quality modules as the speed groups were, since they are readable and quality module names were never exposed.
- Fix some consistency issues.