### PR TITLE
Remove minimum image dimensions

### DIFF
--- a/NFIQ2/NFIQ2Algorithm/src/features/FingerJetFXFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FingerJetFXFeature.cpp
@@ -89,15 +89,6 @@ NFIQ2::QualityFeatures::FingerJetFXFeature::computeFeatureData(
 {
 	std::unordered_map<std::string, double> featureDataList;
 
-	// make local copy of fingerprint image
-	// since FJFX somehow transforms the input image
-	NFIQ2::FingerprintImageData localFingerprintImage(
-	    fingerprintImage.width, fingerprintImage.height,
-	    fingerprintImage.fingerCode, fingerprintImage.ppi);
-	// copy data now
-	localFingerprintImage.resize(fingerprintImage.size());
-	memcpy((void *)localFingerprintImage.data(), fingerprintImage.data(),
-	    fingerprintImage.size());
 
 	std::pair<std::string, double> fd_min_cnt;
 	fd_min_cnt =
@@ -128,10 +119,9 @@ NFIQ2::QualityFeatures::FingerJetFXFeature::computeFeatureData(
 
 	// extract feature set
 	const FRFXLL_RESULT fxRes = FRFXLLCreateFeatureSetFromRaw(hCtx,
-	    (unsigned char *)localFingerprintImage.data(),
-	    localFingerprintImage.size(), localFingerprintImage.width,
-	    localFingerprintImage.height, localFingerprintImage.ppi,
-	    FRFXLL_FEX_ENABLE_ENHANCEMENT, &hFeatureSet);
+	    (unsigned char *)fingerprintImage.data(), fingerprintImage.size(),
+	    fingerprintImage.width, fingerprintImage.height,
+	    fingerprintImage.ppi, FRFXLL_FEX_ENABLE_ENHANCEMENT, &hFeatureSet);
 	if (!FRFXLL_SUCCESS(fxRes)) {
 		FRFXLLCloseHandle(&hCtx);
 		throw NFIQ2::Exception(

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_fingerprintimagedata.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_fingerprintimagedata.cpp
@@ -153,33 +153,17 @@ NFIQ2::FingerprintImageData::copyRemovingNearWhiteFrame() const
 	const cv::Rect roi(leftIndex, topRowIndex, width, height);
 	const cv::Mat roiImg = img(roi);
 
-	static const uint16_t fingerJetMinWidth = 196;
 	static const uint16_t fingerJetMaxWidth = 800;
-	static const uint16_t fingerJetMinHeight = 196;
 	static const uint16_t fingerJetMaxHeight = 1000;
 
 	// Values are from FJFX image size thresholds
-	if (roiImg.cols < fingerJetMinWidth) {
-		throw NFIQ2::Exception(NFIQ2::ErrorCode::InvalidImageSize,
-		    "Width is too small after trimming whitespace. WxH: " +
-			std::to_string(roiImg.cols) + "x" +
-			std::to_string(roiImg.rows) +
-			", but minimum width is " +
-			std::to_string(fingerJetMinWidth));
-	} else if (roiImg.cols > fingerJetMaxWidth) {
+	if (roiImg.cols > fingerJetMaxWidth) {
 		throw NFIQ2::Exception(NFIQ2::ErrorCode::InvalidImageSize,
 		    "Width is too large after trimming whitespace. WxH: " +
 			std::to_string(roiImg.cols) + "x" +
 			std::to_string(roiImg.rows) +
 			", but maximum width is " +
 			std::to_string(fingerJetMaxWidth));
-	} else if (roiImg.rows < fingerJetMinHeight) {
-		throw NFIQ2::Exception(NFIQ2::ErrorCode::InvalidImageSize,
-		    "Height is too small after trimming whitespace. WxH: " +
-			std::to_string(roiImg.cols) + "x" +
-			std::to_string(roiImg.rows) +
-			", but minimum height is " +
-			std::to_string(fingerJetMinHeight));
 	} else if (roiImg.rows > fingerJetMaxHeight) {
 		throw NFIQ2::Exception(NFIQ2::ErrorCode::InvalidImageSize,
 		    "Height is too large after trimming whitespace. WxH: " +


### PR DESCRIPTION
Minimum image dimensions were imposed to work around a limitation of FingerJet FX OSE. The feature extractor does not mind having blank whitespace around a fingerprint though. This change pads the fingerprint image to the bottom and right of the 29794-4 mandated cropped version such that minutiae can be extracted. Minutiae found that are not within the 29794-4 mandated cropped version of the image are removed before the other minutiae-based features are computed.