### PR TITLE
Bump OpenCV to 4.9.0

### DIFF
--- a/.github/workflows/build-member.yml
+++ b/.github/workflows/build-member.yml
@@ -131,7 +131,7 @@ jobs:
           !${{ github.workspace }}/build/nfir*
           !${{ github.workspace }}/build/nfiq2api-prefix/src/nfiq2api-build/CMakeFiles/Nfiq2Api.dir/version.AppleClang.apple64.cpp.o*
           !${{ github.workspace }}/build/nfiq2-prefix/src/nfiq2-build/CMakeFiles/nfiq2-static-lib.dir/src/nfiq2/version.cpp.o*
-        key: ${{ matrix.config.os }}-${{ matrix.config.arch }}-builddir-ocv454
+        key: ${{ matrix.config.os }}-${{ matrix.config.arch }}-builddir-ocv49
 
     - name: Get CMake Version
       shell: bash

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -130,10 +130,10 @@ jobs:
           !${{ github.workspace }}/build/nfir*
           !${{ github.workspace }}/build/nfiq2api-prefix/src/nfiq2api-build/CMakeFiles/Nfiq2Api.dir/version.AppleClang.apple64.cpp.o*
           !${{ github.workspace }}/build/nfiq2-prefix/src/nfiq2-build/CMakeFiles/nfiq2-static-lib.dir/src/nfiq2/version.cpp.o*
-        key: pr-${{ matrix.config.os }}-${{ matrix.config.arch }}-builddir-ocv454
+        key: pr-${{ matrix.config.os }}-${{ matrix.config.arch }}-builddir-ocv49
         restore-keys: |
-          pr-${{ matrix.config.os }}-${{ matrix.config.arch }}-builddir-ocv454
-          ${{ matrix.config.os }}-${{ matrix.config.arch }}-builddir-ocv454
+          pr-${{ matrix.config.os }}-${{ matrix.config.arch }}-builddir-ocv49
+          ${{ matrix.config.os }}-${{ matrix.config.arch }}-builddir-ocv49
 
     - name: Get CMake Version
       shell: bash


### PR DESCRIPTION
Sequestered diff at NIST has passed with no differences.

Closes #348.