### PR TITLE
Fix for build failures due to missing uint8_t

### DIFF
--- a/NFIQ2/NFIQ2Algorithm/include/nfiq2_data.hpp
+++ b/NFIQ2/NFIQ2Algorithm/include/nfiq2_data.hpp
@@ -13,6 +13,7 @@
 
 #include <nfiq2_exception.hpp>
 
+#include <cstdint>
 #include <fstream>
 #include <string>
 #include <vector>


### PR DESCRIPTION
This pull request adds an include for `cstdint` to resolve `Error 2` build failures.

The build failures were observed on Linux (x86_64, EndeavourOS/Arch, kernel 6.7.4-arch1-1) while building from source using the README's build instructions for the CLI version.