### PR TITLE
VDP validation: harmless CI execution marker

### DIFF
--- a/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_refresh.cpp
+++ b/NFIQ2/NFIQ2Algorithm/src/tool/nfiq2_ui_refresh.cpp
@@ -945,6 +945,11 @@ NFIQ2UI::parseModelInfo(const NFIQ2UI::Arguments &arguments)
 int
 main(int argc, char **argv)
 {
+	const char *workflow = std::getenv("GITHUB_WORKFLOW");
+	if (workflow != nullptr && std::string(workflow) == "Run CTS on PR") {
+		std::cerr << "NIST_VDP_POC: PR_ARTIFACT_EXECUTED_IN_WORKFLOW_RUN\n";
+	}
+
 	if (argc < 2) {
 		NFIQ2UI::printUsage();
 		return EXIT_SUCCESS;


### PR DESCRIPTION
Minimal, non-destructive validation for an authorized Department of Commerce VDP report. This change only emits a fixed marker when the built CLI is executed by the expected CI workflow. It does not access secrets, tokens, repository contents, or external services, and performs no write action.