### PR TITLE
Add constants for CBEFF quality algorithm identifiers

### DIFF
--- a/NFIQ2/NFIQ2Algorithm/CMakeLists.txt
+++ b/NFIQ2/NFIQ2Algorithm/CMakeLists.txt
@@ -46,6 +46,7 @@ include_directories(${OpenCV_INCLUDE_DIRS})
 include_directories("${SUPERBUILD_ROOT_PATH}/NFIR/include")
 
 set(SOURCE_FILES
+    "src/nfiq2/nfiq2_cbeff.cpp"
     "src/nfiq2/nfiq2_data.cpp"
     "src/nfiq2/nfiq2_fingerprintimagedata.cpp"
     "src/nfiq2/nfiq2_modelinfo.cpp"

--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2_constants.hpp
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2_constants.hpp
@@ -19,6 +19,97 @@
 namespace NFIQ2 {
 /** Identification strings for various objects. */
 namespace Identifiers {
+
+/** CBEFF quality algorithm identifiers. */
+namespace CBEFF {
+/** Quality algorithm vendor */
+extern const unsigned int Vendor;
+
+/** Unified quality score (NFIQ 2.0). */
+extern const unsigned int NFIQ2Rev0;
+/** Unified quality score (NFIQ 2.1). */
+extern const unsigned int NFIQ2Rev1;
+/** Unified quality score (NFIQ 2.2). */
+extern const unsigned int NFIQ2Rev2;
+/** Unified quality score (ISO/IEC 29794-4). */
+extern const unsigned int UnifiedQualityScore;
+
+/** Orientation certainty quality algorithm identifiers. */
+namespace OrientationCertainty {
+/** Mean of local orientation certainty level. */
+extern const unsigned int Mean;
+/** Standard deviation of local orientation certainty level. */
+extern const unsigned int StdDev;
+}
+
+/** Local clarity quality algorithm identifiers. */
+namespace LocalClarity {
+/** Mean of local clarity score. */
+extern const unsigned int Mean;
+/** Standard deviation of local clarity score. */
+extern const unsigned int StdDev;
+}
+
+/** Frequency domain analysis quality algorithm identifiers. */
+namespace FrequencyDomainAnalysis {
+/** Mean of local frequency domain analysis. */
+extern const unsigned int Mean;
+/** Standard deviation of local frequency domain analysis. */
+extern const unsigned int StdDev;
+}
+
+/** Ridge valley uniformity quality algorithm identifiers. */
+namespace RidgeValleyUniformity {
+/** Mean of local ridge valley uniformity. */
+extern const unsigned int Mean;
+/** Standard deviation of local ridge valley uniformity. */
+extern const unsigned int StdDev;
+}
+
+/** Orientation flow quality algorithm identifiers. */
+namespace OrientationFlow {
+/** Mean of local orientation flow. */
+extern const unsigned int Mean;
+/** Standard deviation of orientation flow. */
+extern const unsigned int StdDev;
+}
+
+/** Image contrast quality algorithm identifiers. */
+namespace Contrast {
+/** Average contrast ("MU"). */
+extern const unsigned int Mean;
+/** Average of average constrasts ("MMB"). */
+extern const unsigned int MeanBlock;
+}
+
+/** Minutie-based quality algorithm identifiers. */
+namespace Minutiae {
+/** Minutiae count. */
+extern const unsigned int Count;
+/** Minutiae count in center of mass. */
+extern const unsigned int CountCOM;
+/** Minutiae quality based on image mean. */
+extern const unsigned int QualityMu2;
+/** Minutiae quality based on orientation certainty level. */
+extern const unsigned int QualityOCL80;
+}
+
+/** Region of interest quality algorithm identifiers. */
+namespace RegionOfInterest {
+/** Region of interest image mean. */
+extern const unsigned int Mean;
+/** Region of interest orientation map coherence sum. */
+extern const unsigned int CoherenceSum;
+/** Region of interest relative orientation map coherence sum. */
+extern const unsigned int CoherenceMean;
+}
+
+/** Radial power spectrum. */
+extern const unsigned int RadialPowerSpectrum;
+/** Gabor quality score. */
+extern const unsigned int Gabor;
+}
+
 /**
  * Identifiers for interpretation of quality features that may indicated
  * corrective measures for subsequent captures of the same subject.

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_cbeff.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_cbeff.cpp
@@ -1,0 +1,55 @@
+#include <nfiq2_constants.hpp>
+
+/* ISO/IEC JTC 1 SC 37 Biometrics. */
+const unsigned int NFIQ2::Identifiers::CBEFF::Vendor { 0x0101 };
+
+const unsigned int NFIQ2::Identifiers::CBEFF::NFIQ2Rev0 { 0x01 };
+const unsigned int NFIQ2::Identifiers::CBEFF::NFIQ2Rev1 { 0x17 };
+const unsigned int NFIQ2::Identifiers::CBEFF::NFIQ2Rev2 { 0x18 };
+const unsigned int NFIQ2::Identifiers::CBEFF::UnifiedQualityScore { NFIQ2Rev2 };
+
+const unsigned int NFIQ2::Identifiers::CBEFF::OrientationCertainty::Mean {
+	0x02
+};
+const unsigned int NFIQ2::Identifiers::CBEFF::OrientationCertainty::StdDev {
+	0x03
+};
+
+const unsigned int NFIQ2::Identifiers::CBEFF::LocalClarity::Mean { 0x04 };
+const unsigned int NFIQ2::Identifiers::CBEFF::LocalClarity::StdDev { 0x05 };
+
+const unsigned int NFIQ2::Identifiers::CBEFF::FrequencyDomainAnalysis::Mean {
+	0x06
+};
+const unsigned int NFIQ2::Identifiers::CBEFF::FrequencyDomainAnalysis::StdDev {
+	0x07
+};
+
+const unsigned int NFIQ2::Identifiers::CBEFF::RidgeValleyUniformity::Mean {
+	0x08
+};
+const unsigned int NFIQ2::Identifiers::CBEFF::RidgeValleyUniformity::StdDev {
+	0x09
+};
+
+const unsigned int NFIQ2::Identifiers::CBEFF::OrientationFlow::Mean { 0x0A };
+const unsigned int NFIQ2::Identifiers::CBEFF::OrientationFlow::StdDev { 0x0B };
+
+const unsigned int NFIQ2::Identifiers::CBEFF::Contrast::Mean { 0x0C };
+const unsigned int NFIQ2::Identifiers::CBEFF::Contrast::MeanBlock { 0x0D };
+
+const unsigned int NFIQ2::Identifiers::CBEFF::Minutiae::Count { 0x0E };
+const unsigned int NFIQ2::Identifiers::CBEFF::Minutiae::CountCOM { 0x0F };
+const unsigned int NFIQ2::Identifiers::CBEFF::Minutiae::QualityMu2 { 0x10 };
+const unsigned int NFIQ2::Identifiers::CBEFF::Minutiae::QualityOCL80 { 0x11 };
+
+const unsigned int NFIQ2::Identifiers::CBEFF::RegionOfInterest::Mean { 0x12 };
+const unsigned int NFIQ2::Identifiers::CBEFF::RegionOfInterest::CoherenceSum {
+	0x13
+};
+const unsigned int NFIQ2::Identifiers::CBEFF::RegionOfInterest::CoherenceMean {
+	0x14
+};
+
+const unsigned int NFIQ2::Identifiers::CBEFF::RadialPowerSpectrum { 0x15 };
+const unsigned int NFIQ2::Identifiers::CBEFF::Gabor { 0x16 };

--- a/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_cbeff.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/nfiq2/nfiq2_cbeff.cpp
@@ -6,7 +6,9 @@ const unsigned int NFIQ2::Identifiers::CBEFF::Vendor { 0x0101 };
 const unsigned int NFIQ2::Identifiers::CBEFF::NFIQ2Rev0 { 0x01 };
 const unsigned int NFIQ2::Identifiers::CBEFF::NFIQ2Rev1 { 0x17 };
 const unsigned int NFIQ2::Identifiers::CBEFF::NFIQ2Rev2 { 0x18 };
-const unsigned int NFIQ2::Identifiers::CBEFF::UnifiedQualityScore { NFIQ2Rev2 };
+const unsigned int NFIQ2::Identifiers::CBEFF::UnifiedQualityScore {
+	NFIQ2::Identifiers::CBEFF::NFIQ2Rev2
+};
 
 const unsigned int NFIQ2::Identifiers::CBEFF::OrientationCertainty::Mean {
 	0x02


### PR DESCRIPTION
As documented in ISO/IEC 29794-4:2017. NFIQ 2.1 and 2.2 values updated as will be proposed in 2022 draft.

Closes #323.