### PR TITLE
vcpkg CMake Toolchain File Path

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -41,6 +41,7 @@ jobs:
         submodules: true
 
     - name: Install vcpkg
+      working-directory: ${{ github.workspace }}
       if: ${{ runner.os == 'Windows' }}
       run: |
         git clone https://github.com/microsoft/vcpkg.git fresh-vcpkg
@@ -151,11 +152,11 @@ jobs:
       shell: bash
       env:
         cmake_arch_flag: ${{ matrix.config.arch == 'x86' && 'Win32' || 'x64' }}
-      working-directory: ${{ github.workspace }}\build
+      working-directory: ${{ github.workspace }}/build
       run: |
         cmake \
             -A ${cmake_arch_flag} \
-            -DCMAKE_TOOLCHAIN_FILE=../fresh-vcpkg/scripts/buildsystems/vcpkg.cmake \
+            -DCMAKE_TOOLCHAIN_FILE=${GITHUB_WORKSPACE}/fresh-vcpkg/scripts/buildsystems/vcpkg.cmake \
             -DVCPKG_TARGET_TRIPLET=${{ matrix.config.arch }}-windows-static \
             -DCMAKE_CONFIGURATION_TYPES="${CONFIGURATION}" \
             -DVCPKG_VERBOSE=ON \


### PR DESCRIPTION
Attempting to fix a relative path issue (?) with the toolchain file in the GitHub Actions under Windows. The vcpkg CMake toolchain can no longer be found.