### PR TITLE
Update to OpenCV 4.5.4

### DIFF
--- a/.github/workflows/build-member.yml
+++ b/.github/workflows/build-member.yml
@@ -119,7 +119,7 @@ jobs:
         path: |
           ${{ github.workspace }}/build
           !${{ github.workspace }}/build/nfir*
-        key: ${{ matrix.config.os }}-${{ matrix.config.arch }}-builddir
+        key: ${{ matrix.config.os }}-${{ matrix.config.arch }}-builddir-ocv454
 
     - name: Get CMake Version
       shell: bash

--- a/.github/workflows/build-member.yml
+++ b/.github/workflows/build-member.yml
@@ -119,6 +119,8 @@ jobs:
         path: |
           ${{ github.workspace }}/build
           !${{ github.workspace }}/build/nfir*
+          !${{ github.workspace }}/build/nfiq2api-prefix/src/nfiq2api-build/CMakeFiles/Nfiq2Api.dir/version.AppleClang.apple64.cpp.o*
+          !${{ github.workspace }}/build/nfiq2-prefix/src/nfiq2-build/CMakeFiles/nfiq2-static-lib.dir/src/nfiq2/version.cpp.o*
         key: ${{ matrix.config.os }}-${{ matrix.config.arch }}-builddir-ocv454
 
     - name: Get CMake Version

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -118,10 +118,10 @@ jobs:
         path: |
           ${{ github.workspace }}/build
           !${{ github.workspace }}/build/nfir*
-        key: pr-${{ matrix.config.os }}-${{ matrix.config.arch }}-builddir
+        key: pr-${{ matrix.config.os }}-${{ matrix.config.arch }}-builddir-ocv454
         restore-keys: |
-          pr-${{ matrix.config.os }}-${{ matrix.config.arch }}-builddir
-          ${{ matrix.config.os }}-${{ matrix.config.arch }}-builddir
+          pr-${{ matrix.config.os }}-${{ matrix.config.arch }}-builddir-ocv454
+          ${{ matrix.config.os }}-${{ matrix.config.arch }}-builddir-ocv454
 
     - name: Get CMake Version
       shell: bash

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -118,6 +118,8 @@ jobs:
         path: |
           ${{ github.workspace }}/build
           !${{ github.workspace }}/build/nfir*
+          !${{ github.workspace }}/build/nfiq2api-prefix/src/nfiq2api-build/CMakeFiles/Nfiq2Api.dir/version.AppleClang.apple64.cpp.o*
+          !${{ github.workspace }}/build/nfiq2-prefix/src/nfiq2-build/CMakeFiles/nfiq2-static-lib.dir/src/nfiq2/version.cpp.o*
         key: pr-${{ matrix.config.os }}-${{ matrix.config.arch }}-builddir-ocv454
         restore-keys: |
           pr-${{ matrix.config.os }}-${{ matrix.config.arch }}-builddir-ocv454


### PR DESCRIPTION
Closes #319. Also closes #254 (unrelated, but this is a good spot where the cache is already blown).