### PR TITLE
Refactor addHistogramFeatures

### DIFF
--- a/NFIQ2/NFIQ2Algorithm/src/features/FDAFeature.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FDAFeature.cpp
@@ -194,6 +194,16 @@ NFIQ2::QualityFeatures::FDAFeature::computeFeatureData(
 			bc = 0;
 		}
 
+		const int binCount { 10 };
+		if (dataVector.size() < binCount) {
+			throw NFIQ2::Exception {
+				ErrorCode::FeatureCalculationError,
+				"Cannot compute Frequency Domain Analysis (FDA): "
+				"Not enough data to generate histogram bins (is "
+				"the image blank?)"
+			};
+		}
+
 		std::vector<double> histogramBins10;
 		histogramBins10.push_back(FDAHISTLIMITS[0]);
 		histogramBins10.push_back(FDAHISTLIMITS[1]);
@@ -205,7 +215,7 @@ NFIQ2::QualityFeatures::FDAFeature::computeFeatureData(
 		histogramBins10.push_back(FDAHISTLIMITS[7]);
 		histogramBins10.push_back(FDAHISTLIMITS[8]);
 		addHistogramFeatures(featureDataList, NFIQ2FDAFeaturePrefix,
-		    histogramBins10, dataVector, 10);
+		    histogramBins10, dataVector, binCount);
 
 		this->setSpeed(timer.stop());
 	} catch (const cv::Exception &e) {

--- a/NFIQ2/NFIQ2Algorithm/src/features/FeatureFunctions.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FeatureFunctions.cpp
@@ -550,10 +550,7 @@ NFIQ2::QualityFeatures::addHistogramFeatures(
 
 	std::sort(dataVector.begin(), dataVector.end());
 
-	int *bins = new int[binCount];
-	for (int i = 0; i < binCount; i++) {
-		bins[i] = 0;
-	}
+	std::vector<int> bins(binCount, 0);
 	int currentBucket = 0;
 	double currentBound = binBoundaries.at(currentBucket);
 
@@ -578,10 +575,6 @@ NFIQ2::QualityFeatures::addHistogramFeatures(
 	    mean.val[0];
 	featureDataList[featurePrefix + FeatureFunctionsStdDevSuffix] =
 	    stdDev.val[0];
-
-	if (bins) {
-		delete[] bins;
-	}
 }
 
 void

--- a/NFIQ2/NFIQ2Algorithm/src/features/FeatureFunctions.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/features/FeatureFunctions.cpp
@@ -554,9 +554,8 @@ NFIQ2::QualityFeatures::addHistogramFeatures(
 	int currentBucket = 0;
 	double currentBound = binBoundaries.at(currentBucket);
 
-	for (std::vector<double>::iterator it = dataVector.begin();
-	     it != dataVector.end(); ++it) {
-		while (!cvIsInf(*it) && *it >= currentBound) {
+	for (const auto &value : dataVector) {
+		while (!cvIsInf(value) && value >= currentBound) {
 			currentBucket++;
 			currentBound = binBoundaries.at(currentBucket);
 		}


### PR DESCRIPTION
Modernize some of `addHistogramFeatures()`.

Closes #310 by providing a better error message when no observations are available in FDA. Note that the histogram bin size check for FDA only occurs in FDA because FDA is currently the first feature computed. There's likely a better way to add these histogram features, and so I'm just doing the minimum now to get the better message.